### PR TITLE
Test fixes

### DIFF
--- a/simulators/devp2p/udp.go
+++ b/simulators/devp2p/udp.go
@@ -421,7 +421,7 @@ func (t *V4Udp) SpoofingFindNodeCheck(toid enode.ID, tomac string, toaddr *net.U
 		if p.ptype == neighborsPacket {
 			return ErrUnsolicitedReply
 		}
-		return nil
+		return ErrTimeout
 	}
 
 	return <-t.sendSpoofedPacket(toid, toaddr, fromaddr, findreq, findpacket, tomac, callback)
@@ -703,8 +703,12 @@ func (t *V4Udp) FindnodeWithoutBond(toid enode.ID, toaddr *net.UDPAddr, target e
 	//expect nothing
 	t.l.Log("Establishing criteria: Fail if any packet received. Succeed if nothing received within timeouts.")
 	callback := func(p reply) error {
-
+		if p.ptype == pingPacket {
+			t.l.Log("Warning: Node attempting to bond in response to FindNode.")
+			return ErrTimeout
+		}
 		return ErrUnsolicitedReply
+
 	}
 
 	return <-t.sendPacket(toid, toaddr, req, packet, callback)

--- a/simulators/ethereum/sync/sync_test.go
+++ b/simulators/ethereum/sync/sync_test.go
@@ -109,7 +109,7 @@ func TestSyncsWithGeth(t *testing.T) {
 					"HIVE_FORK_TANGERINE": "0",
 					"HIVE_FORK_SPURIOUS":  "0",
 					"HIVE_FORK_BYZANTIUM": "0",
-					"HIVE_FORK_DAO_BLOCK": "0",
+					//	"HIVE_FORK_DAO_BLOCK": "0",
 					// "HIVE_FORK_CONSTANTINOPLE": "0",
 				}
 				clientID, nodeIP, _, err := host.StartNewNode(parms)
@@ -189,7 +189,7 @@ func TestSyncsWithGeth(t *testing.T) {
 					"HIVE_FORK_TANGERINE": "0",
 					"HIVE_FORK_SPURIOUS":  "0",
 					"HIVE_FORK_BYZANTIUM": "0",
-					"HIVE_FORK_DAO_BLOCK": "0",
+					//	"HIVE_FORK_DAO_BLOCK": "0",
 					// "HIVE_FORK_CONSTANTINOPLE": "0",
 				}
 				clientID, nodeIP, _, err := host.StartNewNode(parms)


### PR DESCRIPTION
Parity now behaves differently in response to FindNode in that replies with a Ping... the test needs to be extended to see if this is an error or not.

The sync tests were failing for Parity too, but this was down to an error in the sync test.