### PR TITLE
simulator: fix nil deref on failure to build simulators

### DIFF
--- a/simulator.go
+++ b/simulator.go
@@ -638,6 +638,9 @@ func terminateAndUpdate() {
 	// host terminated for those that were prematurely ended.
 	// NB!: this indirectly kills client containers. There is
 	// no need for client container timeouts.
+	if testManager == nil {
+		return
+	}
 	if err := testManager.Terminate(); err != nil {
 		log15.Error("Could not terminate tests: %s\n", err.Error())
 	}


### PR DESCRIPTION
This PR fixes an error which caused a nil deref if the simulator image fails to build, as was the case in https://github.com/hyperledger/besu/issues/797 