### PR TITLE
internal/libhive: report client versions in suite

### DIFF
--- a/cmd/hiveview/assets/app.js
+++ b/cmd/hiveview/assets/app.js
@@ -421,6 +421,7 @@ function onSuiteData(data, jsonsource) {
         "id": 0,
         "name": "Devp2p discovery v4 test suite",
         "description": "This suite of tests checks for basic conformity to the discovery v4 protocol and for some known security weaknesses.",
+        "versionInfo": "",
         "testCases": {
             "1": {
                 "id": 1,
@@ -436,7 +437,6 @@ function onSuiteData(data, jsonsource) {
                     "a46beeb9": {
                         "id": "a46beeb9",
                         "name": "parity_latest",
-                        "versionInfo": "",
                         "instantiatedAt": "2020-04-22T17:12:14.275491827Z",
                         "logFile": "parity_latest/client-a46beeb9.log",
                         "WasInstantiated": true

--- a/cmd/hiveview/assets/app.js
+++ b/cmd/hiveview/assets/app.js
@@ -421,7 +421,7 @@ function onSuiteData(data, jsonsource) {
         "id": 0,
         "name": "Devp2p discovery v4 test suite",
         "description": "This suite of tests checks for basic conformity to the discovery v4 protocol and for some known security weaknesses.",
-        "versionInfo": "",
+        "clientVersions": "",
         "testCases": {
             "1": {
                 "id": 1,

--- a/hivesim/testapi_test.go
+++ b/hivesim/testapi_test.go
@@ -49,7 +49,6 @@ func TestSuiteReporting(t *testing.T) {
 			Description: suite.Description,
 			TestCases: map[libhive.TestID]*libhive.TestCase{
 				1: {
-					ID:          1,
 					Name:        "passing test",
 					Description: "this test passes",
 					SummaryResult: libhive.TestResult{
@@ -58,7 +57,6 @@ func TestSuiteReporting(t *testing.T) {
 					},
 				},
 				2: {
-					ID:          2,
 					Name:        "failing test",
 					Description: "this test fails",
 					SummaryResult: libhive.TestResult{

--- a/hivesim/testapi_test.go
+++ b/hivesim/testapi_test.go
@@ -44,9 +44,10 @@ func TestSuiteReporting(t *testing.T) {
 
 	wantResults := map[libhive.TestSuiteID]*libhive.TestSuite{
 		0: {
-			ID:          0,
-			Name:        suite.Name,
-			Description: suite.Description,
+			ID:             0,
+			Name:           suite.Name,
+			Description:    suite.Description,
+			ClientVersions: make(map[string]string),
 			TestCases: map[libhive.TestID]*libhive.TestCase{
 				1: {
 					Name:        "passing test",

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -236,13 +236,19 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		clientInfo := &ClientInfo{
 			ID:             info.ID,
 			IP:             info.IP,
-			MAC:            info.MAC,
 			Name:           name,
-			VersionInfo:    api.env.ClientVersions[name],
 			InstantiatedAt: time.Now(),
 			LogFile:        logPath,
 			wait:           info.Wait,
 		}
+		// log client version in test suite
+		suite, ok := api.tm.runningTestSuites[suiteID]
+		if !ok {
+			http.Error(w, ErrNoSuchTestSuite.Error(), http.StatusNotFound)
+			return
+		}
+		suite.ClientVersions[name] = api.env.ClientVersions[name]
+		// register the node
 		api.tm.RegisterNode(testID, info.ID, clientInfo)
 	}
 	if err != nil {

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -24,7 +24,7 @@ type TestSuite struct {
 	ID             TestSuiteID          `json:"id"`
 	Name           string               `json:"name"`
 	Description    string               `json:"description"`
-	ClientVersions map[string]string    `json:"versionInfo"`
+	ClientVersions map[string]string    `json:"clientVersions"`
 	TestCases      map[TestID]*TestCase `json:"testCases"`
 	// the log-file pertaining to the simulator. (may encompass more than just one TestSuite)
 	SimulatorLog string `json:"simLog"`
@@ -32,7 +32,6 @@ type TestSuite struct {
 
 // TestCase represents a single test case in a test suite.
 type TestCase struct {
-	ID            TestID                 `json:"id"`          // Test case reference number.
 	Name          string                 `json:"name"`        // Test case short name.
 	Description   string                 `json:"description"` // Test case long description in MD.
 	Start         time.Time              `json:"start"`

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -21,10 +21,11 @@ func (tsID TestID) String() string {
 
 // TestSuite is a single run of a simulator, a collection of testcases.
 type TestSuite struct {
-	ID          TestSuiteID          `json:"id"`
-	Name        string               `json:"name"`
-	Description string               `json:"description"`
-	TestCases   map[TestID]*TestCase `json:"testCases"`
+	ID             TestSuiteID          `json:"id"`
+	Name           string               `json:"name"`
+	Description    string               `json:"description"`
+	ClientVersions map[string]string    `json:"versionInfo"`
+	TestCases      map[TestID]*TestCase `json:"testCases"`
 	// the log-file pertaining to the simulator. (may encompass more than just one TestSuite)
 	SimulatorLog string `json:"simLog"`
 }
@@ -50,9 +51,7 @@ type TestResult struct {
 type ClientInfo struct {
 	ID             string    `json:"id"`
 	IP             string    `json:"ip"`
-	MAC            string    `json:"mac"` // TODO: remove this
 	Name           string    `json:"name"`
-	VersionInfo    string    `json:"versionInfo"` //URL to github repo + branch.
 	InstantiatedAt time.Time `json:"instantiatedAt"`
 	LogFile        string    `json:"logFile"` //Absolute path to the logfile.
 

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -353,11 +353,12 @@ func (manager *TestManager) StartTestSuite(name string, description string) (Tes
 
 	var newSuiteID = TestSuiteID(manager.testSuiteCounter)
 	manager.runningTestSuites[newSuiteID] = &TestSuite{
-		ID:           newSuiteID,
-		Name:         name,
-		Description:  description,
-		TestCases:    make(map[TestID]*TestCase),
-		SimulatorLog: manager.simLogFile,
+		ID:             newSuiteID,
+		Name:           name,
+		Description:    description,
+		ClientVersions: make(map[string]string),
+		TestCases:      make(map[TestID]*TestCase),
+		SimulatorLog:   manager.simLogFile,
 	}
 	manager.testSuiteCounter++
 	return newSuiteID, nil

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -383,7 +383,6 @@ func (manager *TestManager) StartTest(testSuiteID TestSuiteID, name string, desc
 	var newCaseID = TestID(manager.testCaseCounter)
 	// create a new test case and add it to the test suite
 	newTestCase := &TestCase{
-		ID:          newCaseID,
 		Name:        name,
 		Description: description,
 		Start:       time.Now(),
@@ -393,7 +392,7 @@ func (manager *TestManager) StartTest(testSuiteID TestSuiteID, name string, desc
 	// and to the general map of id:testcases
 	manager.runningTestCases[newCaseID] = newTestCase
 
-	return newTestCase.ID, nil
+	return newCaseID, nil
 }
 
 // EndTest finishes the test case


### PR DESCRIPTION
This PR changes client version reporting to only report the client versions at the suite level to not cloud the log output.

It also removes test case ID reporting as it's not really necessary. 