### PR TITLE
clients/nethermind: fix some more issues

### DIFF
--- a/clients/nethermind/Dockerfile
+++ b/clients/nethermind/Dockerfile
@@ -1,4 +1,4 @@
-ARG branch=latest
+ARG branch=alpine
 FROM nethermindeth/nethermind-hive:$branch
 
 RUN apt-get update && apt-get install -y wget
@@ -6,6 +6,7 @@ RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /
     echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
     chmod +x /usr/local/bin/jq
 
+ADD genesis.json /genesis.json
 ADD mapper.jq /mapper.jq
 ADD test.cfg /configs/test.cfg
 ADD enode.sh /enode.sh
@@ -13,6 +14,9 @@ ADD nethermind.sh /nethermind.sh
 
 RUN chmod +x /nethermind.sh
 RUN chmod +x /enode.sh
+
+# Write the version file.
+RUN echo "{\"repo\":\"https://github.com/nethermindeth/nethermind\",\"branch\":\"\",\"commit\":\"$(cat /nethermind/git-hash)\"}" > /version.json
 
 ENV NETHERMIND_HIVE_ENABLED true
 

--- a/clients/nethermind/genesis.json
+++ b/clients/nethermind/genesis.json
@@ -1,0 +1,15 @@
+{
+    "coinbase"   : "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "difficulty" : "0x020000",
+    "extraData"  : "0x42",
+    "gasLimit"   : "0x2fefd8",
+    "mixHash"    : "0x2c85bcbce56429100b2108254bb56906257582aeafcbd682bc9af67a9f5aee46",
+    "nonce"      : "0x78cc16f7b4f65485",
+    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "timestamp"  : "0x54c98c81",
+    "alloc"      : {
+        "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+            "balance" : "0x09184e72a000"
+        }
+    }
+}

--- a/clients/nethermind/nethermind.sh
+++ b/clients/nethermind/nethermind.sh
@@ -33,6 +33,7 @@ set -e
 # Configure the chain.
 mkdir -p /chainspec
 jq -f /mapper.jq /genesis.json > /chainspec/test.json
+jq . /chainspec/test.json
 
 # Set bootnode.
 if [ -n "$HIVE_BOOTNODE" ]; then


### PR DESCRIPTION
This changes the default branch to 'alpine' because the Nethermind team
is not pushing to the 'latest' tag anymore. The tag actually points to
an Ubuntu-based image though.

It also adds back the version.json and genesis.json files because they
are required for all tests.