### PR TITLE
Make hive operational again

### DIFF
--- a/clients/aleth/aleth.sh
+++ b/clients/aleth/aleth.sh
@@ -22,9 +22,15 @@
 #  - HIVE_FORK_BYZANTIUM block number for Byzantium transition
 #  - HIVE_FORK_CONSTANTINOPLE block number for Constantinople transition
 #  - HIVE_FORK_PETERSBURG  block number for ConstantinopleFix/PetersBurg transition
+#  - HIVE_FORK_ISTANBUL block number for Istanbul
+#  - HIVE_FORK_MUIRGLACIER block number for Muir Glacier
+#  - HIVE_FORK_BERLIN block number for Berlin
+#
+# Other:
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 #  - HIVE_SKIP_POW       If set, skip PoW verification during block import
+#  - HIVE_LOGLEVEL		 Simulator loglevel
 
 # Immediately abort the script on any error encountered
 set -e
@@ -99,17 +105,6 @@ if [ "$HIVE_FORK_BYZANTIUM" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([ \"params\", \"byzantiumForkBlock\"]; \"0x$HIVE_FORK_BYZANTIUM\")"`
 fi
 
-if [ "$HIVE_FORK_ISTANBUL" != "" ]; then
-	HIVE_FORK_ISTANBUL=`echo "obase=16; $HIVE_FORK_ISTANBUL" | bc`
-
-	if [ "$((16#$HIVE_FORK_ISTANBUL))" -eq "0" ]; then
-		# Also new precompiles
-		chainconfig=`echo $chainconfig | jq "setpath([\"accounts\", \"0000000000000000000000000000000000000009\"]; { \"precompiled\": { \"name\": \"blake2_compression\" } })"`
-		
-	fi
-
-	chainconfig=`echo $chainconfig | jq "setpath([ \"params\", \"istanbulForkBlock\"]; \"0x$HIVE_FORK_ISTANBUL\")"`
-fi
 
 if [ "$HIVE_FORK_CONSTANTINOPLE" != "" ]; then
 	HIVE_FORK_CONSTANTINOPLE=`echo "obase=16; $HIVE_FORK_CONSTANTINOPLE" | bc`
@@ -120,6 +115,15 @@ if [ "$HIVE_FORK_PETERSBURG" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([ \"params\", \"constantinopleFixForkBlock\"]; \"0x$HIVE_FORK_PETERSBURG\")"`
 fi
 
+if [ "$HIVE_FORK_ISTANBUL" != "" ]; then
+	HIVE_FORK_ISTANBUL=`echo "obase=16; $HIVE_FORK_ISTANBUL" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([ \"params\", \"istanbulForkBlock\"]; \"0x$HIVE_FORK_ISTANBUL\")"`
+fi
+
+if [ "$HIVE_FORK_MUIRGLACIER" != "" ]; then
+	HIVE_FORK_MUIRGLACIER=`echo "obase=16; $HIVE_FORK_MUIRGLACIER" | bc`
+	chainconfig=`echo $chainconfig | jq "setpath([ \"params\", \"muirGlacierForkBlock\"]; \"$HIVE_FORK_MUIRGLACIER\")"`
+fi
 if [ "$HIVE_CHAIN_ID" != "" ]; then
 	chainconfig=`echo $chainconfig | jq "setpath([\"params\", \"chainID\"]; \"0x$HIVE_CHAIN_ID\")"`
 fi

--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -35,7 +35,7 @@
 #  - HIVE_SKIP_POW             If set, skip PoW verification during block import
 
 besu=/opt/besu/bin/besu
-RPCFLAGS="--graphql-http-enabled --graphql-http-host=0.0.0.0"
+RPCFLAGS="--graphql-http-enabled --graphql-http-host=0.0.0.0 --host-whitelist=*"
 RPCFLAGS="$RPCFLAGS --rpc-http-enabled --rpc-http-api=ETH,NET,WEB3,ADMIN --rpc-http-host=0.0.0.0"
 
 set -e
@@ -46,6 +46,8 @@ fi
 
 if [ "$HIVE_NETWORK_ID" != "" ]; then
 	FLAGS="$FLAGS --network-id=$HIVE_NETWORK_ID"
+else
+    FLAGS="$FLAGS --network-id=1337"
 fi
 
 if [ "$HIVE_NODETYPE" == "full" ]; then

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -14,6 +14,9 @@
 #  - HIVE_NETWORK_ID     network ID number to use for the eth protocol
 #  - HIVE_TESTNET        whether testnet nonces (2^20) are needed
 #  - HIVE_NODETYPE       sync and pruning selector (archive, full, light)
+#
+# Forks
+#
 #  - HIVE_FORK_HOMESTEAD block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_BLOCK block number of the DAO hard-fork transition
 #  - HIVE_FORK_DAO_VOTE  whether the node support (or opposes) the DAO fork
@@ -22,6 +25,11 @@
 #  - HIVE_FORK_BYZANTIUM block number for Byzantium transition
 #  - HIVE_FORK_CONSTANTINOPLE block number for Constantinople transition
 #  - HIVE_FORK_PETERSBURG  block number for ConstantinopleFix/PetersBurg transition
+#  - HIVE_FORK_ISTANBUL block number for Istanbul
+#  - HIVE_FORK_MUIRGLACIER block number for Muir Glacier
+#  - HIVE_FORK_BERLIN block number for Berlin
+#
+# Other:
 #  - HIVE_MINER          address to credit with mining rewards (single thread)
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 #  - HIVE_SKIP_POW       If set, skip PoW verification during block import
@@ -47,7 +55,12 @@ fi
 # If a specific network ID is requested, use that
 if [ "$HIVE_NETWORK_ID" != "" ]; then
 	FLAGS="$FLAGS --networkid $HIVE_NETWORK_ID"
+else
+    # Unless otherwise specified by hive, we try to avoid mainnet networkid. If geth detects mainnet network id,
+    # then it tries to bump memory quite a lot
+    FLAGS="$FLAGS --networkid 1337"
 fi
+
 
 # If the client is to be run in testnet mode, flag it as such
 if [ "$HIVE_TESTNET" == "1" ]; then
@@ -104,6 +117,12 @@ if [ "$HIVE_USE_GENESIS_CONFIG" == "" ]; then
 	if [ "$HIVE_FORK_ISTANBUL" != "" ]; then
 		JQPARAMS="$JQPARAMS + {\"istanbulBlock\": $HIVE_FORK_ISTANBUL}"
 	fi
+	if [ "$HIVE_FORK_MUIRGLACIER" != "" ]; then
+		JQPARAMS="$JQPARAMS + {\"muirGlacierBlock\": $HIVE_FORK_MUIRGLACIER}"
+	fi
+	if [ "$HIVE_FORK_BERLIN" != "" ]; then
+		JQPARAMS="$JQPARAMS + {\"berlinBlock\": $HIVE_FORK_BERLIN}"
+	fi
 	if [ "$HIVE_CHAIN_ID" != "" ]; then
 		JQPARAMS="$JQPARAMS + {\"chainId\": $HIVE_CHAIN_ID}"
 	fi
@@ -128,7 +147,6 @@ if [ -f /chain.rlp ]; then
 	$geth $FLAGS --gcmode=archive import /chain.rlp
 else
 	echo "Warning: chain.rlp not found."
-	ls -la /
 fi
 
 # Load the remainder of the test chain

--- a/clients/parity/parity.sh
+++ b/clients/parity/parity.sh
@@ -44,6 +44,8 @@ fi
 # If a specific network ID is requested, use that
 if [ "$HIVE_NETWORK_ID" != "" ]; then
 	FLAGS="$FLAGS --network-id $HIVE_NETWORK_ID"
+else
+    FLAGS="$FLAGS --network-id 1337"
 fi
 
 # Configure and set the chain definition for the node

--- a/hive.go
+++ b/hive.go
@@ -43,8 +43,10 @@ var (
 	simulatorPattern = flag.String("sim", "", "Regexp selecting the simulation tests to run")
 
 	simulatorParallelism = flag.Int("sim-parallelism", 1, "Max number of parallel clients/containers to run tests against")
-	hiveDebug            = flag.Bool("debug", false, "A flag indicating debug mode, to allow docker containers to launch headless delve instances and so on")
-	simRootContext       = flag.Bool("sim-rootcontext", false, "Indicates if the simulation should build the dockerfile with root (simulator) or local context. Needed for access to sibling folders like simulators/common")
+	simulatorTestLimit   = flag.Int("sim-testlimit", -1, "Max number of tests to execute per client (interpreted by simulators)")
+
+	hiveDebug      = flag.Bool("debug", false, "A flag indicating debug mode, to allow docker containers to launch headless delve instances and so on")
+	simRootContext = flag.Bool("sim-rootcontext", false, "Indicates if the simulation should build the dockerfile with root (simulator) or local context. Needed for access to sibling folders like simulators/common")
 
 	chainGenerate   = flag.Bool("chainGenerate", false, "Tell Hive to generate a blockchain on the basis of a supplied genesis and terminate")
 	chainLength     = flag.Uint("chainLength", 2, "The length of the chain to generate")

--- a/hive.go
+++ b/hive.go
@@ -31,22 +31,27 @@ var (
 	noShellContainer = flag.Bool("docker-noshell", false, "Disable outer docker shell, running directly on the host")
 	noCachePattern   = flag.String("docker-nocache", "", "Regexp selecting the docker images to forcibly rebuild")
 
-	clientListFlag = flag.String("client", "go-ethereum_master", "Comma separated list of permitted clients for the test type, where client is formatted clientname_branch eg: go-ethereum_master and the client name is a subfolder of the clients directory")
+	clientListFlag     = flag.String("client", "go-ethereum_master", "Comma separated list of permitted clients for the test type, where client is formatted clientname_branch eg: go-ethereum_master and the client name is a subfolder of the clients directory")
+	checkTimeLimitFlag = flag.Duration("client.checktimelimit", 3*time.Minute, "The timeout to wait for a newly "+
+		"instantiated client to open up the RPC port. If a very long chain is imported, this timeout may need to be quite large. "+
+		"A lower value means that hive won't wait as long for in case node crashes and never opens the RPC port.")
 
 	overrideFiles = flag.String("override", "", "Comma separated regexp:files to override in client containers")
 	smokeFlag     = flag.Bool("smoke", false, "Whether to only smoke test or run full test suite")
 
-	simLimiterFlag = flag.Int("simlimiter", -1, "Run all simulators with a time limit in seconds, -1 being unlimited")
+	simulatorPattern     = flag.String("sim", "", "Regexp selecting the simulation tests to run")
+	simulatorParallelism = flag.Int("sim.parallelism", 1, "Max number of parallel clients/containers to run tests against")
+	simulatorTestLimit   = flag.Int("sim.testlimit", -1, "Max number of tests to execute per client (interpreted by simulators)")
+	simRootContext       = flag.Bool("sim.rootcontext", false, "Indicates if the simulation should build "+
+		"the dockerfile with root (simulator) or local context. Needed for access to sibling folders like simulators/common")
+	simLimiterFlag  = flag.Int("sim.timelimit", -1, "Run all simulators with a time limit in seconds, -1 being unlimited")
+	simloglevelFlag = flag.Int("sim.loglevel", 3, "The base log level for simulator client instances. "+
+		"This number from 0-6 is interpreted differently depending on the client type.")
 
-	hiveMaxTestsFlag = flag.Int("hivemaxtestcount", -1, "Limit the number of tests the simulator is permitted to generate in a testsuite for the Hive provider. Used for smoke testing consensus tests themselves.")
+	hiveMaxTestsFlag = flag.Int("hivemaxtestcount", -1, "Limit the number of tests the simulator is permitted to generate in a testsuite for the Hive provider. "+
+		"Used for smoke testing consensus tests themselves.")
 
-	simulatorPattern = flag.String("sim", "", "Regexp selecting the simulation tests to run")
-
-	simulatorParallelism = flag.Int("sim-parallelism", 1, "Max number of parallel clients/containers to run tests against")
-	simulatorTestLimit   = flag.Int("sim-testlimit", -1, "Max number of tests to execute per client (interpreted by simulators)")
-
-	hiveDebug      = flag.Bool("debug", false, "A flag indicating debug mode, to allow docker containers to launch headless delve instances and so on")
-	simRootContext = flag.Bool("sim-rootcontext", false, "Indicates if the simulation should build the dockerfile with root (simulator) or local context. Needed for access to sibling folders like simulators/common")
+	hiveDebug = flag.Bool("debug", false, "A flag indicating debug mode, to allow docker containers to launch headless delve instances and so on")
 
 	chainGenerate   = flag.Bool("chainGenerate", false, "Tell Hive to generate a blockchain on the basis of a supplied genesis and terminate")
 	chainLength     = flag.Uint("chainLength", 2, "The length of the chain to generate")
@@ -55,8 +60,7 @@ var (
 	chainGenesis    = flag.String("chainGenesis", "", "The path and filename to the source genesis.json")
 	chainBlockTime  = flag.Uint("chainBlockTime", 30, "The desired block time in seconds")
 
-	loglevelFlag    = flag.Int("loglevel", 3, "Log level to use for displaying system events")
-	simloglevelFlag = flag.Int("simloglevel", 3, "The base log level for simulator client instances. This number from 0-6 is interpreted differently depending on the client type.")
+	loglevelFlag = flag.Int("loglevel", 3, "Log level to use for displaying system events")
 )
 
 var (
@@ -65,7 +69,7 @@ var (
 	allPseudos           map[string]string                  //map of pseudo names to docker image names
 	allClientVersions    map[string]map[string]string       //map of client names (name_branch format) to a general json struct (map[string]string) containing the version info
 	dockerClient         *docker.Client                     //the web client to the docker api
-	timeoutCheckDuration = time.Duration(180 * time.Second) //liveness check timeout
+	timeoutCheckDuration = time.Duration(120 * time.Second) //liveness check timeout
 )
 
 func main() {
@@ -74,6 +78,7 @@ func main() {
 
 	// Parse the flags and configure the logger
 	flag.Parse()
+	timeoutCheckDuration = *checkTimeLimitFlag
 	log15.Root().SetHandler(log15.LvlFilterHandler(log15.Lvl(*loglevelFlag), log15.StreamHandler(os.Stderr, log15.TerminalFormat())))
 	if *chainGenerate {
 		chaintools.ProduceTestChainFromGenesisFile(*chainGenesis, *chainOutputPath, *chainLength, *chainBlockTime)

--- a/hiveviewer/Scripts/app/app.js
+++ b/hiveviewer/Scripts/app/app.js
@@ -205,7 +205,7 @@ app.prototype.LoadTestSuites = function(path, file) {
     }
     ).
     fail(function (e) {
-        alert("error");
+        alert("Failed to load test suites:" + e.status);
     });
 }
 
@@ -225,6 +225,8 @@ function testSuiteSummary(data) {
     self.data = data;
     self.path = "";
     self.fileName = ko.observable(data.fileName);
+    //self.simLog = ko.observable(data.simLog)
+    self.simLog = ko.observable(getFilePath(data.simLog))
     self.name = ko.observable(data.name);
     self.started = ko.observable(Date.parse(data.start));
     self.primaryClient = ko.observable(data.primaryClient);
@@ -334,15 +336,9 @@ function provokePopup(popup,self) {
 
 testClientInfo.prototype.ShowLogs = function () {
     self = this;
-    
-  
-   
 
-    var popup = window.open("popup.html", "_blank", 'toolbar=no, menubar=no, resizable=yes');
-  
+    var popup = window.open("popup.html", "", "");
     provokePopup(popup,self);
-
-   
 
     return true;
 
@@ -356,9 +352,10 @@ testClientInfo.prototype.ShowLogs = function () {
  */
 
 // testClientResult ctor
-function testClientResult(pass,details,name,version,instantiated,log) {
+function testClientResult(pass,details,name,desc,version,instantiated,log) {
     this.pass = ko.observable(pass);
     this.details = ko.observable(details);
+    this.description = ko.observable(desc);
     this.clientName = ko.observable(name);
     this.clientVersion = ko.observable(version);
     this.clientInstantiated = ko.observable(instantiated);
@@ -431,6 +428,7 @@ function makeClientResults(clientResults, clientInfos) {
     return $.map(clientResults, function (testResult,clientName) {
         var pass = testResult.pass;
         var details = testResult.details;
+        var desc = testResult.description
         var name = "Missing client info.";
         var version = "";
         var instantiated;
@@ -442,7 +440,7 @@ function makeClientResults(clientResults, clientInfos) {
             instantiated = clientInfo.instantiatedAt;
             log = getFilePath(clientInfo.logFile);
         }
-        return new testClientResult(pass, details, name, version, instantiated, log);
+        return new testClientResult(pass, details, name, desc, version, instantiated, log);
     });
 }
 function makeClientInfo( clientInfos) {
@@ -644,7 +642,7 @@ testSuite.prototype.OpenTestSuite = function (vm,e) {
  //   var clonedSuite = new testSuite(ko.utils.parseJson(ko.toJSON(this.original)));
   //  clonedSummary.testSuite(clonedSuite);
   //  clonedSuite.maxPerPage(100);
-    var popup = window.open("testsuite.html", "_blank", 'toolbar=no, menubar=no, resizable=yes');
+    var popup = window.open("testsuite.html", "", "");
 
     provokePopup(popup, summary);
 

--- a/hiveviewer/index.html
+++ b/hiveviewer/index.html
@@ -143,9 +143,13 @@
                 <div data-bind="class: passStyle()+' card accordion-head mt-1'" >
                     <div class="card-header" data-toggle="collapse" aria-expanded="true" data-bind="attr:{id: suiteLabel, 'data-target': '#'+suiteDetailLabel(), 'aria-controls': suiteDetailLabel }">
                         <div class="row ">
-                            <div class="col-4  text-left my-auto font-weight-bold " data-bind="text: name ">
+                            <div class="col-4  text-left my-auto font-weight-bold " >
+                            <span data-bind="text: name "></span>
+                                <!-- ko if: simLog-->
+                                <a data-bind="attr: {href:simLog}" download xlass="btn btn-primary btn-block  " role="button" aria-pressed="true">[simulator log]</a>
+                                <!-- /ko -->
                             </div>
-                            <div class="col-4  text-left my-auto" data-bind="text: primaryClient()+' clients'">
+                            <div class="col-4  text-left my-auto" data-bind="text: primaryClient()">
                             </div>
                             <div class="col-3  text-left my-auto" data-bind="text: moment(started()).format('MMMM Do YYYY, h:mm:ss a')">
                             </div>
@@ -157,6 +161,7 @@
                                 <i class="fa fa-angle-down" ></i>
                                 <!-- /ko -->
                             </div>
+
                         </div>
                     </div>
 
@@ -260,8 +265,14 @@
                                                         </div>
                                                         <div class="collapse" data-bind="attr:{'aria-labelledby': $parents[1].suiteLabel()+id(), id: $parents[1].suiteLabel()+id()+'detail'}">
                                                             <div class="card-body hive-header">
-
-                                                                <p data-bind="text: summaryResult().details()"></p>
+                                                                <p>
+                                                                    <span class="col-sm-3 font-weight-bold">Test description:</span>
+                                                                    <span data-bind="text: description"></span>
+                                                                </p>
+                                                                <p>
+                                                                    <span class="col-sm-3 font-weight-bold">Test Results</span>
+                                                                    <pre data-bind="text: summaryResult().details()"></pre>
+                                                                </p>
                                                                 <div data-bind="ifnot: clientResults().length==0">
                                                                     <div data-bind="foreach: clientResults">
                                                                         <div class="row">
@@ -274,14 +285,15 @@
                                                                             <div class="col-3" data-bind="text:clientVersion">
 
                                                                             </div>
-                                                                            <div class="col-3" data-bind="text:logfile">
-
+                                                                            <div class="col-3">
+                                                                                <a data-bind="attr: {href:logfile}" download class="btn btn-primary btn-block  " role="button" aria-pressed="true">
+                                                                                    <span data-bind="text:logfile"></span>
+                                                                                </a>
                                                                             </div>
                                                                         </div>
                                                                     </div>
                                                                 </div>
                                                                 <div data-bind="if: clientResults().length==0">
-                                                                    <p>Test has summary results only. No per-client test results involved, or the test only involves one client.</p>
                                                                     <p>Participating clients:</p>
                                                                     <div data-bind="foreach: clients">
                                                                         <div class="row">

--- a/hiveviewer/testsuite.html
+++ b/hiveviewer/testsuite.html
@@ -20,18 +20,10 @@
     <script>
         $(function () {
             $( "#content" ).load( "testsuitecomponent.html" );
-
             window.initPopup = function (ko, viewmodel) {
-
                 window.ko = ko;
                 ko.applyBindings(viewmodel, document.body);
-
-               
-
-
-
             };
-
         }
         );
 
@@ -41,8 +33,12 @@
             <div class=" hive-header">
                 <div class="card-header">
                     <div class="row ">
-                        <div class="col-12  text-center my-auto font-weight-bold h1" data-bind="text: name">
-                          
+                        <div class="col-12  my-auto font-weight-bold h1">
+                            <span data-bind="text: name"></span>
+                            <span data-bind="text: primaryClient()"></span>
+                            <!-- ko if: simLog-->
+                            <a data-bind="attr: {href:simLog}" download role="button" aria-pressed="true">[simulator log]</a>
+                            <!-- /ko -->
                         </div>
 
                     </div>

--- a/hiveviewer/testsuitecomponent.html
+++ b/hiveviewer/testsuitecomponent.html
@@ -32,8 +32,14 @@
                 </div>
                 <div class="collapse" data-bind="attr:{'aria-labelledby': $parents[1].suiteLabel()+id(), id: $parents[1].suiteLabel()+id()+'detail'}">
                     <div class="card-body hive-header">
-
-                        <p data-bind="text: summaryResult().details()"></p>
+                        <p>
+                            <span class="col-sm-3 font-weight-bold">Test description:</span>
+                            <span data-bind="text: description"></span>
+                        </p>
+                        <p>
+                            <span class="col-sm-3 font-weight-bold">Test Results</span>
+                        <pre data-bind="text: summaryResult().details()"></pre>
+                        </p>
                         <div data-bind="ifnot: clientResults().length==0">
                             <div data-bind="foreach: clientResults">
                                 <div class="row">
@@ -46,8 +52,10 @@
                                     <div class="col-3" data-bind="text:clientVersion">
 
                                     </div>
-                                    <div class="col-3" data-bind="text:logfile">
-
+                                    <div class="col-3">
+                                        <a data-bind="attr: {href:logfile}" download class="btn btn-primary btn-block  " role="button" aria-pressed="true">
+                                            <span data-bind="text:logfile"></span>
+                                        </a>
                                     </div>
                                 </div>
                             </div>

--- a/simulator.go
+++ b/simulator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"mime/multipart"
@@ -75,15 +76,27 @@ func runSimulations(simulatorPattern string, overrides []string, cacher *buildCa
 func simulate(simDuration int, simulator string, simulatorLabel string, overrides []string, logger log15.Logger, logdir string) error {
 	logger.Info(fmt.Sprintf("running client simulation: %s", simulatorLabel))
 
+	// The simulator creates the testŕesult files, aswell as updates the index file. However, it needs to also
+	// be aware of the location of it's own logfile, which should also be placed into the index.
+	// We generate a unique name here, and pass it to the simulator via ENV vars
+	var logName string
+	{
+		b := make([]byte, 16)
+		rand.Read(b)
+		logName = fmt.Sprintf("%d-%x-simulator.log", time.Now().Unix(), b)
+	}
+
 	// Start the simulator controller container
 	logger.Debug("creating simulator container")
 	hostConfig := &docker.HostConfig{Privileged: true, CapAdd: []string{"SYS_PTRACE"}, SecurityOpt: []string{"seccomp=unconfined"}}
 	sc, err := dockerClient.CreateContainer(docker.CreateContainerOptions{
 		Config: &docker.Config{
 			Image: simulator,
-			Env: []string{"HIVE_SIMULATOR=http://" + simListenerAddress,
-				"HIVE_DEBUG=" + strconv.FormatBool(*hiveDebug),
-				"HIVE_PARALLELISM=" + fmt.Sprintf("%d", *simulatorParallelism),
+			Env: []string{
+				fmt.Sprintf("HIVE_SIMULATOR=http://%v", simListenerAddress),
+				fmt.Sprintf("HIVE_DEBUG=%v", strconv.FormatBool(*hiveDebug)),
+				fmt.Sprintf("HIVE_PARALLELISM=%d", *simulatorParallelism),
+				fmt.Sprintf("HIVE_SIMLOG=%v", logName),
 			},
 		},
 		HostConfig: hostConfig,
@@ -105,8 +118,8 @@ func simulate(simDuration int, simulator string, simulatorLabel string, override
 
 	// Start the tester container and wait until it finishes
 	slogger.Debug("running simulator container")
-	//TODO - Simulator.log? Need to decide how to organise the execution logs.
-	waiter, err := runContainer(sc.ID, slogger, filepath.Join(logdir, "simulator.log"), false, *loglevelFlag)
+
+	waiter, err := runContainer(sc.ID, slogger, filepath.Join(logdir, logName), false, *loglevelFlag)
 	if err != nil {
 		slogger.Error("failed to run simulator", "error", err)
 		return err
@@ -439,10 +452,11 @@ func testStart(w http.ResponseWriter, request *http.Request) {
 	}
 	fmt.Fprintf(w, "%s", testID)
 }
+
 func suiteStart(w http.ResponseWriter, request *http.Request) {
 	log15.Info("Server - suites start request")
 	dict := parseForm(request)
-	suiteID, err := testManager.StartTestSuite(dict["name"], dict["description"])
+	suiteID, err := testManager.StartTestSuite(dict["name"], dict["description"], dict["simlog"])
 	if err != nil {
 		msg := fmt.Sprintf("unable to start test case: %s", err.Error())
 		log15.Error(msg)
@@ -450,6 +464,7 @@ func suiteStart(w http.ResponseWriter, request *http.Request) {
 	}
 	fmt.Fprintf(w, "%s", suiteID)
 }
+
 func suiteEnd(w http.ResponseWriter, request *http.Request) {
 	log15.Info("Server - end suite request")
 	testSuite, ok := checkSuiteRequest(request, w)
@@ -525,7 +540,6 @@ func newNode(w http.ResponseWriter, envs map[string]string, files map[string]*mu
 	containerIP := ""
 	containerMAC := ""
 	//and now initialise it with supplied files
-
 	//start a new client logger
 	logger := log15.New("client started with id", containerID)
 	logfileRelative := filepath.Join(strings.Replace(clientName, string(filepath.Separator), "_", -1), fmt.Sprintf("client-%s.log", containerID))
@@ -637,214 +651,3 @@ func terminateAndUpdate() {
 	}
 
 }
-
-// ServeHTTP handles all the simulator API requests and executes them.
-// func (h *testSuiteAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
-// 	log15.Debug("new simulator request", "from", r.RemoteAddr, "method", r.Method, "endpoint", r.URL.Path)
-
-// 	switch r.Method {
-// 	case "GET":
-// 		// Information retrieval, fetch whatever's needed and return it
-// 		switch {
-// 		case r.URL.Path == "/docker":
-// 			// Docker infos requested, gather and send them back
-// 			info, err := dockerClient.Info()
-// 			if err != nil {
-// 				logger.Error("failed to gather docker infos", "error", err)
-// 				http.Error(w, err.Error(), http.StatusInternalServerError)
-// 				return
-// 			}
-// 			out, _ := json.MarshalIndent(info, "", "  ")
-// 			fmt.Fprintf(w, "%s\n", out)
-
-// case strings.HasPrefix(r.URL.Path, "/nodes/"):
-// 	// Node IP retrieval requested
-// 	id := strings.TrimPrefix(r.URL.Path, "/nodes/")
-// 	h.lock.Lock()
-// 	containerInfo, ok := h.nodes[id]
-// 	h.lock.Unlock()
-// 	if !ok {
-// 		logger.Error("unknown client requested", "id", id)
-// 		http.Error(w, "not found", http.StatusNotFound)
-// 		return
-// 	}
-// 	container, err := dockerClient.InspectContainer(containerInfo.container.ID)
-// 	if err != nil {
-// 		logger.Error("failed to inspect client", "error", err)
-// 		http.Error(w, err.Error(), http.StatusInternalServerError)
-// 		return
-// 	}
-// 	fmt.Fprintf(w, "%s", container.NetworkSettings.IPAddress)
-
-// case strings.HasPrefix(r.URL.Path, "/enodes/"):
-
-// case strings.HasPrefix(r.URL.Path, "/clients"):
-// 	w.Header().Set("Content-Type", "application/json")
-// 	clients := make([]string, 0, len(h.availableClients))
-// 	for client := range h.availableClients {
-// 		clients = append(clients, client)
-// 	}
-// 	json.NewEncoder(w).Encode(clients)
-
-// default:
-// 	http.Error(w, "not found", http.StatusNotFound)
-// }
-
-// 	case "POST":
-// 		// Data mutation, execute the request and return the results
-// 		switch r.URL.Path {
-// 		case "/nodes":
-
-// 			h.newNode(w, r, logger, h.availableClients, true, true)
-// 			return
-// 		case "/pseudos":
-
-// 			h.newNode(w, r, logger, h.availablePseudos, false, false)
-// 			return
-// 		case "/logs":
-// 			body, _ := ioutil.ReadAll(r.Body)
-// 			h.logger.Info("message from simulator", "log", string(body))
-
-// 		case "/subresults":
-// 			// Parse the subresult field into a hive struct
-// 			r.ParseMultipartForm(1024 * 1024)
-
-// 			success, err := strconv.ParseBool(r.Form.Get("success"))
-// 			if err != nil {
-// 				http.Error(w, err.Error(), http.StatusBadRequest)
-// 				return
-// 			}
-
-// 			//If there has been a failure, update the whole test result
-// 			//which at present means updating the result set for each
-// 			//known client. TODO: the output format should be
-// 			//re-arranged so that it is grouped first by test and then by client instance type
-// 			if !success {
-// 				for _, resultset := range h.result {
-// 					resultset[h.simulatorLabel].Success = false
-// 				}
-// 			}
-
-// 			nodeid := r.Form.Get("nodeid")
-// 			if err != nil {
-// 				http.Error(w, err.Error(), http.StatusBadRequest)
-// 				return
-// 			}
-// 			var details json.RawMessage
-// 			if blob := r.Form.Get("details"); blob != "" {
-// 				if err := json.Unmarshal([]byte(blob), &details); err != nil {
-// 					http.Error(w, err.Error(), http.StatusBadRequest)
-// 					return
-// 				}
-// 			}
-// 			// If everything parsed correctly, append the subresult
-// 			h.lock.Lock()
-// 			containerInfo, exist := h.nodes[nodeid]
-// 			if !exist {
-// 				// Add an error even so
-// 				if containerInfo, exist := h.timedOutNodes[nodeid]; exist {
-// 					delete(h.timedOutNodes, nodeid)
-// 					res := h.result[containerInfo.name][h.simulatorLabel]
-// 					res.Subresults = append(res.Subresults, simulationSubresult{
-// 						Name:    r.Form.Get("name"),
-// 						Success: success,
-// 						Error:   fmt.Sprintf("%s (killed after timeout by Hive)", r.Form.Get("error")),
-// 						Details: details,
-// 					})
-// 				}
-// 				h.lock.Unlock()
-// 				http.Error(w, fmt.Sprintf("unknown node %v", nodeid), http.StatusBadRequest)
-// 				return
-// 			}
-// 			res := h.result[containerInfo.name][h.simulatorLabel]
-// 			res.Subresults = append(res.Subresults, simulationSubresult{
-// 				Name:    r.Form.Get("name"),
-// 				Success: success,
-// 				Error:   r.Form.Get("error"),
-// 				Details: details,
-// 			})
-// 			// Also terminate the container now
-// 			delete(h.nodes, nodeid)
-// 			logger.Debug("deleting client container", "id", nodeid)
-// 			h.lock.Unlock()
-// 			if err := dockerClient.RemoveContainer(docker.RemoveContainerOptions{ID: containerInfo.container.ID, Force: true}); err != nil {
-// 				logger.Error("failed to delete client ", "id", nodeid, "error", err)
-// 				http.Error(w, err.Error(), http.StatusInternalServerError)
-// 				return
-// 			}
-
-// 		default:
-// 			http.Error(w, "not found", http.StatusNotFound)
-// 		}
-
-// 	case "DELETE":
-// 		// Data deletion, execute the request and return the results
-// 		switch {
-// 		case strings.HasPrefix(r.URL.Path, "/nodes/"):
-// 			// Node deletion requested
-// 			id := strings.TrimPrefix(r.URL.Path, "/nodes/")
-
-// 			h.lock.Lock()
-// 			h.terminateContainer(id, w)
-// 			h.lock.Unlock()
-
-// 		default:
-// 			http.Error(w, "not found", http.StatusNotFound)
-// 		}
-
-// 	default:
-// 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-// 	}
-// }
-
-// CheckTimeout is a goroutine that checks if the timeout has passed and stops
-// container if it has.
-// func  CheckTimeout() {
-// 	for {
-// 		h.lock.Lock()
-// 		for id, cInfo := range h.nodes {
-
-// 			cont, err := dockerClient.InspectContainer(cInfo.container.ID)
-// 			if err != nil {
-// 				//container already gone
-// 				h.logger.Info("Container already deleted. ", "Container", cInfo.container.ID)
-// 			} else {
-// 				cInfo.container = cont
-// 				if !cInfo.container.State.Running || (time.Now().Sub(cInfo.timeout) >= 0 && cInfo.useTimeout) {
-
-// 					h.logger.Info("Timing out. ", "Running", cInfo.container.State.Running)
-// 					h.timeoutContainer(id, nil)
-
-// 					// remember this container, for when the subresult comes in later
-// 					h.timedOutNodes[id] = cInfo
-// 				}
-
-// 			}
-
-// 		}
-// 		h.lock.Unlock()
-// 		time.Sleep(timeoutCheckDuration)
-// 	}
-// }
-
-// // timeoutContainer terminates a container. OBS! It assumes that the caller already holds h.lock
-// func (h *testSuiteAPIHandler) timeoutContainer(id string, w http.ResponseWriter) {
-// 	containerInfo, ok := h.nodes[id]
-
-// 	if !ok {
-// 		h.logger.Error("unknown client deletion requested", "id", id)
-// 		if w != nil {
-// 			http.Error(w, "not found", http.StatusNotFound)
-// 		}
-// 		return
-// 	}
-// 	delete(h.nodes, id)
-// 	h.logger.Debug("deleting client container on timeout", "id", id)
-// 	if err := dockerClient.RemoveContainer(docker.RemoveContainerOptions{ID: containerInfo.container.ID, Force: true}); err != nil {
-// 		h.logger.Error("failed to delete client ", "id", id, "error", err)
-// 		if w != nil {
-// 			http.Error(w, err.Error(), http.StatusInternalServerError)
-// 		}
-// 	}
-// }

--- a/simulator.go
+++ b/simulator.go
@@ -96,6 +96,7 @@ func simulate(simDuration int, simulator string, simulatorLabel string, override
 				fmt.Sprintf("HIVE_SIMULATOR=http://%v", simListenerAddress),
 				fmt.Sprintf("HIVE_DEBUG=%v", strconv.FormatBool(*hiveDebug)),
 				fmt.Sprintf("HIVE_PARALLELISM=%d", *simulatorParallelism),
+				fmt.Sprintf("HIVE_SIMLIMIT=%d", *simulatorTestLimit),
 				fmt.Sprintf("HIVE_SIMLOG=%v", logName),
 			},
 		},

--- a/simulators/common/providers/hive/hive.go
+++ b/simulators/common/providers/hive/hive.go
@@ -91,10 +91,11 @@ func (sim *host) EndTest(testSuite common.TestSuiteID, test common.TestID, summa
 	return err
 }
 
-func (sim *host) StartTestSuite(name string, description string) (common.TestSuiteID, error) {
+func (sim *host) StartTestSuite(name, description, simlog string) (common.TestSuiteID, error) {
 	vals := make(url.Values)
 	vals.Add("name", name)
 	vals.Add("description", description)
+	vals.Add("simlog", simlog)
 	idstring, err := wrapHTTPErrorsPost(fmt.Sprintf("%s/testsuite", sim.configuration.HostURI), vals)
 	if err != nil {
 		return 0, err

--- a/simulators/common/providers/local/local.go
+++ b/simulators/common/providers/local/local.go
@@ -53,13 +53,6 @@ type host struct {
 	// runningTestCases  map[common.TestID]*common.TestCase
 
 	*common.TestManager
-
-	//	nodeMutex         sync.Mutex
-
-	// testCaseMutex     sync.Mutex
-	// testSuiteMutex    sync.Mutex
-	// testSuiteCounter  uint32
-	// testCaseCounter   uint32
 }
 
 var hostProxy *host
@@ -141,35 +134,6 @@ func mapClients() {
 	hostProxy.pseudoTypes = pseudoTypes
 }
 
-// EndTestSuite ends the test suite by writing the test suite results to the supplied
-// stream and removing the test suite from the running list
-// func (sim *host) EndTestSuite(testSuite common.TestSuiteID) error {
-// 	sim.testSuiteMutex.Lock()
-// 	defer sim.testSuiteMutex.Unlock()
-
-// 	// check the test suite exists
-// 	suite, ok := sim.runningTestSuites[testSuite]
-// 	if !ok {
-// 		return common.ErrNoSuchTestSuite
-// 	}
-// 	// check the suite has no running test cases
-// 	for k := range suite.TestCases {
-// 		_, ok := sim.runningTestCases[k]
-// 		if ok {
-// 			return common.ErrTestSuiteRunning
-// 		}
-// 	}
-// 	// update the db
-// 	err := suite.UpdateDB(sim.configuration.OutputPath)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	//remove the test suite
-// 	delete(sim.runningTestSuites, testSuite)
-
-// 	return nil
-// }
-
 // GetClientEnode Get the client enode for the specified node id, which in this case is just the index
 func (sim *host) GetClientEnode(testSuite common.TestSuiteID, test common.TestID, node string) (*string, error) {
 
@@ -185,99 +149,6 @@ func (sim *host) GetClientEnode(testSuite common.TestSuiteID, test common.TestID
 	//return the enode
 	return sim.configuration.AvailableClients[nodeIndex].Enode, nil
 }
-
-// StartTestSuite starts a test suite and returns the context id
-// func (sim *host) StartTestSuite(name string, description string) (common.TestSuiteID, error) {
-
-// 	sim.testSuiteMutex.Lock()
-// 	defer sim.testSuiteMutex.Unlock()
-
-// 	var newSuiteID = common.TestSuiteID(sim.testSuiteCounter)
-
-// 	sim.runningTestSuites[newSuiteID] = &common.TestSuite{
-// 		ID:          newSuiteID,
-// 		Name:        name,
-// 		Description: description,
-// 		TestCases:   make(map[common.TestID]*common.TestCase),
-// 	}
-
-// 	sim.testSuiteCounter++
-
-// 	return newSuiteID, nil
-// }
-
-//StartTest starts a new test case, returning the testcase id as a context identifier
-// func (sim *host) StartTest(testSuiteID common.TestSuiteID, name string, description string) (common.TestID, error) {
-
-// 	//TODO - StartTest goes onto the TestSuiteManager
-
-// 	sim.testCaseMutex.Lock()
-// 	defer sim.testCaseMutex.Unlock()
-
-// 	// check if the testsuite exists
-// 	testSuite, ok := sim.runningTestSuites[testSuiteID]
-// 	if !ok {
-// 		return 0, common.ErrNoSuchTestSuite
-// 	}
-
-// 	// increment the testcasecounter
-// 	sim.testCaseCounter++
-
-// 	var newCaseID = common.TestID(sim.testCaseCounter)
-
-// 	// create a new test case and add it to the test suite
-// 	newTestCase := &common.TestCase{
-// 		ID:          newCaseID,
-// 		Name:        name,
-// 		Description: description,
-// 		Start:       time.Now(),
-// 		ClientInfo:  make(map[string]*common.TestClientInfo),
-// 	}
-
-// 	// add the test case to the test suite
-// 	testSuite.TestCases[newCaseID] = newTestCase
-// 	// and to the general map of id:testcases
-// 	sim.runningTestCases[newCaseID] = newTestCase
-
-// 	return newTestCase.ID, nil
-// }
-
-// EndTest finishes the test case
-// func (sim *host) EndTest(testSuiteRun common.TestSuiteID, testID common.TestID, summaryResult *common.TestResult, clientResults map[string]*common.TestResult) error {
-
-// 	sim.testCaseMutex.Lock()
-// 	defer sim.testCaseMutex.Unlock()
-
-// 	// Check if the test case is running
-// 	testCase, ok := sim.runningTestCases[testID]
-// 	if !ok {
-// 		return common.ErrNoSuchTestCase
-// 	}
-
-// 	/// Make sure there is at least a result summary
-// 	if summaryResult == nil {
-// 		return common.ErrNoSummaryResult
-// 	}
-
-// 	// Add the results to the test case
-// 	testCase.End = time.Now()
-// 	testCase.SummaryResult = *summaryResult
-// 	testCase.ClientResults = clientResults
-
-// 	delete(sim.runningTestCases, testCase.ID)
-
-// 	// A local configuration might want to be informed
-// 	// of the fact that the test case has ended in order to
-// 	// reset state.
-// 	// The main Hive Docker provider achieves this by killing
-// 	// containers. The Local provider specifies pre-existing clients.
-// 	// Signal that state should be reset by using the Kill message.
-// 	for k := range testCase.ClientInfo {
-// 		sim.KillNode(testSuiteRun, testID, k)
-// 	}
-
-// 	return nil
-// }
 
 //GetClientTypes Get all client types available
 func (sim *host) GetClientTypes() (availableClients []string, err error) {

--- a/simulators/common/providers/local/local_test.go
+++ b/simulators/common/providers/local/local_test.go
@@ -154,8 +154,8 @@ func TestStartTestSuite(t *testing.T) {
 
 	testSuiteHost := setupBasicInstance(t)
 
-	suite1ID, _ := testSuiteHost.StartTestSuite("consensus", "consensus tests")
-	suite2ID, _ := testSuiteHost.StartTestSuite("p2p", "p2p tests")
+	suite1ID, _ := testSuiteHost.StartTestSuite("consensus", "consensus tests", "")
+	suite2ID, _ := testSuiteHost.StartTestSuite("p2p", "p2p tests", "")
 
 	suite1, ok1 := hostProxy.TestManager.IsTestSuiteRunning(suite1ID)
 	suite2, ok2 := hostProxy.TestManager.IsTestSuiteRunning(suite2ID)
@@ -169,13 +169,14 @@ func TestStartTestSuite(t *testing.T) {
 	}
 
 	if suite1.Description != "consensus tests" || suite2.Description != "p2p tests" {
-		t.Fatalf("Test suite description not registered")
+		t.Fatalf(
+			"Test suite description not registered")
 	}
 }
 
 func setupTestSuite(t *testing.T) (common.TestSuiteHost, *common.TestSuite) {
 	testSuiteHost := setupBasicInstance(t)
-	suiteID, _ := testSuiteHost.StartTestSuite("consensus", "consensus tests")
+	suiteID, _ := testSuiteHost.StartTestSuite("consensus", "consensus tests", "foo")
 	suite, ok := hostProxy.TestManager.IsTestSuiteRunning(suiteID)
 	if !ok {
 		t.Fatalf("Test setup failed, test suite not found")

--- a/simulators/common/testmanager.go
+++ b/simulators/common/testmanager.go
@@ -133,16 +133,17 @@ func (manager *TestManager) EndTestSuite(testSuite TestSuiteID) error {
 }
 
 // StartTestSuite starts a test suite and returns the context id
-func (manager *TestManager) StartTestSuite(name string, description string) (TestSuiteID, error) {
+func (manager *TestManager) StartTestSuite(name string, description string, simlog string) (TestSuiteID, error) {
 
 	manager.testSuiteMutex.Lock()
 	defer manager.testSuiteMutex.Unlock()
 	var newSuiteID = TestSuiteID(manager.testSuiteCounter)
 	manager.runningTestSuites[newSuiteID] = &TestSuite{
-		ID:          newSuiteID,
-		Name:        name,
-		Description: description,
-		TestCases:   make(map[TestID]*TestCase),
+		ID:           newSuiteID,
+		Name:         name,
+		Description:  description,
+		TestCases:    make(map[TestID]*TestCase),
+		SimulatorLog: simlog,
 	}
 	manager.testSuiteCounter++
 

--- a/simulators/common/testsuiteprovider.go
+++ b/simulators/common/testsuiteprovider.go
@@ -24,7 +24,7 @@ func RegisterProvider(key string, provider TestSuiteProviderInitialiser) {
 
 //TestSuiteHost The test suite host the simulator communicates with to manage test cases and their resources
 type TestSuiteHost interface {
-	StartTestSuite(name string, description string) (TestSuiteID, error)
+	StartTestSuite(string, description, simlog string) (TestSuiteID, error)
 	// StartTest starts a test case, which provides a context for clients and results, returning the test case identifier
 	StartTest(testSuiteRun TestSuiteID, name string, description string) (TestID, error)
 	// EndTest ends a test case, cleaning up client instances created for the test and writing out results

--- a/simulators/common/utils.go
+++ b/simulators/common/utils.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+)
+
+// truncateHead truncates the head lines, leaving somewhere slightly below 'size' bytes,
+// and ensures that lines are kept intact.
+func truncateHead(path string, size int64) error {
+	var tmpFileName = fmt.Sprintf("%s.tmp", path)
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	// seek N bytes from the end (whence=2)
+	if _, err := file.Seek(-size, 2); err != nil {
+		file.Close()
+		return err
+	}
+	reader := bufio.NewReader(file)
+	// read until a line-break
+	if _, err = reader.ReadString('\n'); err != nil {
+		file.Close()
+		return fmt.Errorf("seek failed: %v", err)
+	}
+	// reader is now positioned correctly, we can shove all remaining data into the next index-file
+	newFile, err := os.OpenFile(tmpFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		file.Close()
+		return err
+	}
+	io.Copy(newFile, reader)
+	newFile.Close()
+	file.Close()
+	// Now, delete the old one, and swap in the new one
+	if err = os.Remove(path); err != nil {
+		return err
+	}
+	return os.Rename(tmpFileName, path)
+}
+
+// appendLine appends given data + linebreak to the file at the given path. The file is created with 0644
+// permissions if it does not already exist
+func appendLine(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(string(data) + "\n")
+	f.Close()
+	return err
+}

--- a/simulators/devp2p/basic/tests.sh
+++ b/simulators/devp2p/basic/tests.sh
@@ -4,10 +4,9 @@
 echo "Starting simulator."
 cd /go/src/github.com/ethereum/hive/simulators/devp2p/basic/
 
-
-
 echo "Simulator endpoint: $HIVE_SIMULATOR"
 echo "Simulator parallelism: $HIVE_PARALLELISM"
+echo "Simulator logfile: $HIVE_SIMLOG"
 
 echo "{ \"hostURI\":\"$HIVE_SIMULATOR\" }" >hiveProviderConfig.json
  

--- a/simulators/devp2p/udp.go
+++ b/simulators/devp2p/udp.go
@@ -359,6 +359,12 @@ func (t *V4Udp) SpoofedPing(toid enode.ID, tomac string, toaddr *net.UDPAddr, fr
 
 //SpoofingFindNodeCheck tests if a client is susceptible to being used
 //as an attack vector for findnode amplification attacks
+//
+// The test spoofs a ping from a different ip address('victim ip'), and later on sends a spoofed 'pong'. The spoofed 'pong' will have
+// an invalid reply-token (since the target will send the 'pong' to 'victim ip'), and should thus be ignored by the target.
+// If the target fails to verify reply-token, it will believe to now be bonded with a node at 'victim ip'.
+// The test then sends a spoofed 'findnode' request. If the 'target' responds to the findnode-request, sending a large
+// 'neighbours'-packet to 'victim ip', it can be used for DoS attacks.
 func (t *V4Udp) SpoofingFindNodeCheck(toid enode.ID, tomac string, toaddr *net.UDPAddr, fromaddr *net.UDPAddr, validateEnodeID bool, netInterface string) error {
 
 	//send ping

--- a/simulators/ethereum/consensus/main.go
+++ b/simulators/ethereum/consensus/main.go
@@ -186,11 +186,14 @@ func init() {
 	hive.Support()
 }
 
-func deliverTests(root string) chan *testcase {
+func deliverTests(root string, limit int) chan *testcase {
 	out := make(chan *testcase)
 	var i, j = 0, 0
 	go func() {
 		filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if limit >= 0 && i >= limit {
+				return nil
+			}
 			if info.IsDir() {
 				return nil
 			}
@@ -439,6 +442,7 @@ func getHash(rawClient *rpc.Client, arg string) ([]byte, error) {
 }
 func main() {
 	paralellism := 16
+	log.Root().SetHandler(log.StdoutHandler)
 	if val, ok := os.LookupEnv("HIVE_PARALLELISM"); ok {
 		if p, err := strconv.Atoi(val); err != nil {
 			log.Warn("Hive paralellism could not be converted to int", "error", err)
@@ -446,7 +450,15 @@ func main() {
 			paralellism = p
 		}
 	}
-	log.Info("Hive simulator started.", "paralellism", paralellism)
+	testLimit := -1
+	if val, ok := os.LookupEnv("HIVE_SIMLIMIT"); ok {
+		if p, err := strconv.Atoi(val); err != nil {
+			log.Warn("Simulator test limit could not be converted to int", "error", err)
+		} else {
+			testLimit = p
+		}
+	}
+	log.Info("Hive simulator started.", "paralellism", paralellism, "testlimit", testLimit)
 
 	// get the test suite engine provider and initialise
 	simProviderType := flag.String("simProvider", "", "the simulation provider type (local|hive)")
@@ -473,17 +485,17 @@ func main() {
 	for _, client := range availableClients {
 		testSuiteID, err := host.StartTestSuite("consensus", "consensus test suite blockchain tests for a single client type", logFile)
 		if err != nil {
-			log.Error(fmt.Sprintf("Unable to start test suite: %s", err.Error()), err.Error())
+			log.Error("Unable to start test suite", "error", err)
 			os.Exit(1)
 		}
 		defer func() {
 			if err := host.EndTestSuite(testSuiteID); err != nil {
-				log.Error(fmt.Sprintf("Unable to end test suite: %s", err.Error()), err.Error())
+				log.Error("Unable to end test suite", "error", err)
 				os.Exit(1)
 			}
 		}()
 
-		testCh := deliverTests(fileRoot)
+		testCh := deliverTests(fileRoot, testLimit)
 		var wg sync.WaitGroup
 		for i := 0; i < paralellism; i++ {
 			wg.Add(1)
@@ -493,7 +505,7 @@ func main() {
 				wg.Done()
 			}()
 		}
-		log.Info("Tests started", "num threads", 16)
+		log.Info("Tests started", "num threads", paralellism)
 		wg.Wait()
 	}
 }

--- a/simulators/ethereum/consensus/main.go
+++ b/simulators/ethereum/consensus/main.go
@@ -467,10 +467,11 @@ func main() {
 	availableClients, _ := host.GetClientTypes()
 
 	log.Info("Got clients", "clients", availableClients)
+	logFile, _ := os.LookupEnv("HIVE_SIMLOG")
 
 	fileRoot := fmt.Sprintf("%s/BlockchainTests/", testpath)
 	for _, client := range availableClients {
-		testSuiteID, err := host.StartTestSuite("consensus", "consensus test suite blockchain tests for a single client type")
+		testSuiteID, err := host.StartTestSuite("consensus", "consensus test suite blockchain tests for a single client type", logFile)
 		if err != nil {
 			log.Error(fmt.Sprintf("Unable to start test suite: %s", err.Error()), err.Error())
 			os.Exit(1)

--- a/simulators/ethereum/consensus/tests.sh
+++ b/simulators/ethereum/consensus/tests.sh
@@ -5,6 +5,7 @@ cd /go/src/github.com/ethereum/hive/simulators/ethereum/consensus/
 
 echo "Simulator endpoint: $HIVE_SIMULATOR"
 echo "Simulator parallelism: $HIVE_PARALLELISM"
+echo "Simulator test limit: $HIVE_SIMLIMIT"
 
 #generate the config file for a hive provider
 echo "{ \"hostURI\":\"$HIVE_SIMULATOR\" }" >hiveProviderConfig.json

--- a/simulators/ethereum/graphql/graphql.go
+++ b/simulators/ethereum/graphql/graphql.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -14,14 +16,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ethereum/hive/simulators/common/providers/hive"
-	"github.com/ethereum/hive/simulators/common/providers/local"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/hive/simulators/common"
+	"github.com/ethereum/hive/simulators/common/providers/hive"
+	"github.com/ethereum/hive/simulators/common/providers/local"
 )
-
-type envvars map[string]int
 
 func init() {
 	//support providers
@@ -29,11 +28,14 @@ func init() {
 	local.Support()
 }
 
-func deliverTests() chan *testcase {
+func deliverTests(limit int) chan *testcase {
 	out := make(chan *testcase)
 	var i = 0
 	go func() {
 		filepath.Walk("/testcases", func(filepath string, info os.FileInfo, err error) error {
+			if limit >= 0 && i >= limit {
+				return nil
+			}
 			if info.IsDir() {
 				return nil
 			}
@@ -77,7 +79,7 @@ type testcase struct {
 func run(testChan chan *testcase, host common.TestSuiteHost, suiteID common.TestSuiteID, client string) {
 	var i = 0
 	for t := range testChan {
-		if err := runTest(t, host, suiteID, client); err != nil {
+		if err := prepareRunTest(t, host, suiteID, client); err != nil {
 			log.Error("error", "err", err)
 		}
 		i++
@@ -85,7 +87,8 @@ func run(testChan chan *testcase, host common.TestSuiteHost, suiteID common.Test
 	log.Info("executor finished", "num_executed", i)
 }
 
-func runTest(t *testcase, host common.TestSuiteHost, suiteID common.TestSuiteID, client string) error {
+// prepareRunTest administers the hive-specific test stuff, registering the suite and reporting back the suite results
+func prepareRunTest(t *testcase, host common.TestSuiteHost, suiteID common.TestSuiteID, client string) error {
 
 	log.Info("Starting test", "name", t.name)
 
@@ -93,75 +96,72 @@ func runTest(t *testcase, host common.TestSuiteHost, suiteID common.TestSuiteID,
 	if err != nil {
 		return err
 	}
-
-	var done = func() {
-		var (
-			errString = ""
-			success   = (err == nil)
-		)
-		if !success {
-			errString = err.Error()
-		}
-		host.EndTest(suiteID, testID, &common.TestResult{success, errString}, nil)
-	}
-	defer done()
-
+	// The graphql chain comes from the Besu codebase, and is built on Frontier
 	env := map[string]string{
-		"CLIENT":                   client,
-		"HIVE_FORK_DAO_VOTE":       "1",
-		"HIVE_CHAIN_ID":            "1",
-		"HIVE_FORK_HOMESTEAD":      "0",
-		"HIVE_FORK_TANGERINE":      "0",
-		"HIVE_FORK_SPURIOUS":       "0",
-		"HIVE_FORK_BYZANTIUM":      "0",
-		"HIVE_FORK_CONSTANTINOPLE": "0",
-		"HIVE_FORK_PETERSBURG":     "0",
+		"CLIENT":             client,
+		"HIVE_FORK_DAO_VOTE": "1",
+		"HIVE_CHAIN_ID":      "1",
 	}
 	files := map[string]string{
 		"genesis.json": "/init/testGenesis.json",
 		"chain.rlp":    "/init/testBlockchain.blocks",
 	}
-
 	_, ip, _, err := host.GetNode(suiteID, testID, env, files)
+	if err != nil {
+		host.EndTest(suiteID, testID, &common.TestResult{false, err.Error()}, nil)
+		return err
+	}
+	if testErr := runTest(ip, t); testErr != nil {
+		host.EndTest(suiteID, testID, &common.TestResult{false, testErr.Error()}, nil)
+		return testErr
+	}
+	host.EndTest(suiteID, testID, &common.TestResult{Pass: true}, nil)
+	return nil
+}
+
+// runTest does the actual testing: querying the client-under-test. It executes after a client has been
+// successfully instantiated
+func runTest(ip net.IP, t *testcase) error {
+	type qlQuery struct {
+		Query string `json:"query"`
+	}
+
+	// Example of working queries:
+	// curl 'http://127.0.0.1:8547/graphql' --data-binary '{"query":"query blockNumber {\n  block {\n    number\n  }\n}\n"}'
+	// curl 'http://127.0.0.1:8547/graphql' --data-binary '{"query":"query blockNumber {\n  block {\n    number\n  }\n}\n","variables":null,"operationName":"blockNumber"}'
+
+	postData, err := json.Marshal(qlQuery{string(t.graphql)})
 	if err != nil {
 		return err
 	}
-	graphql := strings.ReplaceAll(strings.ReplaceAll(string(t.graphql), "\r", ""), "\n", "") //the newlines either work or don't depending on the executing platform. remove.
-
-	nodeQuery := fmt.Sprintf("http://%s:8547/graphql/query=%s", ip.String(), graphql)
-	resp, err := http.Get(nodeQuery)
+	resp, err := http.Post(fmt.Sprintf("http://%s:8547/graphql", ip.String()),
+		"application/json",
+		bytes.NewReader(postData))
+	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-
 	//verify the response matches expected
-	if resp.StatusCode == http.StatusOK {
-		jsonbytes, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		jsonstring := string(jsonbytes)
-
-		expected := string(t.expected)
-
-		res, err := areEqualJSON(jsonstring, string(t.expected))
-		if err != nil {
-			return err
-		}
-		if !res {
-			return fmt.Errorf("Test failed, expected %s ...got.. %s  ", expected, jsonstring)
-		}
-
-	} else {
-		return fmt.Errorf("Error sending request %s", strconv.Itoa(resp.StatusCode))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Node HTTP response not 200 OK, got: %v, response: %v", resp.Status, string(respBytes))
 	}
-
+	exp, got := string(t.expected), string(respBytes)
+	if res, err := areEqualJSON(got, exp); err != nil {
+		return err
+	} else if !res {
+		return fmt.Errorf("Test failed. Query:\n```\n%v\n```\nexpected: \n```\n%s\n```\n got:\n```\n%s\n```\n", string(t.graphql), exp, got)
+	}
 	return nil
 }
 
 func main() {
-	paralellism := 16
+	var (
+		paralellism = 16
+		testLimit   = -1
+	)
+
+	log.Root().SetHandler(log.StdoutHandler)
 	if val, ok := os.LookupEnv("HIVE_PARALLELISM"); ok {
 		if p, err := strconv.Atoi(val); err != nil {
 			log.Warn("Hive paralellism could not be converted to int", "error", err)
@@ -169,7 +169,14 @@ func main() {
 			paralellism = p
 		}
 	}
-	log.Info("Hive simulator started.", "paralellism", paralellism)
+	if val, ok := os.LookupEnv("HIVE_SIMLIMIT"); ok {
+		if p, err := strconv.Atoi(val); err != nil {
+			log.Warn("Simulator test limit could not be converted to int", "error", err)
+		} else {
+			testLimit = p
+		}
+	}
+	log.Info("Hive simulator started.", "paralellism", paralellism, "testlimit", testLimit)
 
 	// get the test suite engine provider and initialise
 	simProviderType := flag.String("simProvider", "", "the simulation provider type (local|hive)")
@@ -198,7 +205,7 @@ func main() {
 			}
 		}()
 
-		testCh := deliverTests()
+		testCh := deliverTests(testLimit)
 		var wg sync.WaitGroup
 		for i := 0; i < paralellism; i++ {
 			wg.Add(1)

--- a/simulators/ethereum/graphql/graphql.go
+++ b/simulators/ethereum/graphql/graphql.go
@@ -183,9 +183,10 @@ func main() {
 
 	availableClients, _ := host.GetClientTypes()
 	log.Info("Got clients", "clients", availableClients)
+	logFile, _ := os.LookupEnv("HIVE_SIMLOG")
 
 	for _, client := range availableClients {
-		testSuiteID, err := host.StartTestSuite("graphql", "graphql test suite covering the graphql API surface")
+		testSuiteID, err := host.StartTestSuite("graphql", "graphql test suite covering the graphql API surface", logFile)
 		if err != nil {
 			log.Error(fmt.Sprintf("Unable to start test suite: %s", err.Error()), err.Error())
 			os.Exit(1)

--- a/simulators/ethereum/graphql/graphql_test.go
+++ b/simulators/ethereum/graphql/graphql_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+func TestJsonComparison(t *testing.T) {
+
+	a := `{
+  "errors": [
+    {
+      "message": "Exception while fetching data (/block) : Block hash 0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0 was not found",
+      "locations": [
+        {
+          "line": 1,
+          "column": 2
+        }
+      ],
+      "path": ["block"],
+      "extensions": {
+        "classification": "DataFetchingException"
+      }
+    }
+  ],
+  "data": null
+}
+`
+	b := `
+{
+  "errors" : [ {
+    "message" : "Exception while fetching data (/block) : Block hash 0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0 was not found",
+    "extensions" : {
+      "classification" : "DataFetchingException"
+    },
+    "path" : [ "block" ],
+    "locations" : [ {
+      "column" : 2,
+      "line" : 1
+    } ]
+  } ],
+  "data" : null
+}`
+	got, err := areEqualJSON(a, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatalf("Expected equality=true for identity, got false")
+	}
+	got, err = areEqualJSON(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatalf("Expected equality=true, got false")
+	}
+}

--- a/simulators/ethereum/sync/sync_test.go
+++ b/simulators/ethereum/sync/sync_test.go
@@ -60,8 +60,15 @@ func RunTestSuite(m *testing.M) int {
 
 func TestSyncsWithGeth(t *testing.T) {
 
+	logFile, _ := os.LookupEnv("HIVE_SIMLOG")
 	//start the test suite
-	testSuite, err := host.StartTestSuite("Sync test suite", "This suite of tests verifies that clients can sync from each other in different modes.")
+	testSuite, err := host.StartTestSuite("Sync test suite",
+		`This suite of tests verifies that clients can sync from each other in different modes.
+ It consists of two specific tests, both using geth as the reference client, testing these two aspects: 
+
+- Whether the client-under-test can sync from geth
+- Whether geth can sync from the client-under-test'
+`, logFile)
 	if err != nil {
 		t.Fatalf("Simulator error. Failed to start test suite. %v ", err)
 	}
@@ -93,7 +100,9 @@ func TestSyncsWithGeth(t *testing.T) {
 		}
 		startTime := time.Now()
 
-		testID, err := host.StartTest(testSuite, "From geth", "This test initialises an instance of geth with a predefined chain and genesis (configured to run in fast-sync) and then attempts to sync multiple clients from that one.")
+		testID, err := host.StartTest(testSuite, "Serve as sync source",
+			`This test initialises each client-under-test with a predefined chain, 
+and attempts to sync up a geth-node against the client-under-test.`)
 		if err != nil {
 			t.Fatalf("Unable to start test: %s", err.Error())
 		}
@@ -196,7 +205,9 @@ func TestSyncsWithGeth(t *testing.T) {
 		}
 
 		startTime := time.Now()
-		testID, err := host.StartTest(testSuite, "From geth", "This test initialises an instance of geth with a predefined chain and genesis (configured to run in fast-sync) and then attempts to sync multiple clients from that one.")
+		testID, err := host.StartTest(testSuite, "Sync from geth",
+			`This test initialises an instance of geth with a predefined chain and genesis and attempts to 
+sync each client-under-test from the geth master.`)
 		if err != nil {
 			t.Fatalf("Unable to start test: %s", err.Error())
 		}

--- a/simulators/ethereum/sync/sync_test.go
+++ b/simulators/ethereum/sync/sync_test.go
@@ -369,8 +369,7 @@ func syncClient(doneFn func(), mainURL, clientID string, nodeIP net.IP, t *testi
 			block, err := ethClient.GetBlockByNumber(ctx, -1)
 			if err != nil {
 				t.Errorf("Error getting block from %s ", clientURL)
-			}
-			if block != nil {
+			} else {
 				blockNumber := block.GetNumber()
 				t.Logf("Block number: %d", block.GetNumber())
 				if blockNumber == int64(chainLength) {

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,6 @@
 # and should thus complete in tens of minutes
 #
 
-
 HIVEHOME="./"
 
 # Store results in temp
@@ -18,44 +17,40 @@ FLAGS="--docker-noshell --loglevel 4"
 FLAGS="$FLAGS --results-root $RESULTS "
 FLAGS="$FLAGS --sim.parallelism 1 --sim.rootcontext --client.checktimelimit=20s"
 
+echo "Running the quick'n'dirty version of the Hive tests, for local development"
+echo "To the the hive viewer up, you can do"
+echo ""
+echo "  cd $HIVEHOME/hiveviewer && ln -s /tmp/TestResults/ Results && python -m SimpleHTTPServer"
+echo ""
+echo "And then visit http://localhost:8000/ with your browser. "
+echo "Log-files and stuff is availalbe in $RESULTS."
+echo ""
+echo ""
+
+
+function run {
+  echo "$HIVEHOME> $1"
+  (cd $HIVEHOME && $1)
+}
+
 function testconsensus {
   client=$1
-  cd $HIVEHOME;
-
-  echo "$(date) Starting hive consensus simulation [$client], check progress at output.log"
-  hive --sim ethereum/consensus \
-  --client $client --sim.loglevel 6 --sim.testlimit 2 $FLAGS
-
+  echo "$(date) Starting hive consensus simulation [$client]"
+  run "hive --sim ethereum/consensus --client $client --sim.loglevel 6 --sim.testlimit 2 $FLAGS"
+}
+function testgraphql {
+  echo "$(date) Starting graphql simulation [$1]"
+  run "hive --sim ethereum/graphql --client $1 $FLAGS"
 }
 
 function testsync {
-  client1=$1
-  client2=$2
-  cd $HIVEHOME;
-
-  echo "$(date) Starting hive sync simulation [$client<->$client2], check progress at output.log"
-
-  hive --sim ethereum/sync --client "$client1,$client2" $FLAGS
-
+  echo "$(date) Starting hive sync simulation [$1<->$2]"
+  run "hive --sim ethereum/sync --client=\"$1,$2\" $FLAGS"
 }
 
 function testdevp2p {
-  client=$1
-  cd $HIVEHOME;
-
-  echo "$(date) Starting p2p simulation [$client], check progress at output.log"
-
-  hive --sim devp2p --client $client $FLAGS
-}
-
-
-function testgraphql {
-  client=$1
-  cd $HIVEHOME;
-
-  echo "$(date) Starting graphql simulation [$client], check progress at output.log"
-
-  hive --sim ethereum/graphql --sim.testlimit 5 --client $client $FLAGS
+  echo "$(date) Starting p2p simulation [$1]"
+  run "hive --sim devp2p --client $1 $FLAGS"
 }
 
 mkdir $RESULTS

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+#
+# This is a little test-script, that can be used for a some trial runs of clients.
+#
+# This script runs all production-ready tests, but does so with very restrictive options,
+# and should thus complete in tens of minutes
+#
+
+
+HIVEHOME="./"
+
+# Store results in temp
+RESULTS="/tmp/TestResults"
+
+#FLAGS="--docker-noshell --docker-nocache ."
+FLAGS="--docker-noshell --loglevel 4"
+FLAGS="$FLAGS --results-root $RESULTS "
+FLAGS="$FLAGS --sim.parallelism 1 --sim.rootcontext --client.checktimelimit=20s"
+
+function testconsensus {
+  client=$1
+  cd $HIVEHOME;
+
+  echo "$(date) Starting hive consensus simulation [$client], check progress at output.log"
+  hive --sim ethereum/consensus \
+  --client $client --sim.loglevel 6 --sim.testlimit 2 $FLAGS
+
+}
+
+function testsync {
+  client1=$1
+  client2=$2
+  cd $HIVEHOME;
+
+  echo "$(date) Starting hive sync simulation [$client<->$client2], check progress at output.log"
+
+  hive --sim ethereum/sync --client "$client1,$client2" $FLAGS
+
+}
+
+function testdevp2p {
+  client=$1
+  cd $HIVEHOME;
+
+  echo "$(date) Starting p2p simulation [$client], check progress at output.log"
+
+  hive --sim devp2p --client $client $FLAGS
+}
+
+
+function testgraphql {
+  client=$1
+  cd $HIVEHOME;
+
+  echo "$(date) Starting graphql simulation [$client], check progress at output.log"
+
+  hive --sim ethereum/graphql --sim.testlimit 5 --client $client $FLAGS
+}
+
+mkdir $RESULTS
+
+# Sync are quick tests
+#
+#testsync go-ethereum_latest go-ethereum_stable
+#testsync go-ethereum_latest parity_latest
+#testsync go-ethereum_latest aleth_nightly
+#testsync go-ethereum_latest nethermind_latest
+#testsync go-ethereum_latest besu_latest
+
+# GraphQL implemented only in besu and geth
+#
+
+testgraphql go-ethereum_latest
+testgraphql besu_latest
+
+
+# The devp2p tests are pretty quick -- a few minutes
+#testdevp2p go-ethereum_latest
+#testdevp2p nethermind_latest
+#testdevp2p besu_latest
+#testdevp2p parity_latest
+
+
+# These take an extremely long time to run
+#testconsensus aleth_nightly
+#testconsensus go-ethereum_latest
+#testconsensus parity_latest
+#testconsensus nethermind_latest
+#testconsensus besu_latest
+
+
+


### PR DESCRIPTION
A massive PR which brings along quite a lot of needed maintenance. To name a few: 

- Graphql tests now actually work (they previously failed, but were reported as successfull). Geth + Besu enabled. 
- Aleth fixed up for Istanbul+
- Ability to download simulator log file, which is quite important
- Expose log file even if client container doesn't open RPC port
- Several more cmd line options, e..g to make it possible to run tests more limited, for local testing
- Make "popups" use regular windows/tabs instead of pesky floating windows

Changes some cmd line params too: 

```
     sim-parallelism => sim.parallelism
     simlimiter => sim.testlimit
     sim-rootcontext => sim.rootcontext
     simloglevel => sim.loglevel
```