### PR TITLE
add besu fast-sync config flags for contrived test chains

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -54,7 +54,8 @@ else
 fi
 
 if [ "$HIVE_NODETYPE" == "full" ]; then
-	FLAGS="$FLAGS --sync-mode=FAST"
+	FLAGS="$FLAGS --sync-mode=FAST --fast-sync-min-peers=1 --Xsynchronizer-fast-sync-pivot-distance=0"
+
 fi
 if [ "$HIVE_NODETYPE" == "light" ]; then
     echo "Besu does not support light nodes"


### PR DESCRIPTION
hyperledger/besu#797 brought up a fast sync issue that is a result of the test chain not conforming to certain configured minimums.

These flags are there to protect against chain reorgs and bad pivot-block-selection while fast syncing. I'm curious why geth's sync doesn't need these precautions! If you have a link to a resource that explains how geth's sync gets around these that would be lovely.
