### PR TITLE
simulators/ethereum/graphql: rename module back to proper name

### DIFF
--- a/simulators/ethereum/graphql/Dockerfile
+++ b/simulators/ethereum/graphql/Dockerfile
@@ -11,5 +11,5 @@ RUN go build -v .
 FROM alpine:latest
 ADD . /source
 WORKDIR /source
-COPY --from=builder /source/graphql2 ./graphql
+COPY --from=builder /source/graphql .
 ENTRYPOINT ["./graphql"]

--- a/simulators/ethereum/graphql/go.mod
+++ b/simulators/ethereum/graphql/go.mod
@@ -1,5 +1,5 @@
-module github.com/ethereum/hive/simulators/ethereum/graphql2
+module github.com/ethereum/hive/simulators/ethereum/graphql
 
 go 1.13
 
-require github.com/ethereum/hive v0.0.0-20201104230044-a309add1fcb9
+require github.com/ethereum/hive v0.0.0-20201105000855-c76ca0f10a01

--- a/simulators/ethereum/graphql/go.sum
+++ b/simulators/ethereum/graphql/go.sum
@@ -98,8 +98,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.9.1 h1:MrdTRvKIa3apdx6NW1azzSgl8BQB1eTBVSUmFhuztaU=
 github.com/ethereum/go-ethereum v1.9.1/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
-github.com/ethereum/hive v0.0.0-20201104230044-a309add1fcb9 h1:f0x4d5XuZqjtc1JyjEqu9rMWSdpRLtg4uAJ6//GNS4E=
-github.com/ethereum/hive v0.0.0-20201104230044-a309add1fcb9/go.mod h1:2oTDtJ+hKbi+YF0+PS25sIZixHB88M/yUaXi/SRzgSE=
+github.com/ethereum/hive v0.0.0-20201105000855-c76ca0f10a01 h1:ENqy16eVOtsmflyH16tWUw+sPlg2ZrNgDslBNeC5pcY=
+github.com/ethereum/hive v0.0.0-20201105000855-c76ca0f10a01/go.mod h1:2oTDtJ+hKbi+YF0+PS25sIZixHB88M/yUaXi/SRzgSE=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=


### PR DESCRIPTION
The simulation module had to be renamed temporarily in order to make it
build. Now that the parent hive module no longer includes the packages
of this simulation module, we can put the correct name back.