### PR TITLE
refactor the sync tests

### DIFF
--- a/clients/aleth/enode.sh
+++ b/clients/aleth/enode.sh
@@ -9,7 +9,7 @@
 # Immediately abort the script on any error encountered
 set -e
 
-
+sleep 1
 TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}' "localhost:8545" )
 
 

--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -116,7 +116,7 @@ if [ "$HIVE_USE_GENESIS_CONFIG" == "" ]; then
 		JQPARAMS="$JQPARAMS + {\"osakaBlock\": $HIVE_FORK_MUIR_OSAKA}"
 	fi
 	chainconfig=`echo $chainconfig | jq "$JQPARAMS"`
-	genesis=`cat /etc/besu/genesis.json` && echo $genesis | jq ". + {\"config\": $chainconfig}" > /etc/besu/genesis.json
+	genesis=`cat /genesis.json` && echo $genesis | jq ". + {\"config\": $chainconfig}" > /etc/besu/genesis.json
 fi
 
 

--- a/clients/parity/enode.sh
+++ b/clients/parity/enode.sh
@@ -10,8 +10,9 @@
 set -e
 
 
-
-
+# This script errors at times, so we add a little sleep here to
+# give the node some more time
+sleep 1
 TARGET_RESPONSE=$(curl --data '{"method":"parity_enode","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST "localhost:8545" )
 
 

--- a/clients/parity/parity.sh
+++ b/clients/parity/parity.sh
@@ -240,5 +240,6 @@ if [ "$HIVE_MINER_EXTRA" != "" ]; then
 fi
 
 # Run the parity implementation with the requested flags
-echo "Running parity..."
-parity $FLAGS  --no-warp --usd-per-eth 1 --nat none --jsonrpc-interface all --jsonrpc-hosts all
+FLAGS="$FLAGS --no-warp --usd-per-eth 1 --nat none --jsonrpc-interface all --jsonrpc-hosts all  --jsonrpc-apis all"
+echo "running parity $FLAGS"
+parity $FLAGS


### PR DESCRIPTION
This PR changes the way the sync-tests behaves, to not be tied to geth, but any client syncing with any client. 
It uses the `HIVE_BOOTNODE` env variable instead of RPC peering. 

Also fixes the besu genesis problem in https://github.com/ethereum/hive/issues/259 .