### PR TITLE
Chain tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ improved in the future to offer generation of chains that exhibit different char
 * `chainConfig`     String              Reserved for future usage. Will allow Hive to generate test chains of different types
 *	`chainOutputPath` String  (.)   Chain destination folder
 *	`chainGenesis`    String  ("")  The path and filename to the source genesis.json
-*	`chainBlockTime`  Uint    (30)    The desired block time in seconds
+*	`chainBlockTime`  Uint    (30)    The desired block time in seconds. OBS: It's recommended to set this value to somwhere above 20s to keep the mining difficulty low.
 
 For example   `hive --loglevel 6 --chainGenerate --chainLength 2 --chainOutputPath "C:\Ethereum\Path" --chainGenesis "C:\Ethereum\Path\Genesis.json" --chainBlockTime 30`
 

--- a/README.md
+++ b/README.md
@@ -521,11 +521,33 @@ will result a `subresults` field
   }
 ]
 ```
-
 ### Closing notes
 
  * There is no constraint on how much time a simulation may run, but please be considerate.
  * The simulator doesn't have to terminate nodes itself, upon exit all resources are reclaimed.
+
+# Generating test blockchains
+
+`Hive` allows you to create rlp encoded blockchains for inclusion into sync tests 
+
+## To generate a blockchain offline
+
+`Hive` can be run with the `chainGenerate` setting to generate a blockchain according to specification
+and then exit. The current version only generates blocks with empty transactions, but this will be
+improved in the future to offer generation of chains that exhibit different characteristics for testing.
+
+* `chainGenerate`   Bool    (false)  Tell Hive to generate a blockchain on the basis of a supplied genesis and terminate
+* `chainLength`     Uint    (2)     The length of the chain to generate
+* `chainConfig`     String              Reserved for future usage. Will allow Hive to generate test chains of different types
+*	`chainOutputPath` String  (.)   Chain destination folder
+*	`chainGenesis`    String  ("")  The path and filename to the source genesis.json
+*	`chainBlockTime`  Uint    (30)    The desired block time in seconds
+
+For example   `hive --loglevel 6 --chainGenerate --chainLength 2 --chainOutputPath "C:\Ethereum\Path" --chainGenesis "C:\Ethereum\Path\Genesis.json" --chainBlockTime 30`
+
+
+
+
 
 # Continuous integration
 

--- a/chaintools/chaintools.go
+++ b/chaintools/chaintools.go
@@ -1,0 +1,189 @@
+package chaintools
+
+import (
+	"io"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+	log15 "gopkg.in/inconshreveable/log15.v2"
+)
+
+// save the genesis file
+func writeGenesis(gspec *core.Genesis, path string) error {
+	bytes, err := gspec.MarshalJSON()
+	filename := filepath.Join(path, "genesis.json")
+
+	err = ioutil.WriteFile(filename, bytes, 0644)
+	if err != nil {
+		log15.Crit("failed to save genesis", "error", err)
+		return err
+	}
+	return nil
+}
+
+// ProduceSimpleTestChain : The first of multiple chains exhibiting different characteristics for
+// differing test purposes. This chain involves two accounts that transfer funds to each other
+// in alternating blocks. These functions save the chain.rlp and genesis.json to the specified path.
+// blockCount indicates the desired chain length in blocks.
+func ProduceSimpleTestChain(path string, blockCount uint) error {
+
+	var (
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
+	)
+
+	signer := types.HomesteadSigner{}
+	blockModifier := func(i int, gen *core.BlockGen) {
+		gen.OffsetTime(int64((i + 1) * 30))
+		if i%2 == 0 {
+			tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), signer, key1)
+			gen.AddTx(tx)
+		} else {
+			tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr1, big.NewInt(10000), params.TxGas, nil, nil), signer, key2)
+			gen.AddTx(tx)
+		}
+	}
+
+	gspec := &core.Genesis{
+		Config: &params.ChainConfig{
+			HomesteadBlock:      new(big.Int),
+			ChainID:             big.NewInt(1),
+			DAOForkBlock:        big.NewInt(0),
+			DAOForkSupport:      true,
+			EIP150Block:         big.NewInt(0),
+			EIP150Hash:          ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+			EIP155Block:         big.NewInt(0),
+			EIP158Block:         big.NewInt(0),
+			ByzantiumBlock:      big.NewInt(0),
+			ConstantinopleBlock: nil,
+			EWASMBlock:          nil,
+			Ethash:              new(params.EthashConfig),
+		},
+		Nonce:      0xdeadbeefdeadbeef,
+		Timestamp:  0x0,
+		GasLimit:   0x8000000,
+		Difficulty: big.NewInt(0x10),
+		Mixhash:    ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		Coinbase:   ethcommon.HexToAddress("0x0000000000000000000000000000000000000000"),
+
+		Alloc: core.GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
+	}
+
+	err := writeGenesis(gspec, path)
+	if err != nil {
+		log15.Crit("write genesis error", "error", err)
+		return err
+	}
+
+	err = GenerateChainAndSave(gspec, blockCount, path, blockModifier)
+	if err != nil {
+		log15.Crit("generate chain error", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+// ProduceTestChainFromGenesisFile Produce a test chain with no transactions or other modifications
+// based on an externally specified genesis file. The blockTimeInSeconds is used to manipulate
+// the block difficulty
+func ProduceTestChainFromGenesisFile(sourceGenesis string, outputPath string, blockCount uint, blockTimeInSeconds uint) error {
+
+	gspec := &core.Genesis{}
+
+	var err error
+	if sourceGenesisBytes, err := ioutil.ReadFile(sourceGenesis); err == nil {
+
+		err = gspec.UnmarshalJSON(sourceGenesisBytes)
+		if err != nil {
+			log15.Crit("failed to deserialize genesis json", "error", err)
+			return err
+		}
+
+		blockModifier := func(i int, gen *core.BlockGen) {
+			gen.OffsetTime(int64((i+1)*int(blockTimeInSeconds) - 10))
+
+		}
+
+		err = GenerateChainAndSave(gspec, blockCount, outputPath, blockModifier)
+		if err != nil {
+			log15.Crit("generate chain error", "error", err)
+			return err
+		}
+
+		return nil
+	}
+	log15.Crit("failed to read genesis json", "error", err)
+	return err
+
+}
+
+// WriteChain - save blockchain to file
+func WriteChain(chain *core.BlockChain, filename string) error {
+
+	// Make sure we can create the file to export into
+	out, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	var writer io.Writer = out
+
+	// Export the blockchain
+	if err := chain.Export(writer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GenerateChainAndSave produces a chain based on the genesis-config with
+// valid proof of work, and block difficulty modified by the OffsetTime function
+// in the per-block post-processing function.
+func GenerateChainAndSave(gspec *core.Genesis, blockCount uint, path string, blockModifier func(i int, gen *core.BlockGen)) error {
+
+	// Use an in memory db
+	db := ethdb.NewMemDatabase()
+
+	// Initialise the state with the genesis specification and return the genesis block
+	genesis := gspec.MustCommit(db)
+
+	// Create an ethash engine that immediately seals any generated blocks
+	eng := NewSealingEthash(ethash.Config{PowMode: ethash.ModeNormal}, nil, false)
+
+	// Generate a chain where each block is created, modified, and immediately sealed
+	chain, _ := core.GenerateChain(gspec.Config, genesis, eng, db, int(blockCount), blockModifier)
+
+	// Import the chain. This runs all block validation rules.
+	blockchain, err := core.NewBlockChain(db, nil, gspec.Config, eng, vm.Config{}, nil)
+	if err != nil {
+		log15.Crit("new chain error", "error", err)
+		return err
+	}
+	defer blockchain.Stop()
+	if _, err := blockchain.InsertChain(chain); err != nil {
+		log15.Crit("insert chain error", "error", err)
+		return err
+	}
+
+	// Write out the generated blockchain
+	if err := WriteChain(blockchain, filepath.Join(path, "chain.rlp")); err != nil {
+		log15.Crit("error writing chain to file", "error", err)
+		return err
+	}
+
+	return nil
+}

--- a/chaintools/sealingEthash.go
+++ b/chaintools/sealingEthash.go
@@ -1,0 +1,112 @@
+package chaintools
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// SealingEthash is intended for use with chain_makers GenerateChain
+// to produce blocks with a valid proof of work
+type SealingEthash struct {
+	EthashEngine *ethash.Ethash
+}
+
+// NewSealingEthash : ctor
+func NewSealingEthash(config ethash.Config, notify []string, noverify bool) *SealingEthash {
+	sealingEthash := &SealingEthash{
+		EthashEngine: ethash.New(config, notify, noverify),
+	}
+	return sealingEthash
+}
+
+// Finalize implements consensus.Engine, accumulating the block and uncle rewards,
+// setting the final state and assembling the block.
+func (e *SealingEthash) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+
+	finalizedBlock, err := e.EthashEngine.Finalize(chain, header, state, txs, uncles, receipts)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(chan *types.Block)
+	e.EthashEngine.Seal(nil, finalizedBlock, results, nil)
+
+	// Header seems complete, assemble into a block and return
+	return <-results, nil
+}
+
+// Author retrieves the Ethereum address of the account that minted the given
+// block, which may be different from the header's coinbase if a consensus
+// engine is based on signatures.
+func (e *SealingEthash) Author(header *types.Header) (common.Address, error) {
+	return e.EthashEngine.Author(header)
+}
+
+// VerifyHeader checks whether a header conforms to the consensus rules of a
+// given engine. Verifying the seal may be done optionally here, or explicitly
+// via the VerifySeal method.
+func (e *SealingEthash) VerifyHeader(chain consensus.ChainReader, header *types.Header, seal bool) error {
+	return e.EthashEngine.VerifyHeader(chain, header, seal)
+}
+
+// VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
+// concurrently. The method returns a quit channel to abort the operations and
+// a results channel to retrieve the async verifications (the order is that of
+// the input slice).
+func (e *SealingEthash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	return e.EthashEngine.VerifyHeaders(chain, headers, seals)
+}
+
+// VerifyUncles verifies that the given block's uncles conform to the consensus
+// rules of a given engine.
+func (e *SealingEthash) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {
+	return e.EthashEngine.VerifyUncles(chain, block)
+}
+
+// VerifySeal checks whether the crypto seal on a header is valid according to
+// the consensus rules of the given engine.
+func (e *SealingEthash) VerifySeal(chain consensus.ChainReader, header *types.Header) error {
+	return e.EthashEngine.VerifySeal(chain, header)
+}
+
+// Prepare initializes the consensus fields of a block header according to the
+// rules of a particular engine. The changes are executed inline.
+func (e *SealingEthash) Prepare(chain consensus.ChainReader, header *types.Header) error {
+	return e.EthashEngine.Prepare(chain, header)
+}
+
+// Seal generates a new sealing request for the given input block and pushes
+// the result into the given channel.
+//
+// Note, the method returns immediately and will send the result async. More
+// than one result may also be returned depending on the consensus algorithm.
+func (e *SealingEthash) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+	panic("SealingEthash returns a sealed block from Finalize. Seal is not supported.")
+}
+
+// SealHash returns the hash of a block prior to it being sealed.
+func (e *SealingEthash) SealHash(header *types.Header) common.Hash {
+	return e.EthashEngine.SealHash(header)
+}
+
+// CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty
+// that a new block should have.
+func (e *SealingEthash) CalcDifficulty(chain consensus.ChainReader, time uint64, parent *types.Header) *big.Int {
+	return e.EthashEngine.CalcDifficulty(chain, time, parent)
+}
+
+// APIs returns the RPC APIs this consensus engine provides.
+func (e *SealingEthash) APIs(chain consensus.ChainReader) []rpc.API {
+	return e.EthashEngine.APIs(chain)
+}
+
+// Close terminates any background threads maintained by the consensus engine.
+func (e *SealingEthash) Close() error {
+	return e.EthashEngine.Close()
+}

--- a/hive.go
+++ b/hive.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/hive/chaintools"
 	"github.com/fsouza/go-dockerclient"
 	"gopkg.in/inconshreveable/log15.v2"
 )
@@ -39,6 +40,13 @@ var (
 	hiveDebug            = flag.Bool("debug", false, "A flag indicating debug mode, to allow docker containers to launch headless delve instances and so on")
 	simRootContext       = flag.Bool("sim-rootcontext", false, "Indicates if the simulation should build the dockerfile with root (simulator) or local context. Needed for access to sibling folders like simulators/common")
 
+	chainGenerate   = flag.Bool("chainGenerate", false, "Tell Hive to generate a blockchain on the basis of a supplied genesis and terminate")
+	chainLength     = flag.Uint("chainLength", 2, "The length of the chain to generate")
+	chainConfig     = flag.String("chainConfig", "", "Reserved for future usage. Will allow Hive to generate test chains of different types")
+	chainOutputPath = flag.String("chainOutputPath", ".", "Chain destination folder")
+	chainGenesis    = flag.String("chainGenesis", "", "The path and filename to the source genesis.json")
+	chainBlockTime  = flag.Uint("chainBlockTime", 30, "The desired block time in seconds")
+
 	loglevelFlag = flag.Int("loglevel", 3, "Log level to use for displaying system events")
 
 	dockerTimeout         = flag.Int("dockertimeout", 10, "Time to wait for container to finish before stopping it")
@@ -56,7 +64,10 @@ func main() {
 	// Parse the flags and configure the logger
 	flag.Parse()
 	log15.Root().SetHandler(log15.LvlFilterHandler(log15.Lvl(*loglevelFlag), log15.StreamHandler(os.Stderr, log15.TerminalFormat())))
-
+	if *chainGenerate {
+		chaintools.ProduceTestChainFromGenesisFile(*chainGenesis, *chainOutputPath, *chainLength, *chainBlockTime)
+		return
+	}
 	// Connect to the local docker daemon and make sure it works
 	daemon, err := docker.NewClient(*dockerEndpoint)
 	if err != nil {

--- a/simulators/devp2p/basic/devp2p_test.go
+++ b/simulators/devp2p/basic/devp2p_test.go
@@ -83,7 +83,7 @@ func ClientTestRunner(t *testing.T, client string, testName string, testFunc fun
 
 		if ok {
 
-			enodeID, err := host.GetClientEnode(*nodeID)
+			enodeID, err := host.GetClientEnode(nodeID)
 			if err != nil || enodeID == nil || *enodeID == "" {
 				errorMessage = fmt.Sprintf("FATAL: Unable to get node: %v", err)
 				ok = false
@@ -107,7 +107,7 @@ func ClientTestRunner(t *testing.T, client string, testName string, testFunc fun
 			}
 		}
 
-		host.AddResults(ok, *nodeID, testName, errorMessage, time.Since(startTime))
+		host.AddResults(ok, nodeID, testName, errorMessage, time.Since(startTime))
 
 		if !ok {
 			t.Errorf("Test failed: %s", errorMessage)


### PR DESCRIPTION
This PR adds the "chain tools" (chaintools folder) necessary for the sync simulations. It also adds some helpful command line options to Hive to allow testers to generate rlp encoded blockchains for import. More info in the Readme.md.


In future PRs these chaintools may be moved to simulators/common to allow dynamic regeneration of blockchains for sync tests.
