### PR TITLE
clients: fix more client issues

### DIFF
--- a/clients/aleth/Dockerfile
+++ b/clients/aleth/Dockerfile
@@ -1,12 +1,4 @@
-# Multistage Dockerfile for the Aleth Ethereum node.
-# Build stage
-
-# This can be run separately, as a standalone image, 
-# to obtain a cache and save rebuilding all the time (during development)
-#
-# docker build --target builder -t aleth_base
-#
-ARG branch=latest
+ARG branch=nightly
 FROM ethereum/aleth:$branch
 
 # Genesis template
@@ -20,17 +12,14 @@ ADD aleth.sh /aleth.sh
 USER root
 RUN chmod +x /aleth.sh
 
-# Inject the enode id retriever script
+# Inject the enode retriever script
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh
 
 RUN apk add --no-cache jq bc bash curl
 
-
 # Copy buildinfo into version.json, and also remove the 'bool' field is_prerelease
-
-# remove softlink
-RUN cat /usr/share/aleth/buildinfo.json |jq "del(.is_prerelease)"  > /version.json
+RUN jq "del(.is_prerelease)" /usr/share/aleth/buildinfo.json > /version.json
 
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 8547 30303 30303/udp

--- a/clients/besu/Dockerfile
+++ b/clients/besu/Dockerfile
@@ -1,7 +1,8 @@
-# Hyperledger publihes regular developer 'head' images, just use that one
-FROM hyperledger/besu:develop
+ARG branch=develop
+FROM hyperledger/besu:$branch
 
 USER root
+
 # Inject the startup script
 ADD besu.sh /opt/besu/bin/besu-hive.sh
 RUN chmod +x /opt/besu/bin/besu-hive.sh
@@ -16,7 +17,6 @@ RUN apt-get update && \
 
 ADD genesis.json /genesis.json
 
-ARG branch=master
 RUN echo "{\
   \"repo\":\"https://github.com/hyperledger/besu\",\
   \"branch\":\"${branch:-detached}\", \
@@ -27,5 +27,3 @@ RUN echo "{\
 EXPOSE 8545 8546 8547 30303 30303/udp
 
 ENTRYPOINT ["/opt/besu/bin/besu-hive.sh"]
-
-#EOF

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -24,7 +24,7 @@ def int_to_hex:
   def stream:
     recurse(if . > 0 then ./16|floor else empty end) | . % 16 ;
   if . == 0 then "0x0"
-  else "0x" + ([stream] | reverse | .[1:] | map(tostring) | join(""))
+  else "0x" + ([stream] | reverse | .[1:] | map(if .<10 then 48+. else 87+. end) | implode)
   end
 ;
 

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -7,11 +7,8 @@ def remove_empty:
           .value != null and
           .value != "" and
           .value != [] and
-          .value != {} and
           .key != null and
-          .key != "" and
-          .key != [] and
-          .key != {}
+          .key != ""
         )
       )
     else .
@@ -47,14 +44,13 @@ def infix_zeros_to_length(s;l):
   "engine": {
     "Ethash": {
       "params": {
-        "minimumDifficulty": "0x020000",
-        "difficultyBoundDivisor": "0x0800",
+        "minimumDifficulty": "0x20000",
+        "difficultyBoundDivisor": "0x800",
         "durationLimit": "0x0d",
         "homesteadTransition": env.HIVE_FORK_HOMESTEAD|to_hex,
         "eip100bTransition": env.HIVE_FORK_BYZANTIUM|to_hex,
         "daoHardforkTransition": env.HIVE_FORK_DAO_BLOCK|to_hex,
         "daoHardforkBeneficiary": "0xbf4ed7b27f1d666546e30d74d50d173d20bca754",
-        "daoHardforkAccounts": [],
         "blockReward": {
           "0x0": "0x4563918244F40000",
           (env.HIVE_FORK_BYZANTIUM|to_hex//""): "0x29A2241AF62C0000",

--- a/clients/openethereum/Dockerfile
+++ b/clients/openethereum/Dockerfile
@@ -1,5 +1,3 @@
-# Docker container spec for building the master branch of parity.
-
 ARG branch=latest
 FROM openethereum/openethereum:$branch
 
@@ -14,6 +12,9 @@ RUN chmod 777 /chain.json
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh 
 RUN chmod 777 /enode.sh
+
+# Add dummy /version.json
+RUN echo "{\"repo\":\"\", \"branch\":\"\", \"commit\":\"\"}" > /version.json
 
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 8547 30303 30303/udp

--- a/clients/trinity/Dockerfile
+++ b/clients/trinity/Dockerfile
@@ -15,6 +15,7 @@ RUN git clone --branch $branch https://github.com/ethereum/trinity .
 RUN pip install -e .[dev]  --no-cache-dir
 RUN pip install -U trinity --no-cache-dir
 
+ADD genesis.json /genesis.json
 ADD mapper.jq /mapper.jq
 ADD trinity.sh /trinity.sh
 RUN chmod +x /trinity.sh

--- a/clients/trinity/genesis.json
+++ b/clients/trinity/genesis.json
@@ -1,0 +1,15 @@
+{
+    "coinbase"   : "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "difficulty" : "0x020000",
+    "extraData"  : "0x42",
+    "gasLimit"   : "0x2fefd8",
+    "mixHash"    : "0x2c85bcbce56429100b2108254bb56906257582aeafcbd682bc9af67a9f5aee46",
+    "nonce"      : "0x78cc16f7b4f65485",
+    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "timestamp"  : "0x54c98c81",
+    "alloc"      : {
+        "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+            "balance" : "0x09184e72a000"
+        }
+    }
+}

--- a/clients/trinity/mapper.jq
+++ b/clients/trinity/mapper.jq
@@ -55,7 +55,8 @@ def infix_zeros_to_length(s;l):
   },
   "params": {
     "miningMethod": (if env.HIVE_SKIP_POW != null then "NoProof" else "ethash" end),
-    "chainId": env.HIVE_CHAIN_ID|to_hex,
+    "chainId": (if env.HIVE_CHAIN_ID != null then env.HIVE_CHAIN_ID|to_hex else "0x1" end),
+    "frontierForkBlock": "0x0",
     "homesteadForkBlock": env.HIVE_FORK_HOMESTEAD|to_hex,
     "DAOForkBlock": env.HIVE_FORK_DAO_BLOCK|to_hex,
     "EIP150ForkBlock": env.HIVE_FORK_TANGERINE|to_hex,

--- a/clients/trinity/mapper.jq
+++ b/clients/trinity/mapper.jq
@@ -7,11 +7,8 @@ def remove_empty:
           .value != null and
           .value != "" and
           .value != [] and
-          .value != {} and
           .key != null and
-          .key != "" and
-          .key != [] and
-          .key != {}
+          .key != ""
         )
       )
     else .

--- a/clients/trinity/mapper.jq
+++ b/clients/trinity/mapper.jq
@@ -55,7 +55,7 @@ def infix_zeros_to_length(s;l):
   },
   "params": {
     "miningMethod": (if env.HIVE_SKIP_POW != null then "NoProof" else "ethash" end),
-    "chainId": (if env.HIVE_CHAIN_ID != null then env.HIVE_CHAIN_ID|to_hex else "0x1" end),
+    "chainId": (env.HIVE_CHAIN_ID|to_hex // "0x1"),
     "frontierForkBlock": "0x0",
     "homesteadForkBlock": env.HIVE_FORK_HOMESTEAD|to_hex,
     "DAOForkBlock": env.HIVE_FORK_DAO_BLOCK|to_hex,

--- a/clients/trinity/trinity.sh
+++ b/clients/trinity/trinity.sh
@@ -62,6 +62,7 @@ fi
 
 # Configure and set the chain definition.
 jq -f /mapper.jq /genesis.json > /newconfig.json
+cat /newconfig.json
 FLAGS="$FLAGS --genesis /newconfig.json"
 
 # Disable TxPool. Trinity won't start with a custom genesis unless
@@ -74,6 +75,7 @@ set +e
 # Import blockchain from /chain.rlp and /blocks.
 if [ -f /chain.rlp ]; then
     echo "Loading initial blockchain..."
+    echo trinity $FLAGS import /chain.rlp
     trinity $FLAGS import /chain.rlp
 fi
 if [ -d /blocks ]; then


### PR DESCRIPTION
This fixes a few more issues with the client scripts:

- Aleth: use the 'nightly' tag by default
- OpenEthereum: add version.json to make it launch again
- Nethermind: fix some issues in mapper.jq
- Trinity: various tweaks to mapper.jq to make it work correctly
- Besu: allow pulling docker tags other than 'develop'
