### PR TITLE
simulators/ethereum/graphql: replace #42 test query with decimal instead of hex string

### DIFF
--- a/simulators/ethereum/graphql/testcases/42_graphql_blocks_byRange.json
+++ b/simulators/ethereum/graphql/testcases/42_graphql_blocks_byRange.json
@@ -1,7 +1,7 @@
 {
   "request": 
     
-    "{blocks (from : \"0x1e\", to: \"0x20\") { number gasUsed gasLimit hash nonce  stateRoot receiptsRoot transactionCount }} ",
+    "{blocks (from : 30, to: 32) { number gasUsed gasLimit hash nonce  stateRoot receiptsRoot transactionCount }} ",
 
 
   "response":{


### PR DESCRIPTION
Geth deprecated the ability to take a hex string as a parameter for a query on `Block` with [this PR](https://github.com/ethereum/go-ethereum/pull/21883). 