### PR TITLE
simulators/ethereum/graphql: change `from` to hex string to match `to` in eth_call_BlockLatest

### DIFF
--- a/simulators/ethereum/graphql/testcases/03_eth_call_BlockLatest.json
+++ b/simulators/ethereum/graphql/testcases/03_eth_call_BlockLatest.json
@@ -1,5 +1,5 @@
 {
-  "request": "{block {number call (data : {from : \"a94f5374fce5edbc8e2a8697c15331677e6ebf0b\", to: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\", data :\"0x12a7b914\"}){data status}}}"
+  "request": "{block {number call (data : {from : \"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b\", to: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\", data :\"0x12a7b914\"}){data status}}}"
   ,
   "response":{
     "data" : {


### PR DESCRIPTION
This PR changes the `03_eth_call_BlockLatest` graphql test case `from` field to a hex string to match the `to` field.

If there is a valid reason for the difference in input formats, I will close this PR.