### PR TITLE
clients/besu: add AOT compilation of besu jars

### DIFF
--- a/clients/besu/Dockerfile
+++ b/clients/besu/Dockerfile
@@ -2,10 +2,14 @@ ARG branch=develop
 FROM hyperledger/besu:$branch
 
 USER root
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl binutils
 RUN curl -L -o /usr/local/bin/jq 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64' && \
     echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
     chmod +x /usr/local/bin/jq
+
+# Add the AOT compiler script and run it.
+ADD aot-compile.sh /aot-compile.sh
+RUN /aot-compile.sh
 
 # Inject the startup script.
 ADD besu.sh /opt/besu/bin/besu-hive.sh

--- a/clients/besu/aot-compile.sh
+++ b/clients/besu/aot-compile.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script builds a shared library for most of besu using the JEP 295 ahead-of-time
+# compiler.
+#
+# The output files can be used to speed up starting besu by
+# passing them to the java runtime like this:
+#
+#  -XX:AOTLibrary=/opt/besu/besuAOT.so -XX:AOTLibrary=/opt/besu/javaBaseAOT.so
+
+set -e
+
+cd /opt/besu/lib
+classpath=$(ls -1 $PWD/*.jar | paste -sd ':' -)
+
+aotjars="$(echo besu-*.jar picocli-*.jar tuweni-*.jar jackson-*.jar log4j-*.jar guava*.jar bcprov-*.jar rocksdb-*)"
+jaotc --ignore-errors --output /opt/besu/besuAOT.so -J-cp -J$classpath --jar $aotjars
+jaotc --ignore-errors --output /opt/besu/javaBaseAOT.so --module java.base

--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -38,6 +38,17 @@ besu=/opt/besu/bin/besu
 # See https://github.com/hyperledger/besu/issues/1464
 export BESU_OPTS="-Dsecp256k1.randomize=false"
 
+# Print touched methods. This is useful for finding
+# the set of modules that benefit from AOT-compilation.
+# export BESU_OPTS="$BESU_OPTS -XX:+UnlockDiagnosticVMOptions -XX:+LogTouchedMethods -XX:+PrintTouchedMethodsAtExit"
+
+# Enable AOT library.
+export BESU_OPTS="$BESU_OPTS -XX:+UnlockExperimentalVMOptions -XX:+UseAOT -XX:AOTLibrary=/opt/besu/besuAOT.so -XX:AOTLibrary=/opt/besu/javaBaseAOT.so"
+
+# Print used AOT code. Uncomment this to check if the AOT library
+# is actually being used.
+# export BESU_OPTS="$BESU_OPTS -XX:+UnlockDiagnosticVMOptions -verbose -XX:+PrintAOT"
+
 # Configure logging.
 LOG=info
 case "$HIVE_LOGLEVEL" in


### PR DESCRIPTION
This reduces the startup overhead of the JVM. In my tests, besu starts
quite a bit faster with the AOT libraries enabled: it takes 9s without,
5s with AOT. The downside to this is that the precompilation takes a lot
of time.