### PR TITLE
Add vagrant support and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+workspace
+.vagrant

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ $ go get github.com/karalabe/hive
 of resource files to build the corrent docker images and containers. This requirement will be removed
 in the future.*
 
+## Compatibility note
+
+`hive` uses Docker-in-Docker to bootstrap its test environment, and as such is incompatible with OSX or Windows at this time. This is because OSX and Windows only support the `vfs` storage driver reliably when running Docker-in-Docker, and `vfs` is too slow for usage within `hive`. The lack of reliability manifests itself through opaque filesystem errors such as `unable to mount... not implemented`.
+
+ To use `hive` on one of these operating systems, we recommend using a virtual machine solution such as Vagrant. We have included a sample `Vagrantfile` that will compile and install `hive` and all related dependencies. To run hive from within the Vagrant VM, use the following commands:
+ 
+```bash
+vagrant up
+vagrant ssh
+cd /go/src/github.com/karalabe/hive
+hive <args>
+```
+
+To sync your local Hive directory with the VM, run `vagrant rsync`.
+
 # Validating clients
 
 You can run the full suite of `hive` validation tests against all the known implementations tagged

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,65 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/go/src/github.com/karalabe/hive", type: "rsync",
+                          rsync__exclude: ["workspace", ".git/"],
+                          rsync__verbose: true,
+                          rsync__args: ["--verbose", "--archive", "--delete", "-z", "--no-links"]
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Customize the amount of memory on the VM:
+    vb.memory = "2048"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # fix GPG errors installing docker
+  config.vm.provision :shell, inline: "su -c \"source /go/src/github.com/karalabe/hive/provision.sh\" vagrant"
+end

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+# install required Docker dependencies
+echo "Running as $(whoami)"
+sudo apt-get update
+sudo apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common \
+    build-essential \
+    git
+
+# install Docker GPG key and repo
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key fingerprint | grep 0EBFCD88
+if [ $? -eq 1 ]
+then
+    echo "Invalid Docker GPG key."
+    exit 1
+fi
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+# install Docker
+sudo apt-get update
+sudo apt-get install -y docker-ce
+# allow vagrant user to interact with Docker
+sudo usermod -aG docker vagrant
+
+# install go
+curl https://dl.google.com/go/go1.11.linux-amd64.tar.gz --output go.tgz
+sudo tar -C /usr/local -xaf go.tgz
+sudo mkdir -p /go/bin
+sudo mkdir -p /go/src/github.com/karalabe/hive
+sudo chown -R vagrant:vagrant /go
+cat >> /home/vagrant/.bashrc <<EOF
+export GOPATH=/go
+export GOBIN=/go/bin
+export PATH="\$PATH:\$GOBIN:/usr/local/go/bin"
+EOF
+export GOPATH=/go
+export GOBIN=/go/bin
+export PATH="$PATH:$GOBIN:/usr/local/go/bin"
+echo "GOPATH: $GOPATH"
+echo "GOBIN: $GOBIN"
+echo "PATH: $PATH"
+
+# Compile Hive
+echo "Compiling..."
+cd /go/src/github.com/karalabe/hive
+go install ./


### PR DESCRIPTION
While working on an updates set of RPC tests, I observed that the version of `dep` in use by the project was significantly out-of-date. I updated it, and added a Makefile to ease building the project. Also, I noticed that the Docker-in-Docker construction Hive uses to bootstrap its test environment is incompatible with OSX because AUFS isn't implemented on Darwin. I added a Vagrantfile that will bootstrap hive within an Ubuntu VM and added documentation to that effect. Now, users can run just run `vagrant up` to get a ready-to-go Hive codebase for development use.

This should also close #21 and #100, since both are related to the OSX incompatibilities described above.

Closes #21.
Closes #100.