### PR TITLE
internal/libhive: disconnect containers from network when removing network

### DIFF
--- a/internal/libhive/docker.go
+++ b/internal/libhive/docker.go
@@ -223,6 +223,16 @@ func (b *dockerBackend) NetworkNameToID(name string) (string, error) {
 
 // RemoveNetwork deletes a docker network.
 func (b *dockerBackend) RemoveNetwork(id string) error {
+	info, err := b.client.NetworkInfo(id)
+	if err != nil {
+		return err
+	}
+	for _, container := range info.Containers {
+		err := b.DisconnectContainer(container.Name, id)
+		if err != nil {
+			return err
+		}
+	}
 	return b.client.RemoveNetwork(id)
 }
 


### PR DESCRIPTION
This PR is an alternative to #398 . Instead of adding additional information to the test manager, when RemoveNetwork is called, we should just disconnect all containers from the network first to ensure a clean removal.