### PR TITLE
change default branch for parity dockerhub image from master to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ These run a test verifying that a blockchain can be synced between differing imp
       --loglevel 6
       --docker-noshell
       --results-root /mytests/test
-      --client go-ethereum_master,parity_latest
+      --client go-ethereum_latest,parity_latest
       --sim-parallelism 1
 
 ## Generate a blockchain

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To execute the consensus tests on parity run the latest simulator:
 
 ```text
    --docker-noshell
-   --client parity_master
+   --client parity_latest
    --sim ethereum/consensus2
    --sim.rootcontext
    --results-root /mytests/test
@@ -82,7 +82,7 @@ These run a test verifying that a blockchain can be synced between differing imp
       --loglevel 6
       --docker-noshell
       --results-root /mytests/test
-      --client go-ethereum_latest,parity_master
+      --client go-ethereum_master,parity_latest
       --sim-parallelism 1
 
 ## Generate a blockchain

--- a/simulators/common/providers/local/local_test.go
+++ b/simulators/common/providers/local/local_test.go
@@ -51,7 +51,7 @@ func setupBasicInstance(t *testing.T) common.TestSuiteHost {
 		,
 		
 			{
-				"clientType":"parity_master",
+				"clientType":"parity_latest",
 				"enode":"enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301",
 				"ip":"10.3.58.8",
 				"isPseudo":false,
@@ -119,7 +119,7 @@ func TestGetInstance(t *testing.T) {
 	{
 		"availableClients": [
 			{
-				"clientType":"parity_master",
+				"clientType":"parity_latest",
 				"enode":"enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301",
 				"ip":"10.3.58.6",
 				"isPseudo":false,
@@ -310,7 +310,7 @@ func TestGetClientTypes(t *testing.T) {
 	expectedTypes := []string{
 		"go-ethereum_latest",
 		"nethermind_master",
-		"parity_master",
+		"parity_latest",
 	}
 
 	if len(expectedTypes) != len(actualTypes) {


### PR DESCRIPTION
This PR fixes some inaccurate documentation for the default branch of the docker image for the parity client. It should be `latest`, not `master`.