### PR TITLE
Fix clientproblems

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -35,7 +35,7 @@
 #  - HIVE_FORK_DAO_VOTE        whether the node support (or opposes) the DAO fork
 
 besu=/opt/besu/bin/besu
-RPCFLAGS="--graphql-http-enabled --graphql-http-host=0.0.0.0 --host-whitelist=*"
+RPCFLAGS="--graphql-http-enabled --graphql-http-host=0.0.0.0 --graphql-http-port=8545 --host-whitelist=*"
 RPCFLAGS="$RPCFLAGS --rpc-http-enabled --rpc-http-api=ETH,NET,WEB3,ADMIN --rpc-http-host=0.0.0.0"
 
 set -e

--- a/clients/openethereum/Dockerfile
+++ b/clients/openethereum/Dockerfile
@@ -4,7 +4,7 @@ ARG branch=latest
 FROM openethereum/openethereum:$branch
 
 USER root
-RUN apt-get -y update && apt-get install -y bc jq curl
+RUN apk add --no-cache bc jq curl
 ADD parity.sh /parity.sh
 RUN chmod +x /parity.sh
 ADD chain.json /chain.json
@@ -20,8 +20,5 @@ EXPOSE 8545 8547 30303 30303/udp
 
 ADD genesis.json /genesis.json
 RUN chmod 777 /genesis.json
-
-
-
 
 ENTRYPOINT ["/parity.sh"]

--- a/simulators/ethereum/graphql/graphql.go
+++ b/simulators/ethereum/graphql/graphql.go
@@ -168,9 +168,12 @@ func runTest(ip net.IP, t *graphQLTest) error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.Post(fmt.Sprintf("http://%s:8547/graphql", ip.String()),
+	resp, err := http.Post(fmt.Sprintf("http://%s:8545/graphql", ip.String()),
 		"application/json",
 		bytes.NewReader(postData))
+	if err != nil {
+		return err
+	}
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/test.sh
+++ b/test.sh
@@ -59,9 +59,9 @@ mkdir $RESULTS
 #
 
 # These three can succsessfully sync with themselves
-#testsync parity_latest
+#testsync openethereum_latest
 #testsync go-ethereum_latest
-testsync aleth_nightly,parity_latest,go-ethereum_latest
+testsync aleth_nightly,openethereum_latest,go-ethereum_latest
 
 # These two are failing - even against themselves
 testsync besu_latest       # fails
@@ -70,7 +70,7 @@ testsync nethermind_latest # fails
 #testsync besu_latest,nethermind_latest
 
 #testsync go-ethereum_latest go-ethereum_stable
-#testsync go-ethereum_latest parity_latest
+#testsync go-ethereum_latest openethereum_latest
 #testsync go-ethereum_latest aleth_nightly
 #testsync go-ethereum_latest nethermind_latest
 #testsync go-ethereum_latest besu_latest
@@ -86,13 +86,13 @@ testgraphql besu_latest
 #testdevp2p go-ethereum_latest
 #testdevp2p nethermind_latest
 #testdevp2p besu_latest
-#testdevp2p parity_latest
+#testdevp2p openethereum_latest
 
 
 # These take an extremely long time to run
 #testconsensus aleth_nightly
 #testconsensus go-ethereum_latest
-#testconsensus parity_latest
+#testconsensus openethereum_latest
 #testconsensus nethermind_latest
 #testconsensus besu_latest
 


### PR DESCRIPTION
fixes #310 and #311

Geth now serves graphql on the same port as json-rpc http requests. This PR changes the graphql for besu to also use `8545`. 