### PR TITLE
simulators/consensus: add yolov2/berlin support

### DIFF
--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -121,6 +121,7 @@ if [ "$HIVE_USE_GENESIS_CONFIG" == "" ]; then
 	fi
 	if [ "$HIVE_FORK_BERLIN" != "" ]; then
 		JQPARAMS="$JQPARAMS + {\"berlinBlock\": $HIVE_FORK_BERLIN}"
+		JQPARAMS="$JQPARAMS + {\"yolov2Block\": $HIVE_FORK_BERLIN}"
 	fi
 	if [ "$HIVE_CHAIN_ID" != "" ]; then
 		JQPARAMS="$JQPARAMS + {\"chainId\": $HIVE_CHAIN_ID}"

--- a/simulators/ethereum/consensus/main.go
+++ b/simulators/ethereum/consensus/main.go
@@ -36,6 +36,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"Homestead": {
 		"HIVE_FORK_HOMESTEAD":      0,
@@ -46,6 +47,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"EIP150": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -56,6 +58,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"EIP158": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -66,6 +69,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"Byzantium": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -76,6 +80,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"Constantinople": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -86,6 +91,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 0,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"ConstantinopleFix": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -96,6 +102,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 0,
 		"HIVE_FORK_PETERSBURG":     0,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"Istanbul": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -106,6 +113,18 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 0,
 		"HIVE_FORK_PETERSBURG":     0,
 		"HIVE_FORK_ISTANBUL":       0,
+		"HIVE_FORK_BERLIN":         2000,
+	},
+	"Berlin": {
+		"HIVE_FORK_HOMESTEAD": 0,
+		//"HIVE_FORK_DAO_BLOCK":      2000,
+		"HIVE_FORK_TANGERINE":      0,
+		"HIVE_FORK_SPURIOUS":       0,
+		"HIVE_FORK_BYZANTIUM":      0,
+		"HIVE_FORK_CONSTANTINOPLE": 0,
+		"HIVE_FORK_PETERSBURG":     0,
+		"HIVE_FORK_ISTANBUL":       0,
+		"HIVE_FORK_BERLIN":         0,
 	},
 	"FrontierToHomesteadAt5": {
 		"HIVE_FORK_HOMESTEAD":      5,
@@ -116,6 +135,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"HomesteadToEIP150At5": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -126,6 +146,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"HomesteadToDaoAt5": {
 		"HIVE_FORK_HOMESTEAD":      0,
@@ -136,6 +157,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"EIP158ToByzantiumAt5": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -146,6 +168,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 2000,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"ByzantiumToConstantinopleAt5": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -156,6 +179,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 5,
 		"HIVE_FORK_PETERSBURG":     2000,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"ByzantiumToConstantinopleFixAt5": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -166,6 +190,7 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 5,
 		"HIVE_FORK_PETERSBURG":     5,
 		"HIVE_FORK_ISTANBUL":       2000,
+		"HIVE_FORK_BERLIN":         2000,
 	},
 	"ConstantinopleFixToIstanbulAt5": {
 		"HIVE_FORK_HOMESTEAD": 0,
@@ -176,6 +201,18 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_CONSTANTINOPLE": 0,
 		"HIVE_FORK_PETERSBURG":     0,
 		"HIVE_FORK_ISTANBUL":       5,
+		"HIVE_FORK_BERLIN":         2000,
+	},
+	"IstanbulToBerlinAt5": {
+		"HIVE_FORK_HOMESTEAD": 0,
+		//"HIVE_FORK_DAO_BLOCK":      2000,
+		"HIVE_FORK_TANGERINE":      0,
+		"HIVE_FORK_SPURIOUS":       0,
+		"HIVE_FORK_BYZANTIUM":      0,
+		"HIVE_FORK_CONSTANTINOPLE": 0,
+		"HIVE_FORK_PETERSBURG":     0,
+		"HIVE_FORK_ISTANBUL":       0,
+		"HIVE_FORK_BERLIN":         5,
 	},
 }
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/hive/issues/357 , adds framework support for yolov2 / berlin. 