### PR TITLE
additional fixes for docs and aleth Dockerfile with wrong tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,10 @@ by the Hive host remotely to get the id.
 
 The client has the responsibility of mapping the Hive genesis.json and Hive environment variables
 to its own local genesis format and command line flags. To assist in this, Hive illustrates a technique
-in the `clients/trinity_master` folder using `mapper.jq`, which is invoked in `trinity.sh` This 
+in the `clients/trinity_latest` folder using `mapper.jq`, which is invoked in `trinity.sh` This 
 technique can be replicated for other clients.
 
-For guidance, check out the reference [`go-ethereum:latest`](https://github.com/karalabe/hive/tree/master/clients/go-ethereum:master/Dockerfile) client.
+For guidance, check out the reference [`go-ethereum:latest`](https://github.com/ethereum/hive/blob/master/clients/go-ethereum/Dockerfile) client.
 
 ### Initializing the client
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ by the Hive host remotely to get the id.
 
 The client has the responsibility of mapping the Hive genesis.json and Hive environment variables
 to its own local genesis format and command line flags. To assist in this, Hive illustrates a technique
-in the `clients/trinity_latest` folder using `mapper.jq`, which is invoked in `trinity.sh` This 
+in the `clients/trinity` folder using `mapper.jq`, which is invoked in `trinity.sh` This 
 technique can be replicated for other clients.
 
 For guidance, check out the reference [`go-ethereum:latest`](https://github.com/ethereum/hive/blob/master/clients/go-ethereum/Dockerfile) client.

--- a/clients/aleth/Dockerfile
+++ b/clients/aleth/Dockerfile
@@ -6,7 +6,7 @@
 #
 # docker build --target builder -t aleth_base
 #
-ARG branch=master
+ARG branch=latest
 FROM ethereum/aleth:$branch
 
 # Genesis template


### PR DESCRIPTION
This PR fixes a broken link, the aleth Dockerfile (tag was incorrectly defined as master instead of latest), and some incorrect documentation for trinity in the README.md