### PR TITLE
internal/libhive: use client version info and start timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/golang/snappy v0.0.2 // indirect
-	github.com/google/gopacket v1.1.17
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/graph-gophers/graphql-go v0.0.0-20201027172035-4c772c181653 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
-github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -421,8 +419,6 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 h1:1Fzlr8kkDLQwqMP8GxrhptBLqZG/EDpiATneiZHY998=
-golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/images.go
+++ b/images.go
@@ -6,7 +6,6 @@ package main
 import (
 	"archive/tar"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -65,10 +64,8 @@ func buildClients(clientList []string, cacher *buildCacher, errorReport *HiveErr
 
 // fetchClientVersions downloads the version json specs from all clients that
 // match the given patten.
-func fetchClientVersions(cacher *buildCacher) (map[string]map[string]string, error) {
-
-	// Iterate over the images and collect the versions
-	versions := make(map[string]map[string]string)
+func fetchClientVersions(cacher *buildCacher) (map[string]string, error) {
+	versions := make(map[string]string)
 	for client, image := range allClients {
 		logger := log15.New("client", client)
 		blob, err := downloadFromImage(image, "/version.json", logger)
@@ -76,12 +73,7 @@ func fetchClientVersions(cacher *buildCacher) (map[string]map[string]string, err
 			berr := &buildError{err: err, client: client}
 			return nil, berr
 		}
-		var version map[string]string
-		if err := json.Unmarshal(blob, &version); err != nil {
-			berr := &buildError{err: err, client: client}
-			return nil, berr
-		}
-		versions[client] = version
+		versions[client] = string(blob)
 	}
 	return versions, nil
 }

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -34,7 +34,16 @@ type SimEnv struct {
 	SimLogLevel          int
 	LogDir               string
 	PrintContainerOutput bool
-	Images               map[string]string // client name -> image name
+
+	// This configures the amount of time the simulation waits
+	// for the client to open port 8545 after launching the container.
+	ClientStartTimeout time.Duration
+
+	// client name -> image name
+	Images map[string]string
+
+	// client name -> version info
+	ClientVersions map[string]string
 }
 
 // TestManager collects test results during a simulation run.

--- a/simulator.go
+++ b/simulator.go
@@ -63,9 +63,11 @@ func simulate(simDuration int, simulator string, simulatorLabel string, logger l
 
 	// Create the test manager.
 	env := libhive.SimEnv{
-		Images:               allClients,
 		LogDir:               logdir,
+		Images:               allClients,
+		ClientVersions:       allClientVersions,
 		SimLogLevel:          *simloglevelFlag,
+		ClientStartTimeout:   *checkTimeLimitFlag,
 		PrintContainerOutput: *simloglevelFlag > 3,
 	}
 	backend := libhive.NewDockerBackend(env, dockerClient)
@@ -100,6 +102,9 @@ func simulate(simDuration int, simulator string, simulatorLabel string, logger l
 		},
 		HostConfig: hostConfig,
 	})
+	if err != nil {
+		return err
+	}
 	tm.SetSimContainerID(sc.ID)
 	slogger := logger.New("id", sc.ID[:8])
 	slogger.Debug("created simulator container")


### PR DESCRIPTION
These were already available as globals, but not passed to libhive.
This also removes some other unused code in the main hive executable.