### PR TITLE
clients/aleth: add default genesis.json

### DIFF
--- a/clients/aleth/Dockerfile
+++ b/clients/aleth/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache jq bc bash curl
 ADD aleth.sh /aleth.sh
 RUN chmod +x /aleth.sh
 ADD mapper.jq /mapper.jq
+ADD genesis.json /genesis.json
 
 # Add the enode URL retriever script.
 ADD enode.sh /enode.sh

--- a/clients/aleth/genesis.json
+++ b/clients/aleth/genesis.json
@@ -1,0 +1,15 @@
+{
+    "coinbase"   : "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "difficulty" : "0x020000",
+    "extraData"  : "0x42",
+    "gasLimit"   : "0x2fefd8",
+    "mixHash"    : "0x2c85bcbce56429100b2108254bb56906257582aeafcbd682bc9af67a9f5aee46",
+    "nonce"      : "0x78cc16f7b4f65485",
+    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "timestamp"  : "0x54c98c81",
+    "alloc"      : {
+        "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+            "balance" : "0x09184e72a000"
+        }
+    }
+}


### PR DESCRIPTION
All other clients have it, and it's required for running simulations
which don't care about the genesis block.