### PR TITLE
fixes #314, use separate port for graphql 

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -29,14 +29,18 @@
 #  - HIVE_MINER_EXTRA          extra-data field to set for newly minted blocks
 #  - HIVE_SKIP_POW             If set, skip PoW verification during block import
 #  - HIVE_LOGLEVEL		         Simulator loglevel
-
+#
+#  - HIVE_GRAPHQL_ENABLED      If set, make sure graphql is accessible on port 8550
 # These flags are not supported by the Besu hive client
 #  - HIVE_TESTNET              whether testnet nonces (2^20) are needed
 #  - HIVE_FORK_DAO_VOTE        whether the node support (or opposes) the DAO fork
 
 besu=/opt/besu/bin/besu
-RPCFLAGS="--graphql-http-enabled --graphql-http-host=0.0.0.0 --graphql-http-port=8545 --host-whitelist=*"
-RPCFLAGS="$RPCFLAGS --rpc-http-enabled --rpc-http-api=ETH,NET,WEB3,ADMIN --rpc-http-host=0.0.0.0"
+
+RPCFLAGS=" --host-whitelist=* --rpc-http-enabled --rpc-http-api=ETH,NET,WEB3,ADMIN --rpc-http-host=0.0.0.0"
+if [ "$HIVE_GRAPHQL_ENABLED" != "" ]; then
+	RPCFLAGS="$RPCFLAGS --graphql-http-enabled --graphql-http-host=0.0.0.0 --graphql-http-port=8550"
+fi
 
 set -e
 

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -34,6 +34,7 @@
 #  - HIVE_MINER_EXTRA    extra-data field to set for newly minted blocks
 #  - HIVE_SKIP_POW       If set, skip PoW verification during block import
 #  - HIVE_LOGLEVEL		 Simulator loglevel
+#  - HIVE_GRAPHQL_ENABLED      If set, make sure graphql is accessible on port 8550
 
 # Immediately abort the script on any error encountered
 set -e
@@ -174,6 +175,10 @@ fi
 
 # Run the go-ethereum implementation with the requested flags
 
-FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL --nat=none --http --http.addr=0.0.0.0  --graphql --http.api=admin,debug,eth,miner,net,personal,txpool,web3 --ws --ws.addr=0.0.0.0 --ws.api=admin,debug,eth,miner,net,personal,txpool,web3 --ws.origins \"*\""
+if [ "$HIVE_GRAPHQL_ENABLED" != "" ]; then
+	FLAGS="$FLAGS --graphql --http.port=8550"
+fi
+
+FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL --nat=none --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,miner,net,personal,txpool,web3 --ws --ws.addr=0.0.0.0 --ws.api=admin,debug,eth,miner,net,personal,txpool,web3 --ws.origins \"*\""
 echo "Running go-ethereum with flags $FLAGS"
 $geth $FLAGS

--- a/simulators/ethereum/graphql/graphql.go
+++ b/simulators/ethereum/graphql/graphql.go
@@ -81,9 +81,10 @@ func run(testChan chan *testcase, host common.TestSuiteHost, suiteID common.Test
 
 	// The graphql chain comes from the Besu codebase, and is built on Frontier
 	env := map[string]string{
-		"CLIENT":             client,
-		"HIVE_FORK_DAO_VOTE": "1",
-		"HIVE_CHAIN_ID":      "1",
+		"CLIENT":               client,
+		"HIVE_FORK_DAO_VOTE":   "1",
+		"HIVE_CHAIN_ID":        "1",
+		"HIVE_GRAPHQL_ENABLED": "1",
 	}
 	files := map[string]string{
 		"genesis.json": "/init/testGenesis.json",


### PR DESCRIPTION
This might make all geth-graqhql tests fail, but should allow the consensus tests to work again