### PR TITLE
chaintools: ineffectual error assignment preventing genesis file from being opened

### DIFF
--- a/chaintools/chaintools.go
+++ b/chaintools/chaintools.go
@@ -1,7 +1,6 @@
 package chaintools
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -118,7 +117,6 @@ func ProduceTestChainFromGenesisFile(sourceGenesis string, outputPath string, bl
 	}
 
 	blockModifier := func(i int, gen *core.BlockGen) {
-		fmt.Println("generating block....", i)
 		gen.OffsetTime(int64((i+1)*int(blockTimeInSeconds) - 10))
 
 	}

--- a/chaintools/chaintools.go
+++ b/chaintools/chaintools.go
@@ -103,7 +103,6 @@ func ProduceSimpleTestChain(path string, blockCount uint) error {
 // based on an externally specified genesis file. The blockTimeInSeconds is used to manipulate
 // the block difficulty
 func ProduceTestChainFromGenesisFile(sourceGenesis string, outputPath string, blockCount uint, blockTimeInSeconds uint) error {
-
 	gspec := &core.Genesis{}
 
 	sourceGenesisBytes, err := ioutil.ReadFile(sourceGenesis)

--- a/chaintools/chaintools.go
+++ b/chaintools/chaintools.go
@@ -1,6 +1,7 @@
 package chaintools
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -105,31 +106,31 @@ func ProduceTestChainFromGenesisFile(sourceGenesis string, outputPath string, bl
 
 	gspec := &core.Genesis{}
 
-	var err error
-	if sourceGenesisBytes, err := ioutil.ReadFile(sourceGenesis); err == nil {
-
-		err = gspec.UnmarshalJSON(sourceGenesisBytes)
-		if err != nil {
-			log15.Crit("failed to deserialize genesis json", "error", err)
-			return err
-		}
-
-		blockModifier := func(i int, gen *core.BlockGen) {
-			gen.OffsetTime(int64((i+1)*int(blockTimeInSeconds) - 10))
-
-		}
-
-		err = GenerateChainAndSave(gspec, blockCount, outputPath, blockModifier)
-		if err != nil {
-			log15.Crit("generate chain error", "error", err)
-			return err
-		}
-
-		return nil
+	sourceGenesisBytes, err := ioutil.ReadFile(sourceGenesis)
+	if err != nil {
+		log15.Crit("failed to read genesis json", "error", err)
+		return err
 	}
-	log15.Crit("failed to read genesis json", "error", err)
-	return err
 
+	err = gspec.UnmarshalJSON(sourceGenesisBytes)
+	if err != nil {
+		log15.Crit("failed to deserialize genesis json", "error", err)
+		return err
+	}
+
+	blockModifier := func(i int, gen *core.BlockGen) {
+		fmt.Println("generating block....", i)
+		gen.OffsetTime(int64((i+1)*int(blockTimeInSeconds) - 10))
+
+	}
+
+	err = GenerateChainAndSave(gspec, blockCount, outputPath, blockModifier)
+	if err != nil {
+		log15.Crit("generate chain error", "error", err)
+		return err
+	}
+
+	return nil
 }
 
 // WriteChain - save blockchain to file


### PR DESCRIPTION
This PR fixes an ineffectual error assignment that prevented a genesis file from being accepted with the command `chainGenesis`. 

The following error would result: 

```
CRIT[09-08|14:35:38] failed to read genesis json              error=nil
```

Now, if a user specifies the `chainGenesis` command after the `chainGenerate` command, a more descriptive error will be logged:

```
CRIT[09-08|14:37:33] failed to read genesis json              error="open : no such file or directory"
```

This does not solve the problem, however, that the order in which a user specifies `chainGenerate` and `chainGenesis` matters for whether the given filepath+name is actually recognized.

The valid order is: 
```
-chainGenesis <filepath> -chainGenerate <bool>
```
