### PR TITLE
Simulator fix, hive output fix

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -339,22 +339,17 @@ func mainInHost(daemon *docker.Client, overrides []string, cacher *buildCacher) 
 
 	summaryFileName := filepath.Join(*testResultsRoot, *testResultsSummaryFile)
 
-	//read the existing summary data
-	summaryFileData, err := ioutil.ReadFile(summaryFileName)
-	if err != nil {
-		log15.Crit("failed to report summarised results", "error", err)
-		return err
-	}
-
-	//back it up
-	ioutil.WriteFile(summaryFileName+".bak", summaryFileData, 0644)
-
-	//deserialize from json
 	var allSummaryInfo summaryFile
-	err = json.Unmarshal(summaryFileData, &allSummaryInfo)
-	if err != nil {
-		log15.Crit("failed to read summarised results", "error", err)
-		return err
+	//read the existing summary data, if present
+	if summaryFileData, err := ioutil.ReadFile(summaryFileName); err == nil{
+		//back it up
+		ioutil.WriteFile(summaryFileName+".bak", summaryFileData, 0644)
+		//deserialize from json
+		err = json.Unmarshal(summaryFileData, &allSummaryInfo)
+		if err != nil {
+			log15.Crit("failed to read summarised results", "error", err)
+			return err
+		}
 	}
 
 	//add the new summary

--- a/simulators/ethereum/consensus/hivemodel.py
+++ b/simulators/ethereum/consensus/hivemodel.py
@@ -220,6 +220,7 @@ class BlockTestExecutor(object):
             testcase.setTimeElapsed(1000 * (end - start))
             self.hive.log("Test: %s %s (%s)" % (testcase.testfile, testcase, testcase.status()))
             self.hive.subresult(
+                    node.nodeId,
                     testcase.fullname(),
                     testcase.wasSuccessfull(),
                     testcase.topLevelError(),
@@ -251,8 +252,8 @@ class BlockTestExecutor(object):
 
     def _performTests(self, start=0, end=-1, whitelist=[], blacklist=[]):
         pool = ThreadPool(PARALLEL_TESTS)
-        pool.map(lambda test: self._startNodeAndRunTest(test),
-                 self.makeTestcases(start, end, whitelist, blacklist))
+        testgenerator = self.makeTestcases(start, end, whitelist, blacklist)
+        pool.map(lambda test: self._startNodeAndRunTest(test),testgenerator)
         pool.close()
         pool.join()
         # FIXME: Return false if any tests fail.

--- a/simulators/ethereum/consensus/hivemodel.py
+++ b/simulators/ethereum/consensus/hivemodel.py
@@ -120,7 +120,14 @@ class HiveAPI(object):
             _ip = self._get("/nodes/%s" % _id)
             return HiveNode(_id, _ip)
         except Exception, e:
-            self.log("Failed to start node, trying again")
+            self.log("Failed to start node[1], trying again")
+
+        try:
+            _id = self._post("/nodes", params)
+            _ip = self._get("/nodes/%s" % _id)
+            return HiveNode(_id, _ip)
+        except Exception, e:
+            self.log("Failed to start node[2], trying again (last attempt)")
 
         _id = self._post("/nodes", params)
         _ip = self._get("/nodes/%s" % _id)
@@ -208,6 +215,20 @@ class BlockTestExecutor(object):
             params["HIVE_SKIP_POW"] = "1"
 
         self.hive.log("Starting client node for test %s" % testcase)
+
+
+        def reportTest(tc):
+            tc.setTimeElapsed(1000 * ( time.time() - start))
+            self.hive.log("Test: %s %s (%s)" % (tc.testfile, tc, tc.status()))
+            self.hive.subresult(
+                    node.nodeId,
+                    testcase.fullname(),
+                    testcase.wasSuccessfull(),
+                    testcase.topLevelError(),
+                    testcase.details()
+                )
+
+
         try:
             node = self.hive.newNode(params)
         except Exception, startNodeError:
@@ -216,29 +237,11 @@ class BlockTestExecutor(object):
             except Exception, e:
                 error = str(startNodeError)
             testcase.fail(["Failed to start client node", traceback.format_exc()])
-            end = time.time()
-            testcase.setTimeElapsed(1000 * (end - start))
-            self.hive.log("Test: %s %s (%s)" % (testcase.testfile, testcase, testcase.status()))
-            self.hive.subresult(
-                    node.nodeId,
-                    testcase.fullname(),
-                    testcase.wasSuccessfull(),
-                    testcase.topLevelError(),
-                    testcase.details()
-                )
+            reportTest(testcase)
             return
 
         self.executeTestcase(testcase, node)
-        end = time.time()
-        testcase.setTimeElapsed(1000 * (end - start))
-        self.hive.log("Test: %s %s (%s)" % (testcase.testfile, testcase, testcase.status()))
-        self.hive.subresult(
-                node.nodeId,            
-                testcase.fullname(),
-                testcase.wasSuccessfull(),
-                testcase.topLevelError(),
-                testcase.details()
-            )
+        reportTest(testcase)
 
         try:
             self.hive.killNode(node)


### PR DESCRIPTION
The call to `subresult` was missing one parameter, in the case that a node failed to start