### PR TITLE
clients/trinity: fix trinity docker build and startup script

### DIFF
--- a/clients/trinity/Dockerfile
+++ b/clients/trinity/Dockerfile
@@ -1,22 +1,19 @@
-FROM python:3.6
-# Set up code directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-ARG branch=master
-RUN \
-  apt-get -y update                                        && \
-  apt-get install -y bash  bc curl git make cmake netcat file      
+FROM python:3.7
+ENV branch=master
 
-RUN git clone --recursive --branch ${branch} https://github.com/ethereum/py-evm.git .
-RUN pip install -e .[dev]  --no-cache-dir
-RUN pip install -U trinity --no-cache-dir
-
+# Install dependencies.
+RUN apt-get -y update && apt-get install -y bash curl git make cmake file libsnappy-dev libgmp3-dev
 
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
     echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
     chmod +x /usr/local/bin/jq
 
-
+# Set up code directory.
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+RUN git clone --branch $branch https://github.com/ethereum/trinity .
+RUN pip install -e .[dev]  --no-cache-dir
+RUN pip install -U trinity --no-cache-dir
 
 ADD config.json /config.json
 ADD mapper.jq /mapper.jq
@@ -24,18 +21,17 @@ ADD trinity.sh /trinity.sh
 RUN chmod +x /trinity.sh
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh
+
 #debug genesis, overriden at runtime:
 ADD genesis.json /genesis.json
 
-
-EXPOSE  8545 8546 30303 30303/udp
-
+# Write the version file.
 RUN \
   echo "{}"                                                      \
   | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
   | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
   | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
-  > /version.json              
+  > /version.json
 
-
+EXPOSE  8545 8546 30303 30303/udp
 CMD ["/trinity.sh"]

--- a/clients/trinity/enode.sh
+++ b/clients/trinity/enode.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to retrieve the enode
-# 
+#
 # This is copied into the validator container by Hive
 # and used to provide a client-specific enode id retriever
 #
@@ -9,9 +9,5 @@
 # Immediately abort the script on any error encountered
 set -e
 
-
-#TEMP - Can't see how to set nodekey or work with the IPC endpoint at the moment.
-
-TARGET_ENODE="enode://6433e8fb82c4638a8a6d499d40eb7d8158883219600bfd49acb968e3a37ccced04c964fa87b3a78a2da1b71dc1b90275f4d055720bb67fad4a118a56925125dc@1.2.3.4:30303"
-
-echo "$TARGET_ENODE"
+TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}' "localhost:8545" )
+echo ${TARGET_RESPONSE}| jq -r '.result.enode'

--- a/clients/trinity/mapper.jq
+++ b/clients/trinity/mapper.jq
@@ -13,52 +13,44 @@ def remove_empty:
     end
   );
 
-def addashex:
-  if . != null  and startswith("0x") then . else 
-    if . !=null then "0x"+. else . end
+def to_hex:
+  if . != null and startswith("0x") then . else
+    if . != null then "0x"+. else . end
   end
 ;
 
-def infixzerostolength(s;l):
+def infix_zeros_to_length(s;l):
    if . != null then
      (.[0:s])+("0"*(l-(.|length)))+(.[s:l])
    else .
    end
 ;
 
-
 .|
 .alloc|=with_entries(.key|="0x"+.) |
-{"accounts": .alloc,
+{
+  "accounts": .alloc,
   "genesis": {
     "author":.coinbase,
     "difficulty":.difficulty,
-    "extraData":.extraData|infixzerostolength(2;66),
+    "extraData":.extraData|infix_zeros_to_length(2;66),
     "gasLimit":.gasLimit,
-    "nonce": .nonce,
+    "nonce": .nonce|infix_zeros_to_length(2;18),
     "timestamp":.timestamp,
-    
   },
- 	"params": {
-     
-    "DAOForkBlock": env.HIVE_FORK_DAO_BLOCK|addashex,
-		"EIP150ForkBlock": env.HIVE_FORK_TANGERINE|addashex,
-		"EIP158ForkBlock": env.HIVE_FORK_SPURIOUS|addashex,
-		"byzantiumForkBlock": env.HIVE_FORK_BYZANTIUM|addashex,
-		"homesteadForkBlock": env.HIVE_FORK_HOMESTEAD|addashex,
-		"miningMethod": (if env.HIVE_SKIP_POW!=null then "ethash" else "NoProof" end)
-   },
-  
-	"version": "1"
+  "params": {
+    "miningMethod": (if env.HIVE_SKIP_POW!=null then "ethash" else "NoProof" end),
+    "chainId": env.HIVE_CHAIN_ID|to_hex,
+    "homesteadForkBlock": env.HIVE_FORK_HOMESTEAD|to_hex,
+    "DAOForkBlock": env.HIVE_FORK_DAO_BLOCK|to_hex,
+    "EIP150ForkBlock": env.HIVE_FORK_TANGERINE|to_hex,
+    "EIP158ForkBlock": env.HIVE_FORK_SPURIOUS|to_hex,
+    "byzantiumForkBlock": env.HIVE_FORK_BYZANTIUM|to_hex,
+    "constantinopleForkBlock": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
+    "petersburgForkBlock": env.HIVE_FORK_PETERSBURG|to_hex,
+    "istanbulForkBlock": env.HIVE_FORK_ISTANBUL|to_hex,
+    "muirglacierForkBlock": env.HIVE_FORK_MUIR_GLACIER|to_hex,
+  },
+  "version": "1"
 }|remove_empty
 
-
-
-
-
-
-
-
-
-
-  


### PR DESCRIPTION
With these changes, the client builds and actually starts. It now
supports most of the options that other clients support as well. The
initial chain import is still broken unfortunately, so it can't run the
consensus tests yet.