### PR TITLE
change default branch for geth dockerhub image from master to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ These run devp2p tests, mainly Discovery tests.
     --loglevel 6
     --docker-noshell
     --results-root /mytests/test
-    --client go-ethereum_master
+    --client go-ethereum_latest
     --sim-parallelism 1
 ```
 
@@ -82,7 +82,7 @@ These run a test verifying that a blockchain can be synced between differing imp
       --loglevel 6
       --docker-noshell
       --results-root /mytests/test
-      --client go-ethereum_master,parity_master
+      --client go-ethereum_latest,parity_master
       --sim-parallelism 1
 
 ## Generate a blockchain
@@ -148,7 +148,7 @@ When VS Code is configured for general go development, `hive` may be run simply 
                 
                 "--docker-endpoint","tcp://localhost:2375",
                 "--docker-noshell",
-                "--client","go-ethereum_master" , 
+                "--client","go-ethereum_latest" , 
                 "--loglevel","6",
                 "--smoke"
                 
@@ -179,7 +179,7 @@ An administrator level command prompt must be opened and the target IPs of the c
 UPDATE: Unless we hear a desire to keep them, Validators will be deprecated. Please see `Simulators` for updates.
 
 You can run the full suite of `hive` validation tests against all the known implementations tagged
-`master` by simply running `hive` from the repository root. It will build a docker image for every
+`latest` by simply running `hive` from the repository root. It will build a docker image for every
 known client as well as one for every known validation test.
 
 The end result should be a JSON report, detailing for each client the list of validations failed and
@@ -187,11 +187,11 @@ those passed. If you wish to explore the reasons of failure, full logs from all 
 are pushed into the `workspace/logs` folder.
 
 ```
-$ hive --client=go-ethereum_master --test=.
+$ hive --client=go-ethereum_latest --test=.
 ...
 Validation results:
 {
-  "go-ethereum:master": {
+  "go-ethereum:latest": {
     "fail": [
       "ethereum/rpc-tests"
     ],
@@ -223,7 +223,7 @@ be quite lengthy.
 
 
 `--client` is now an explicit list of permitted clients, where the desired client is of the format
-clientname_branch. For example `go-ethereum_master` and `parity_beta`. Previously this was a regex. 
+clientname_branch. For example `go-ethereum_latest` and `parity_beta`. Previously this was a regex. 
 Other parameters such as the sim or validator still use regexp. This change was introduced to allow
 for branches to be specified as parameters without the need for creating a dedicated client subfolder 
 for that branch. `go-ethereum` and `parity` in this example need to be subfolders of the Hive `clients`
@@ -257,11 +257,11 @@ client the list of simulations failed and those passed. Likewise, if you wish to
 of failure, full logs from all clients and testers are pushed into the `log.txt` log file.
 
 ```
-$ hive --client=go-ethereum_master --test=NONE --sim=.
+$ hive --client=go-ethereum_latest --test=NONE --sim=.
 ...
 Simulation results:
 {
-  "go-ethereum:master": {
+  "go-ethereum:latest": {
     "pass": [
       "dao-hard-fork",
       "smoke/single-node"
@@ -310,7 +310,7 @@ to its own local genesis format and command line flags. To assist in this, Hive 
 in the `clients/trinity_master` folder using `mapper.jq`, which is invoked in `trinity.sh` This 
 technique can be replicated for other clients.
 
-For guidance, check out the reference [`go-ethereum:master`](https://github.com/karalabe/hive/tree/master/clients/go-ethereum:master/Dockerfile) client.
+For guidance, check out the reference [`go-ethereum:latest`](https://github.com/karalabe/hive/tree/master/clients/go-ethereum:master/Dockerfile) client.
 
 ### Initializing the client
 
@@ -377,11 +377,11 @@ validations and simulations that just initialize clients with some pre-configure
 it from the various RPC endpoints.
 
 ```
-$ hive --client=go-ethereum_master --smoke
+$ hive --client=go-ethereum_latest --smoke
 ...
 Validation results:
 {
-  "go-ethereum:master": {
+  "go-ethereum:latest": {
     "pass": [
       "smoke/genesis-chain",
       "smoke/genesis-chain-blocks",
@@ -392,7 +392,7 @@ Validation results:
 ...
 Simulation results:
 {
-  "go-ethereum:master": {
+  "go-ethereum:latest": {
     "smoke/lifecycle": {
       "start": "2017-01-31T09:20:16.975219924Z",
       "end": "2017-01-31T09:20:18.705302536Z",

--- a/hive.go
+++ b/hive.go
@@ -31,7 +31,7 @@ var (
 	noShellContainer = flag.Bool("docker-noshell", false, "Disable outer docker shell, running directly on the host")
 	noCachePattern   = flag.String("docker-nocache", "", "Regexp selecting the docker images to forcibly rebuild")
 
-	clientListFlag     = flag.String("client", "go-ethereum_master", "Comma separated list of permitted clients for the test type, where client is formatted clientname_branch eg: go-ethereum_master and the client name is a subfolder of the clients directory")
+	clientListFlag     = flag.String("client", "go-ethereum_latest", "Comma separated list of permitted clients for the test type, where client is formatted clientname_branch eg: go-ethereum_latest and the client name is a subfolder of the clients directory")
 	checkTimeLimitFlag = flag.Duration("client.checktimelimit", 3*time.Minute, "The timeout to wait for a newly "+
 		"instantiated client to open up the RPC port. If a very long chain is imported, this timeout may need to be quite large. "+
 		"A lower value means that hive won't wait as long for in case node crashes and never opens the RPC port.")
@@ -162,7 +162,7 @@ func mainInHost(overrides []string, cacher *buildCacher) error {
 func initClients(cacher *buildCacher) error {
 	var err error
 	// Build all the clients that we need and make a map of
-	// names (eg: geth_master, in the format client_branch )
+	// names (eg: geth_latest, in the format client_branch )
 	// against image names in the docker image name format
 	allClients, err = buildClients(clientList, cacher)
 	if err != nil {

--- a/simulators/common/providers/local/local_test.go
+++ b/simulators/common/providers/local/local_test.go
@@ -90,7 +90,7 @@ func TestGetInstance(t *testing.T) {
 	{
 		"availableClients": [
 			{
-				"clientType":"go-ethereum_master",
+				"clientType":"go-ethereum_latest",
 				"enode":"enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301",
 				"ip":"10.3.58.6",
 				"isPseudo":false,
@@ -145,7 +145,7 @@ func TestGetInstance(t *testing.T) {
 		hostProxy.configuration.AvailableClients[0].Parameters["HIVE_FORK_DAO_BLOCK"] != "0" ||
 		hostProxy.configuration.AvailableClients[0].Parameters["HIVE_FORK_CONSTANTINOPLE_BLOCK"] != "0" ||
 		*hostProxy.configuration.AvailableClients[0].Mac != "00:0a:95:9d:68:16" ||
-		hostProxy.configuration.AvailableClients[0].ClientType != "go-ethereum_master" {
+		hostProxy.configuration.AvailableClients[0].ClientType != "go-ethereum_latest" {
 		t.Fatalf("Wrong configuration")
 	}
 }
@@ -227,7 +227,7 @@ func TestGetNode(t *testing.T) {
 
 	// test that it gets a node and that parameter selection is used
 	parms := map[string]string{
-		"CLIENT":                         "go-ethereum_master",
+		"CLIENT":                         "go-ethereum_latest",
 		"HIVE_FORK_CONSTANTINOPLE_BLOCK": "10",
 	}
 	_, _, mac, err := host.GetNode(suite.ID, testCaseID, parms, nil)
@@ -242,7 +242,7 @@ func TestGetNode(t *testing.T) {
 
 	// test that the node selected is the least used
 	parms = map[string]string{
-		"CLIENT": "go-ethereum_master",
+		"CLIENT": "go-ethereum_latest",
 	}
 	_, _, mac, err = host.GetNode(suite.ID, testCaseID, parms, nil)
 	if *mac != "00:0a:95:9d:68:16" {
@@ -260,7 +260,7 @@ func TestGetClientEnode(t *testing.T) {
 		t.Fatalf("Test setup failed: testCase could not be created.")
 	}
 	parms := map[string]string{
-		"CLIENT":                         "go-ethereum_master",
+		"CLIENT":                         "go-ethereum_latest",
 		"HIVE_FORK_CONSTANTINOPLE_BLOCK": "10",
 	}
 	nodeID, _, _, err := host.GetNode(suite.ID, testCaseID, parms, nil)
@@ -308,7 +308,7 @@ func TestGetClientTypes(t *testing.T) {
 	}
 
 	expectedTypes := []string{
-		"go-ethereum_master",
+		"go-ethereum_latest",
 		"nethermind_master",
 		"parity_master",
 	}


### PR DESCRIPTION
This PR fixes a build error that occurs from the default value of the `--client` flag pointing to a branch that does not exist. 