### PR TITLE
Return error if no clients match given client regexp pattern

### DIFF
--- a/benchmarker.go
+++ b/benchmarker.go
@@ -43,6 +43,9 @@ func benchmarkClients(daemon *docker.Client, clientPattern, benchmarkerPattern s
 	if err != nil {
 		return nil, err
 	}
+	if len(clients) == 0 {
+		return nil, errors.New("pattern did not match any clients")
+	}
 
 	// Build all the benchmarkers known to the harness
 	log15.Info("building benchmarkers for measurements", "pattern", benchmarkerPattern)

--- a/benchmarker.go
+++ b/benchmarker.go
@@ -44,7 +44,7 @@ func benchmarkClients(daemon *docker.Client, clientPattern, benchmarkerPattern s
 		return nil, err
 	}
 	if len(clients) == 0 {
-		return nil, errors.New("pattern did not match any clients")
+		return nil, errNoMatchingClients
 	}
 
 	// Build all the benchmarkers known to the harness

--- a/hive.go
+++ b/hive.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -14,6 +15,11 @@ import (
 	"github.com/ethereum/hive/chaintools"
 	"github.com/fsouza/go-dockerclient"
 	"gopkg.in/inconshreveable/log15.v2"
+)
+
+var (
+	// errNoMatchingClients is returned when no matching clients are found for a given --client regexp value
+	errNoMatchingClients = errors.New("no matching clients found")
 )
 
 var (

--- a/simulator.go
+++ b/simulator.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -60,7 +59,7 @@ func simulateClients(daemon *docker.Client, clientPattern, simulatorPattern stri
 		return nil, err
 	}
 	if len(clients) == 0 {
-		return nil, errors.New("pattern did not match any clients")
+		return nil, errNoMatchingClients
 	}
 
 	// Build all the simulators known to the test harness

--- a/simulator.go
+++ b/simulator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -57,6 +58,9 @@ func simulateClients(daemon *docker.Client, clientPattern, simulatorPattern stri
 	clients, err := buildClients(daemon, clientPattern, cacher)
 	if err != nil {
 		return nil, err
+	}
+	if len(clients) == 0 {
+		return nil, errors.New("pattern did not match any clients")
 	}
 
 	// Build all the simulators known to the test harness

--- a/validator.go
+++ b/validator.go
@@ -38,7 +38,7 @@ func validateClients(daemon *docker.Client, clientPattern, validatorPattern stri
 		return nil, err
 	}
 	if len(clients) == 0 {
-		return nil, errors.New("pattern did not match any clients")
+		return nil, errNoMatchingClients
 	}
 
 	// Build all the validators known to the test harness

--- a/validator.go
+++ b/validator.go
@@ -37,6 +37,10 @@ func validateClients(daemon *docker.Client, clientPattern, validatorPattern stri
 	if err != nil {
 		return nil, err
 	}
+	if len(clients) == 0 {
+		return nil, errors.New("pattern did not match any clients")
+	}
+
 	// Build all the validators known to the test harness
 	log15.Info("building validators for testing", "pattern", validatorPattern)
 	validators, err := buildValidators(daemon, validatorPattern, cacher)


### PR DESCRIPTION
Fixes #178 by returning an error when given regexp does not match any clients.

Also fixes #175 because the error documented there is what happens when the sim tries to put logs in a path without a client path element.