### PR TITLE
containers: don't write container stdout to stdout for loglevels below 4

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -275,7 +275,7 @@ func runContainer(id string, logger log15.Logger, logfile string, shell bool, lo
 		fdsToClose = append(fdsToClose, log)
 
 		// If console logging was requested, tee the output and tag it with the container id
-		if logLevel > 0 {
+		if logLevel > 3 {
 			// Hook into the containers output stream and tee it out
 			hookedR, hookedW, err := os.Pipe()
 			if err != nil {

--- a/hiveviewer/index.html
+++ b/hiveviewer/index.html
@@ -26,7 +26,7 @@
         $(function () {
 
             hiveViewer = new app();
-            hiveViewer.LoadTestSuites("TestResults", "index.txt");
+            hiveViewer.LoadTestSuites("Results", "index.txt");
             ko.applyBindings(hiveViewer);
             
         }


### PR DESCRIPTION
less verbosity
move testresults to `Results`, so we can have a symlink pointing to either the S3 bucket or a local folder