### PR TITLE
internal/libhive: remove scaling of client startup check timeout

### DIFF
--- a/internal/libhive/docker.go
+++ b/internal/libhive/docker.go
@@ -158,10 +158,6 @@ func (b *dockerBackend) StartClient(name string, env map[string]string, files ma
 		}
 
 		time.Sleep(checkTime)
-		checkTime = checkTime * 2
-		if checkTime > 2*time.Second {
-			checkTime = time.Second
-		}
 
 		if time.Since(container.Created) > timeoutCheckDuration {
 			log15.Debug("deleting client container", "name", name, "id", info.ID)


### PR DESCRIPTION
Doesn't really make sense to use scaling here, checking every 100ms
doesn't hurt and makes tests run faster.