### PR TITLE
Simulation work

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -346,7 +346,7 @@ func mainInHost(daemon *docker.Client, overrides []string, cacher *buildCacher) 
 
 	var allSummaryInfo summaryFile
 	//read the existing summary data, if present
-	if summaryFileData, err := ioutil.ReadFile(summaryFileName); err == nil{
+	if summaryFileData, err := ioutil.ReadFile(summaryFileName); err == nil {
 		//back it up
 		ioutil.WriteFile(summaryFileName+".bak", summaryFileData, 0644)
 		//deserialize from json

--- a/simulators/devp2p/basic/devp2p_test.go
+++ b/simulators/devp2p/basic/devp2p_test.go
@@ -75,19 +75,13 @@ func ClientTestRunner(t *testing.T, client string, testName string, testFunc fun
 			"HIVE_BOOTNODE": "enode://158f8aab45f6d19c6cbf4a089c2670541a8da11978a2f90dbf6a502a4a3bab80d288afdbeb7ec0ef6d92de563767f3b1ea9e8e334ca711e9f8e2df5a0385e8e6@1.2.3.4:30303",
 		}
 
-		nodeID, err := host.StartNewNode(parms)
+		nodeID, ipAddr, err := host.StartNewNode(parms)
 		if err != nil {
 			errorMessage = fmt.Sprintf("FATAL: Unable to start node: %v", err)
 			ok = false
 		}
 
 		if ok {
-
-			ip, err := host.GetClientIP(*nodeID)
-			if err != nil {
-				errorMessage = fmt.Sprintf("FATAL: Unable to get client IP: %v", err)
-				ok = false
-			}
 
 			enodeID, err := host.GetClientEnode(*nodeID)
 			if err != nil || enodeID == nil || *enodeID == "" {
@@ -99,12 +93,6 @@ func ClientTestRunner(t *testing.T, client string, testName string, testFunc fun
 			targetNode, err := enode.ParseV4(*enodeID)
 			if err != nil {
 				errorMessage = fmt.Sprintf("FATAL: Unable to parse enode: %v", err)
-				ok = false
-			}
-
-			ipAddr := net.ParseIP(*ip)
-			if ipAddr == nil {
-				errorMessage = fmt.Sprintf("FATAL: Unable to parse IP: %v", err)
 				ok = false
 			}
 

--- a/simulators/ethereum/consensus2/Dockerfile
+++ b/simulators/ethereum/consensus2/Dockerfile
@@ -1,0 +1,25 @@
+# Build Geth in a stock Go builder container
+FROM golang:1.11-alpine as builder
+
+RUN apk add --no-cache git make gcc musl-dev linux-headers
+
+#RUN (git clone -b master --single-branch https://github.com/ethereum/go-ethereum /go/src/github.com/ethereum/go-ethereum)
+#RUN (git clone -b go_consensus --single-branch https://github.com/holiman/hive /go/src/github.com/ethereum/hive)
+
+#ADD /*.go /go/src/goconsensus/
+RUN go get github.com/holiman/goconsensus && go install goconsensus
+
+
+# Pull Geth into a second stage deploy alpine container
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates git
+COPY --from=builder /go/bin/goconsensus /usr/local/bin/goconsensus
+#COPY --from=builder /tests /tests
+RUN git clone --depth 1 https://github.com/ethereum/tests.git /tests
+
+RUN chmod a+x /usr/local/bin/goconsensus
+
+ENV TESTPATH /tests
+
+CMD ["/usr/local/bin/goconsensus"]


### PR DESCRIPTION
This PR replaces the python-framework for consensus testing with a framework written in go. Additionally, it

* return ip when starting node
* surface http errors as golang erros in the simulator api client
* kills nodes when subresults are reported
