### PR TITLE
Fix typo in go-ethereum_master that breaks all tests for that client 

### DIFF
--- a/clients/go-ethereum_master/geth.sh
+++ b/clients/go-ethereum_master/geth.sh
@@ -63,7 +63,7 @@ fi
 
 
 
-if [ "$HIVE_USE_GENESIS_CONFIG" == ""]; then
+if [ "$HIVE_USE_GENESIS_CONFIG" == "" ]; then
 
 	# Override any chain configs in the go-ethereum specific way
 	chainconfig="{}"


### PR DESCRIPTION
Was causing:

DBUG[03-05|13:25:54] starting container                       client=go-ethereum_master validator=smoke/genesis-chain-blocks id=b6ef6d4e
[b6ef6d4e] /geth.sh: line 66: [: : unary operator expected
[b6ef6d4e] Initializing database with genesis state...
[b6ef6d4e] WARN [03-05|19:26:19.326] Sanitizing cache to Go's GC limits       provided=1024 updated=666
[b6ef6d4e] INFO [03-05|19:26:19.327] Maximum peer count                       ETH=25 LES=0 total=25
[b6ef6d4e] INFO [03-05|19:26:19.328] Allocated cache and file handles         database=/root/.ethereum/geth/chaindata cache=16.00MiB handles=16
[b6ef6d4e] Fatal: Failed to write genesis block: genesis has no chain configuration
[b6ef6d4e] Fatal: Failed to write genesis block: genesis has no chain configuration