### PR TITLE
hive: add error handling for if dockerfile/image can't build or is not found

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -115,8 +115,8 @@ func main() {
 	}
 	//set up clients and get their versions
 	if err := initClients(cacher); err != nil {
-		log15.Crit("failed to initialize client(s), exiting...")
-		os.Exit(1)
+		log15.Crit("failed to initialize client(s), terminating test...")
+		os.Exit(-1)
 	}
 	// Depending on the flags, either run hive in place or in an outer container shell
 	var fail error

--- a/hive.go
+++ b/hive.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -116,8 +115,7 @@ func main() {
 	}
 	//set up clients and get their versions
 	if err := initClients(cacher); err != nil {
-		log15.Crit(fmt.Sprintf("failed to initialize clients: %v", err))
-		os.Exit(1)
+		panic("WAT HAPPENE") // TODO REMOVE
 	}
 	// Depending on the flags, either run hive in place or in an outer container shell
 	var fail error

--- a/hive.go
+++ b/hive.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -114,7 +115,10 @@ func main() {
 		return
 	}
 	//set up clients and get their versions
-	initClients(cacher)
+	if err := initClients(cacher); err != nil {
+		log15.Crit(fmt.Sprintf("failed to initialize clients: %v", err))
+		os.Exit(1)
+	}
 	// Depending on the flags, either run hive in place or in an outer container shell
 	var fail error
 	if *noShellContainer {
@@ -162,6 +166,7 @@ func initClients(cacher *buildCacher) error {
 	allClients, err = buildClients(clientList, cacher)
 	if err != nil {
 		log15.Crit("failed to build client images", "error", err)
+
 		return err
 	}
 	// Build all pseudo clients. pseudo-clients need to be available

--- a/hive.go
+++ b/hive.go
@@ -115,7 +115,8 @@ func main() {
 	}
 	//set up clients and get their versions
 	if err := initClients(cacher); err != nil {
-		panic("WAT HAPPENE") // TODO REMOVE
+		log15.Crit("failed to initialize client(s), exiting...")
+		os.Exit(1)
 	}
 	// Depending on the flags, either run hive in place or in an outer container shell
 	var fail error

--- a/hive.go
+++ b/hive.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -113,17 +114,23 @@ func main() {
 		log15.Crit("failed to parse nocache regexp", "error", err)
 		return
 	}
+	// create hive error reporter
+	errorReport := NewHiveErrorReport()
 	//set up clients and get their versions
-	if err := initClients(cacher); err != nil {
+	if err := initClients(cacher, errorReport); err != nil {
 		log15.Crit("failed to initialize client(s), terminating test...")
+		errorReport.WriteReport(fmt.Sprintf("%s/errorReport.json", *testResultsRoot))
 		os.Exit(-1)
 	}
 	// Depending on the flags, either run hive in place or in an outer container shell
 	var fail error
 	if *noShellContainer {
-		fail = mainInHost(overrides, cacher)
+		fail = mainInHost(overrides, cacher, errorReport)
 	} else {
-		fail = mainInShell(overrides, cacher)
+		fail = mainInShell(overrides, cacher, errorReport)
+	}
+	if err := errorReport.WriteReport(fmt.Sprintf("%s/containerErrorReport.json", *testResultsRoot)); err != nil {
+		log15.Crit("could not write error report", "error", err)
 	}
 	if fail != nil {
 		os.Exit(-1)
@@ -133,7 +140,7 @@ func main() {
 // mainInHost runs the actual hive testsuites on the
 // host machine itself. This is usually the path executed within an outer shell
 // container, but can be also requested directly.
-func mainInHost(overrides []string, cacher *buildCacher) error {
+func mainInHost(overrides []string, cacher *buildCacher, errorReport *HiveErrorReport) error {
 	var err error
 
 	// create or use the specified rootpath
@@ -145,7 +152,7 @@ func mainInHost(overrides []string, cacher *buildCacher) error {
 	// Run all testsuites
 	if *simulatorPattern != "" {
 		//execute testsuites
-		if err = runSimulations(*simulatorPattern, overrides, cacher); err != nil {
+		if err = runSimulations(*simulatorPattern, overrides, cacher, errorReport); err != nil {
 			log15.Crit("failed to run simulations", "error", err)
 			return err
 		}
@@ -157,21 +164,20 @@ func mainInHost(overrides []string, cacher *buildCacher) error {
 
 // initClients builds any docker images needed and maps
 // client name_branchs
-func initClients(cacher *buildCacher) error {
+func initClients(cacher *buildCacher, errorReport *HiveErrorReport) error {
 	var err error
 	// Build all the clients that we need and make a map of
 	// names (eg: geth_latest, in the format client_branch )
 	// against image names in the docker image name format
-	allClients, err = buildClients(clientList, cacher)
+	allClients, err = buildClients(clientList, cacher, errorReport)
 	if err != nil {
 		log15.Crit("failed to build client images", "error", err)
-
 		return err
 	}
 	// Build all pseudo clients. pseudo-clients need to be available
 	// to simulators. pseudo-clients play the role of special types
 	// of actor in a network, such as network relay for example
-	allPseudos, err = buildPseudoClients("pseudo", cacher)
+	allPseudos, err = buildPseudoClients("pseudo", cacher, errorReport)
 	if err != nil {
 		log15.Crit("failed to build client images", "error", err)
 		return err

--- a/hiveErrorReporting.go
+++ b/hiveErrorReporting.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"sync"
+)
+
+type HiveErrorReport struct {
+	mu     sync.Mutex
+	Errors []ContainerError `json:"errors"`
+}
+
+type ContainerError struct {
+	Name    string `json:"name"`
+	Details string `json:"details"`
+}
+
+func NewHiveErrorReport() *HiveErrorReport {
+	return &HiveErrorReport{}
+}
+
+func (h *HiveErrorReport) AddErrorReport(containerError ContainerError) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.Errors = append(h.Errors, containerError)
+}
+
+func (h *HiveErrorReport) WriteReport(outputPath string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	data, err := json.Marshal(h.Errors)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(outputPath, data, 0644)
+}

--- a/images.go
+++ b/images.go
@@ -225,7 +225,6 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 func notFound(names []string, all []string) []string {
 	found := make(map[string]string, len(names))
 	for _, name := range names {
-		log15.Crit(fmt.Sprintf("name: %s", name)) // TODO REMOVE
 		found[name] = name
 	}
 

--- a/images.go
+++ b/images.go
@@ -248,10 +248,7 @@ func getBranch(name string) string {
 }
 
 func matchNames(name string, clientList []string, names *[]string) {
-	log15.Crit("looping inside matchNames")                             // TODO REMOVE
-	log15.Crit(fmt.Sprintf("len of clientList... %d", len(clientList))) // TODO REMOVE
 	for _, client := range clientList {
-		log15.Crit(fmt.Sprintf("client name: %s", client))
 
 		branch := getBranch(client)
 		if len(branch) > 0 {

--- a/images.go
+++ b/images.go
@@ -136,6 +136,11 @@ func buildNestedImages(root string, pattern string, kind string, cacher *buildCa
 	}); err != nil {
 		return nil, err
 	}
+
+	if len(names) < 1 {
+		return nil, fmt.Errorf("could not find simulation %s", pattern)
+	}
+
 	// Iterate over all the matched specs and build their docker images
 	images := make(map[string]string)
 	for _, name := range names {

--- a/images.go
+++ b/images.go
@@ -58,13 +58,13 @@ func buildShell(cacher *buildCacher) (string, error) {
 
 // buildClients iterates over all the known clients and builds a docker image for
 // all unknown ones matching the given pattern.
-func buildClients(clientList []string, cacher *buildCacher) (map[string]string, error) {
-	return buildListedImages("clients", clientList, "client", cacher, false)
+func buildClients(clientList []string, cacher *buildCacher, errorReport *HiveErrorReport) (map[string]string, error) {
+	return buildListedImages("clients", clientList, "client", cacher, false, errorReport)
 }
 
 // buildPseudoClients iterates over all the known pseudo-clients and builds a docker image for
-func buildPseudoClients(pattern string, cacher *buildCacher) (map[string]string, error) {
-	return buildNestedImages("pseudoclients", pattern, "pseudoclient", cacher, false)
+func buildPseudoClients(pattern string, cacher *buildCacher, errorReport *HiveErrorReport) (map[string]string, error) {
+	return buildNestedImages("pseudoclients", pattern, "pseudoclient", cacher, false, errorReport)
 }
 
 // fetchClientVersions downloads the version json specs from all clients that
@@ -92,14 +92,14 @@ func fetchClientVersions(cacher *buildCacher) (map[string]map[string]string, err
 
 // buildSimulators iterates over all the known simulators and builds a docker image
 // for all unknown ones matching the given pattern.
-func buildSimulators(pattern string, cacher *buildCacher) (map[string]string, error) {
-	images, err := buildNestedImages("simulators", pattern, "simulator", cacher, *simRootContext)
+func buildSimulators(pattern string, cacher *buildCacher, errorReport *HiveErrorReport) (map[string]string, error) {
+	images, err := buildNestedImages("simulators", pattern, "simulator", cacher, *simRootContext, errorReport)
 	return images, err
 }
 
 // buildNestedImages iterates over a directory containing arbitrarilly nested
 // docker image definitions and builds all of them matching the provided pattern.
-func buildNestedImages(root string, pattern string, kind string, cacher *buildCacher, rootContext bool) (map[string]string, error) {
+func buildNestedImages(root string, pattern string, kind string, cacher *buildCacher, rootContext bool, errorReport *HiveErrorReport) (map[string]string, error) {
 
 	var contextBuilder func(root string, path string) (string, string)
 
@@ -138,6 +138,10 @@ func buildNestedImages(root string, pattern string, kind string, cacher *buildCa
 	}
 
 	if len(names) < 1 {
+		errorReport.AddErrorReport(ContainerError{
+			Name:    pattern,
+			Details: "could not find simulation",
+		})
 		return nil, fmt.Errorf("could not find simulation %s", pattern)
 	}
 
@@ -164,7 +168,7 @@ func buildNestedImages(root string, pattern string, kind string, cacher *buildCa
 // For example, if the clientList contained geth_master, geth_beta and
 // the clients folder contained a dockerfile for clients\geth, then this
 // will created two images, one for clients\geth_master and one for clients\geth_beta
-func buildListedImages(root string, clientList []string, kind string, cacher *buildCacher, rootContext bool) (map[string]string, error) {
+func buildListedImages(root string, clientList []string, kind string, cacher *buildCacher, rootContext bool, errorReport *HiveErrorReport) (map[string]string, error) {
 
 	var contextBuilder func(root string, path string) (string, string, string)
 
@@ -209,6 +213,10 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 	if len(notFound) > 0 && len(names) != len(clientList) {
 		for _, notFoundDockerfile := range notFound {
 			log15.Crit("Could not find client image", "image", notFoundDockerfile)
+			errorReport.AddErrorReport(ContainerError{
+				Name:    notFoundDockerfile,
+				Details: "could not find client image",
+			})
 		}
 		return nil, fmt.Errorf("invalid client image(s) specified") // TODO fix err message
 	}
@@ -226,7 +234,13 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 			logger                      = log15.New(kind, name)
 		)
 		if err := buildImage(image, branch, context, cacher, logger, dockerfile); err != nil {
-			berr := &buildError{err: fmt.Errorf("%s: %v", context, err), client: name}
+			errorDetails := fmt.Errorf("%s: %v", context, err)
+			berr := &buildError{err: errorDetails, client: name}
+			// report error
+			errorReport.AddErrorReport(ContainerError{
+				Name:    image,
+				Details: errorDetails.Error(),
+			})
 			// if there is only one client to test and it fails, error out,
 			// otherwise proceed building other clients and log error
 			if len(names) < 2 {

--- a/images.go
+++ b/images.go
@@ -199,6 +199,9 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 	}
 
 	notFound := notFound(names, clientList)
+	if len(notFound) > 0 {
+		log15.Crit("WE GOT SOME UNFOUND IMAGES") // TODO REMOVE
+	}
 
 	// Iterate over all the matched specs and build their docker images
 	images := make(map[string]string)

--- a/images.go
+++ b/images.go
@@ -204,6 +204,8 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 	}
 	// list all given client names that were not found in the `clients` directory
 	notFound := notFound(names, clientList)
+	// only throw error if the given client pattern was not found (e.g. "bes" is technically incorrect,
+	// but the pattern matches "besu", so the client is still found)
 	if len(notFound) > 0 && len(names) != len(clientList) {
 		for _, notFoundDockerfile := range notFound {
 			log15.Crit("Could not find client image", "image", notFoundDockerfile)

--- a/images.go
+++ b/images.go
@@ -233,8 +233,9 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 				return nil, berr
 			}
 			log15.Crit("image failed to build", "error", berr)
+		} else {
+			images[name] = image
 		}
-		images[name] = image
 	}
 	return images, nil
 }

--- a/images.go
+++ b/images.go
@@ -246,7 +246,8 @@ func getBranch(name string) string {
 }
 
 func matchNames(name string, clientList []string, names *[]string) {
-	log15.Crit("looping inside matchNames") // TODO REMOVE
+	log15.Crit("looping inside matchNames")                             // TODO REMOVE
+	log15.Crit(fmt.Sprintf("len of clientList... %d", len(clientList))) // TODO REMOVE
 	for _, client := range clientList {
 		log15.Crit(fmt.Sprintf("client name: %s", client))
 

--- a/images.go
+++ b/images.go
@@ -204,7 +204,7 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 	}
 	// list all given client names that were not found in the `clients` directory
 	notFound := notFound(names, clientList)
-	if len(notFound) > 0 {
+	if len(notFound) > 0 && len(names) != len(clientList) {
 		for _, notFoundDockerfile := range notFound {
 			log15.Crit("Could not find client image", "image", notFoundDockerfile)
 		}

--- a/images.go
+++ b/images.go
@@ -200,7 +200,9 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 
 	notFound := notFound(names, clientList)
 	if len(notFound) > 0 {
-		log15.Crit("WE GOT SOME UNFOUND IMAGES") // TODO REMOVE
+		for _, notFoundDockerfile := range notFound {
+			log15.Crit("Could not find client image", "image", notFoundDockerfile)
+		}
 	}
 
 	// Iterate over all the matched specs and build their docker images

--- a/images.go
+++ b/images.go
@@ -197,12 +197,16 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 	}); err != nil {
 		return nil, err
 	}
-
+	// list all given client names that were not found in the `clients` directory
 	notFound := notFound(names, clientList)
 	if len(notFound) > 0 {
 		for _, notFoundDockerfile := range notFound {
 			log15.Crit("Could not find client image", "image", notFoundDockerfile)
 		}
+	}
+	// if no clients were found, error out
+	if len(names) < 1 {
+		return nil, fmt.Errorf("no client images to build") // TODO fix err message
 	}
 
 	// Iterate over all the matched specs and build their docker images

--- a/images.go
+++ b/images.go
@@ -197,6 +197,9 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 	}); err != nil {
 		return nil, err
 	}
+
+	notFound := notFound(names, clientList)
+
 	// Iterate over all the matched specs and build their docker images
 	images := make(map[string]string)
 	for _, name := range names {
@@ -214,6 +217,23 @@ func buildListedImages(root string, clientList []string, kind string, cacher *bu
 	return images, nil
 }
 
+func notFound(names []string, all []string) []string {
+	found := make(map[string]string, len(names))
+	for _, name := range names {
+		log15.Crit(fmt.Sprintf("name: %s", name)) // TODO REMOVE
+		found[name] = name
+	}
+
+	var notFound []string
+	for _, client := range all {
+		if _, exists := found[client]; !exists {
+			notFound = append(notFound, client)
+		}
+	}
+
+	return notFound
+}
+
 func getBranch(name string) string {
 	branch := ""
 	if branchIndex := strings.LastIndex(name, branchDelimiter); branchIndex > 0 && branchIndex < len(name) {
@@ -223,8 +243,9 @@ func getBranch(name string) string {
 }
 
 func matchNames(name string, clientList []string, names *[]string) {
-
+	log15.Crit("looping inside matchNames") // TODO REMOVE
 	for _, client := range clientList {
+		log15.Crit(fmt.Sprintf("client name: %s", client))
 
 		branch := getBranch(client)
 		if len(branch) > 0 {

--- a/simulator.go
+++ b/simulator.go
@@ -27,14 +27,14 @@ var (
 )
 
 // runSimulations runs each 'simulation' container, which are hosts for executing one or more test-suites
-func runSimulations(simulatorPattern string, overrides []string, cacher *buildCacher) error {
+func runSimulations(simulatorPattern string, overrides []string, cacher *buildCacher, errorReport *HiveErrorReport) error {
 
 	// Clean up
 	defer terminateAndUpdate()
 
 	// Build all the simulators known to the test harness
 	log15.Info("building simulators for testing", "pattern", simulatorPattern)
-	simulators, err := buildSimulators(simulatorPattern, cacher)
+	simulators, err := buildSimulators(simulatorPattern, cacher, errorReport)
 	if err != nil {
 		return err
 	}

--- a/simulator.go
+++ b/simulator.go
@@ -176,7 +176,7 @@ func startTestSuiteAPI() error {
 	mux.Delete("/testsuite/{suite}/test/{test}/node/{node}", nodeKill)
 	mux.Post("/testsuite/{suite}/test/{test}", testDelete) //post because the delete http verb does not always support a message body
 	mux.Post("/testsuite/{suite}/test", testStart)
-	mux.Delete("/testsuite/{suite}", suiteEnd) // TODO call this if any container fails
+	mux.Delete("/testsuite/{suite}", suiteEnd)
 	mux.Post("/testsuite", suiteStart)
 	mux.Get("/clients", clientTypesGet)
 	// Start the API webserver for simulators to coordinate with

--- a/simulator.go
+++ b/simulator.go
@@ -176,7 +176,7 @@ func startTestSuiteAPI() error {
 	mux.Delete("/testsuite/{suite}/test/{test}/node/{node}", nodeKill)
 	mux.Post("/testsuite/{suite}/test/{test}", testDelete) //post because the delete http verb does not always support a message body
 	mux.Post("/testsuite/{suite}/test", testStart)
-	mux.Delete("/testsuite/{suite}", suiteEnd)
+	mux.Delete("/testsuite/{suite}", suiteEnd) // TODO call this if any container fails
 	mux.Post("/testsuite", suiteStart)
 	mux.Get("/clients", clientTypesGet)
 	// Start the API webserver for simulators to coordinate with


### PR DESCRIPTION
This PR adds error handling in the cases that: 

**client:**
- can't find user-specified docker image in `clients` dir (in which case, continue test with the clients that have been successfully built, but log critical error)
- no clients get spun up at all (in which case, kill the test)

**simulation:** 
- simulation is not found (in which case, kill the test)
- simulation image build failed (in which case, kill the test)

The errors will be logged both to stderr and to a file `containerErrorReport.json`