### PR TITLE
simulators/ethereum/graphql: print response body when status code mismatch to provide more err context

### DIFF
--- a/simulators/ethereum/graphql/graphql.go
+++ b/simulators/ethereum/graphql/graphql.go
@@ -148,7 +148,7 @@ func (tc *testCase) run(t *hivesim.T, c *hivesim.Client) {
 	resp.Body.Close()
 
 	if resp.StatusCode != tc.gqlTest.StatusCode {
-		t.Errorf("HTTP response code is %d, want %d", resp.StatusCode, tc.gqlTest.StatusCode)
+		t.Errorf("HTTP response code is %d, want %d \n response body: %s", resp.StatusCode, tc.gqlTest.StatusCode, string(respBytes))
 	}
 	if resp.StatusCode != 200 {
 		// Test expects HTTP error, and the client sent one, test done.


### PR DESCRIPTION
It would be nice to also print the response body upon http status mismatch to provide further context to errors. At the moment, if there is a header mismatch, it only prints out the header mismatch (expected vs. got), but no response body to see what went wrong.