### PR TITLE
internal/libhive, hivesim: add client script exec API

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -198,9 +198,9 @@ Response
     content-disposition: form-data; name=file; filename="/genesis.json"
 
     {
-       "difficulty": "0x20000",
-       "gasLimit": "0xFFFFFFFF",
-       ...
+      "difficulty": "0x20000",
+      "gasLimit": "0xFFFFFFFF",
+      ...
     }
     --boundary----
 
@@ -234,6 +234,29 @@ Response:
     content-type: text/plain
 
     enode://1ba850b467b3b96eacdcb6c133d2c7907878794dbdfc114269c7f240d278594439f79975f87e43c45152072c9bd68f9311eb15fd37f1fd438812240e82de9ef9@172.17.0.3:30303
+
+#### Running client scripts
+
+    POST /testsuite/{suite}/test/{test}/node/{container}/exec
+    content-type: application/json
+
+    {
+      "command": ["my-script", "arg1"]
+    }
+
+This request invokes a script in the client container. The script must be present in the
+client container's filesystem in the `/hive-bin` directory.
+
+Response:
+
+    200 OK
+    content-type: application/json
+
+    {
+      "exitCode": 0,
+      "stdout": "output",
+      "stderr": "error output"
+    }
 
 #### Stopping a client
 

--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -12,6 +12,13 @@ type TestResult struct {
 	Details string `json:"details"`
 }
 
+// ExecInfo is the result of running a command in a client container.
+type ExecInfo struct {
+	StdOut   string `json:"out"`
+	StdErr   string `json:"err"`
+	ExitCode int    `json:"code"`
+}
+
 // Params contains client launch parameters.
 // This exists because tests usually want to define common parameters as
 // a global variable and then customize them for specific clients.

--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -14,8 +14,8 @@ type TestResult struct {
 
 // ExecInfo is the result of running a command in a client container.
 type ExecInfo struct {
-	StdOut   string `json:"out"`
-	StdErr   string `json:"err"`
+	Stdout   string `json:"out"`
+	Stderr   string `json:"err"`
 	ExitCode int    `json:"code"`
 }
 

--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -14,9 +14,9 @@ type TestResult struct {
 
 // ExecInfo is the result of running a command in a client container.
 type ExecInfo struct {
-	Stdout   string `json:"out"`
-	Stderr   string `json:"err"`
-	ExitCode int    `json:"code"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int    `json:"exitCode"`
 }
 
 // Params contains client launch parameters.

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -196,14 +196,18 @@ func (sim *Simulation) ClientEnodeURL(testSuite SuiteID, test TestID, node strin
 }
 
 // ClientExec runs a command in a running client.
-func (sim *Simulation) ClientExec(testSuite SuiteID, test TestID, nodeid string, cmd string) (*ExecInfo, error) {
-	params := url.Values{}
-	params.Add("cmd", cmd)
-	p := fmt.Sprintf("%s/testsuite/%d/test/%d/node/%s/exec?%s", sim.url, testSuite, test, nodeid, params.Encode())
-	req, err := http.NewRequest(http.MethodPost, p, nil)
+func (sim *Simulation) ClientExec(testSuite SuiteID, test TestID, nodeid string, cmd []string) (*ExecInfo, error) {
+	type execRequest struct {
+		Command []string `json:"command"`
+	}
+	enc, _ := json.Marshal(&execRequest{cmd})
+
+	p := fmt.Sprintf("%s/testsuite/%d/test/%d/node/%s/exec", sim.url, testSuite, test, nodeid)
+	req, err := http.NewRequest(http.MethodPost, p, bytes.NewReader(enc))
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("content-type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -195,6 +195,40 @@ func (sim *Simulation) ClientEnodeURL(testSuite SuiteID, test TestID, node strin
 	return res, nil
 }
 
+type execInfo struct {
+	StdOut   string `json:"out"`
+	StdErr   string `json:"err"`
+	ExitCode int    `json:"code"`
+}
+
+// ClientRunProgram runs a command in a running client.
+func (sim *Simulation) ClientRunProgram(testSuite SuiteID, test TestID,
+	nodeid string, privileged bool, user string, cmd string) (stdOut string, stdErr string, exitCode int, err error) {
+
+	params := url.Values{}
+	params.Add("privileged", strconv.FormatBool(privileged))
+	params.Add("user", user)
+	params.Add("cmd", cmd)
+	p := fmt.Sprintf("%s/testsuite/%d/test/%d/node/%s/exec?%s", sim.url, testSuite, test, nodeid, params.Encode())
+	req, err := http.NewRequest(http.MethodPost, p, nil)
+	if err != nil {
+		return "", "", 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", 0, err
+	}
+	if resp.Body == nil {
+		return "", "", 0, errors.New("unexpected empty response body")
+	}
+	dec := json.NewDecoder(resp.Body)
+	var res execInfo
+	if err := dec.Decode(&res); err != nil {
+		return "", "", 0, err
+	}
+	return res.StdOut, res.StdErr, res.ExitCode, err
+}
+
 // CreateNetwork sends a request to the hive server to create a docker network by
 // the given name.
 func (sim *Simulation) CreateNetwork(testSuite SuiteID, networkName string) error {

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -201,8 +201,8 @@ type ExecInfo struct {
 	ExitCode int    `json:"code"`
 }
 
-// ClientRunProgram runs a command in a running client.
-func (sim *Simulation) ClientRunProgram(testSuite SuiteID, test TestID, nodeid string, cmd string) (*ExecInfo, error) {
+// ClientExec runs a command in a running client.
+func (sim *Simulation) ClientExec(testSuite SuiteID, test TestID, nodeid string, cmd string) (*ExecInfo, error) {
 	params := url.Values{}
 	params.Add("cmd", cmd)
 	p := fmt.Sprintf("%s/testsuite/%d/test/%d/node/%s/exec?%s", sim.url, testSuite, test, nodeid, params.Encode())

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -195,12 +195,6 @@ func (sim *Simulation) ClientEnodeURL(testSuite SuiteID, test TestID, node strin
 	return res, nil
 }
 
-type ExecInfo struct {
-	StdOut   string `json:"out"`
-	StdErr   string `json:"err"`
-	ExitCode int    `json:"code"`
-}
-
 // ClientExec runs a command in a running client.
 func (sim *Simulation) ClientExec(testSuite SuiteID, test TestID, nodeid string, cmd string) (*ExecInfo, error) {
 	params := url.Values{}

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -195,38 +195,34 @@ func (sim *Simulation) ClientEnodeURL(testSuite SuiteID, test TestID, node strin
 	return res, nil
 }
 
-type execInfo struct {
+type ExecInfo struct {
 	StdOut   string `json:"out"`
 	StdErr   string `json:"err"`
 	ExitCode int    `json:"code"`
 }
 
 // ClientRunProgram runs a command in a running client.
-func (sim *Simulation) ClientRunProgram(testSuite SuiteID, test TestID,
-	nodeid string, privileged bool, user string, cmd string) (stdOut string, stdErr string, exitCode int, err error) {
-
+func (sim *Simulation) ClientRunProgram(testSuite SuiteID, test TestID, nodeid string, cmd string) (*ExecInfo, error) {
 	params := url.Values{}
-	params.Add("privileged", strconv.FormatBool(privileged))
-	params.Add("user", user)
 	params.Add("cmd", cmd)
 	p := fmt.Sprintf("%s/testsuite/%d/test/%d/node/%s/exec?%s", sim.url, testSuite, test, nodeid, params.Encode())
 	req, err := http.NewRequest(http.MethodPost, p, nil)
 	if err != nil {
-		return "", "", 0, err
+		return nil, err
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", "", 0, err
+		return nil, err
 	}
 	if resp.Body == nil {
-		return "", "", 0, errors.New("unexpected empty response body")
+		return nil, errors.New("unexpected empty response body")
 	}
 	dec := json.NewDecoder(resp.Body)
-	var res execInfo
+	var res ExecInfo
 	if err := dec.Decode(&res); err != nil {
-		return "", "", 0, err
+		return nil, err
 	}
-	return res.StdOut, res.StdErr, res.ExitCode, err
+	return &res, err
 }
 
 // CreateNetwork sends a request to the hive server to create a docker network by

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -244,11 +244,11 @@ func TestRunProgram(t *testing.T) {
 		t.Fatal("failed to run program:", err)
 	}
 
-	if want := "out: echo this"; res.StdOut != want {
-		t.Fatalf("wrong std out %q\nwant %q", res.StdOut, want)
+	if want := "out: echo this"; res.Stdout != want {
+		t.Fatalf("wrong std out %q\nwant %q", res.Stdout, want)
 	}
-	if want := "err: echo this"; res.StdErr != want {
-		t.Fatalf("wrong std err %q\nwant %q", res.StdErr, want)
+	if want := "err: echo this"; res.Stderr != want {
+		t.Fatalf("wrong std err %q\nwant %q", res.Stderr, want)
 	}
 	if want := 42; res.ExitCode != want {
 		t.Fatalf("wrong code %q\nwant %q", res.ExitCode, want)

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/hive/internal/fakes"
 	"github.com/ethereum/hive/internal/libhive"
 )
@@ -24,13 +25,20 @@ func TestClientTypes(t *testing.T) {
 	if err != nil {
 		t.Fatal("can't get client types:", err)
 	}
-	if !reflect.DeepEqual(ctypes, []*ClientDefinition{
-		{Name: "client-1", Version: "client-1-version",
-			Meta: ClientMetadata{Roles: []string{"eth1"}}},
-		{Name: "client-2", Version: "client-2-version",
-			Meta: ClientMetadata{Roles: []string{"beacon"}}},
-	}) {
-		t.Fatal("wrong client types:", ctypes)
+	wantClients := []*ClientDefinition{
+		{
+			Name:    "client-1",
+			Version: "client-1-version",
+			Meta:    ClientMetadata{Roles: []string{"eth1"}},
+		},
+		{
+			Name:    "client-2",
+			Version: "client-2-version",
+			Meta:    ClientMetadata{Roles: []string{"beacon"}},
+		},
+	}
+	if !reflect.DeepEqual(ctypes, wantClients) {
+		t.Fatalf("wrong client types: %s", spew.Sdump(ctypes))
 	}
 }
 

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -218,10 +218,10 @@ func TestStartClientStartOptions(t *testing.T) {
 func TestRunProgram(t *testing.T) {
 	// Set up the backend to return program execution. Simple debug program here.
 	hooks := &fakes.BackendHooks{
-		RunProgram: func(containerID string, cmd string) (*libhive.ExecInfo, error) {
+		RunProgram: func(containerID string, cmd []string) (*libhive.ExecInfo, error) {
 			return &libhive.ExecInfo{
-				Stdout:   "out: " + cmd,
-				Stderr:   "err: " + cmd,
+				Stdout:   "out: " + cmd[0],
+				Stderr:   "error output",
 				ExitCode: 42,
 			}, nil
 		},
@@ -247,15 +247,15 @@ func TestRunProgram(t *testing.T) {
 	}
 
 	// Run a program
-	res, err := sim.ClientExec(suiteID, testID, clientID, "echo this")
+	res, err := sim.ClientExec(suiteID, testID, clientID, []string{"echo", "this"})
 	if err != nil {
 		t.Fatal("failed to run program:", err)
 	}
 
-	if want := "out: echo this"; res.Stdout != want {
+	if want := "out: /hive-bin/echo"; res.Stdout != want {
 		t.Fatalf("wrong std out %q\nwant %q", res.Stdout, want)
 	}
-	if want := "err: echo this"; res.Stderr != want {
+	if want := "error output"; res.Stderr != want {
 		t.Fatalf("wrong std err %q\nwant %q", res.Stderr, want)
 	}
 	if want := 42; res.ExitCode != want {

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -212,8 +212,8 @@ func TestRunProgram(t *testing.T) {
 	hooks := &fakes.BackendHooks{
 		RunProgram: func(containerID string, cmd string) (*libhive.ExecInfo, error) {
 			return &libhive.ExecInfo{
-				StdOut:   "out: " + cmd,
-				StdErr:   "err: " + cmd,
+				Stdout:   "out: " + cmd,
+				Stderr:   "err: " + cmd,
 				ExitCode: 42,
 			}, nil
 		},

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -239,7 +239,7 @@ func TestRunProgram(t *testing.T) {
 	}
 
 	// Run a program
-	res, err := sim.ClientRunProgram(suiteID, testID, clientID, "echo this")
+	res, err := sim.ClientExec(suiteID, testID, clientID, "echo this")
 	if err != nil {
 		t.Fatal("failed to run program:", err)
 	}

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -1,7 +1,6 @@
 package hivesim
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http/httptest"
@@ -211,10 +210,10 @@ func TestStartClientStartOptions(t *testing.T) {
 func TestRunProgram(t *testing.T) {
 	// Set up the backend to return program execution. Simple debug program here.
 	hooks := &fakes.BackendHooks{
-		RunProgram: func(containerID string, opt libhive.ExecOptions) (*libhive.ExecInfo, error) {
+		RunProgram: func(containerID string, cmd string) (*libhive.ExecInfo, error) {
 			return &libhive.ExecInfo{
-				StdOut:   fmt.Sprintf("user: %s, privileged: %v", opt.User, opt.Privileged),
-				StdErr:   "cmd: " + strings.Join(opt.Cmd, ","),
+				StdOut:   "out: " + cmd,
+				StdErr:   "err: " + cmd,
 				ExitCode: 42,
 			}, nil
 		},
@@ -240,20 +239,19 @@ func TestRunProgram(t *testing.T) {
 	}
 
 	// Run a program
-	stdOut, stdErr, code, err := sim.ClientRunProgram(
-		suiteID, testID, clientID, true, "ether", "echo this")
+	res, err := sim.ClientRunProgram(suiteID, testID, clientID, "echo this")
 	if err != nil {
 		t.Fatal("failed to run program:", err)
 	}
 
-	if want := "user: ether, privileged: true"; stdOut != want {
-		t.Fatalf("wrong std out %q\nwant %q", stdOut, want)
+	if want := "out: echo this"; res.StdOut != want {
+		t.Fatalf("wrong std out %q\nwant %q", res.StdOut, want)
 	}
-	if want := "cmd: echo this"; stdErr != want {
-		t.Fatalf("wrong std err %q\nwant %q", stdErr, want)
+	if want := "err: echo this"; res.StdErr != want {
+		t.Fatalf("wrong std err %q\nwant %q", res.StdErr, want)
 	}
-	if want := 42; code != want {
-		t.Fatalf("wrong code %q\nwant %q", code, want)
+	if want := 42; res.ExitCode != want {
+		t.Fatalf("wrong code %q\nwant %q", res.ExitCode, want)
 	}
 }
 

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -116,7 +116,7 @@ func (c *Client) RPC() *rpc.Client {
 }
 
 // Exec runs a script in the client container.
-func (c *Client) Exec(command string) (*ExecInfo, error) {
+func (c *Client) Exec(command ...string) (*ExecInfo, error) {
 	return c.test.Sim.ClientExec(c.test.SuiteID, c.test.TestID, c.Container, command)
 }
 

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -115,6 +115,11 @@ func (c *Client) RPC() *rpc.Client {
 	return c.rpc
 }
 
+// Exec runs a script in the client container.
+func (c *Client) Exec(command string) (*ExecInfo, error) {
+	return c.test.Sim.ClientExec(c.test.SuiteID, c.test.TestID, c.Container, command)
+}
+
 // T is a running test. This is a lot like testing.T, but has some additional methods for
 // launching clients.
 //

--- a/internal/fakes/backend.go
+++ b/internal/fakes/backend.go
@@ -15,7 +15,7 @@ type BackendHooks struct {
 	StartContainer  func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error)
 	DeleteContainer func(containerID string) error
 	RunEnodeSh      func(containerID string) (string, error)
-	RunProgram      func(containerID string, cmd string) (*libhive.ExecInfo, error)
+	RunProgram      func(containerID string, cmd []string) (*libhive.ExecInfo, error)
 
 	NetworkNameToID     func(string) (string, error)
 	CreateNetwork       func(string) (string, error)
@@ -92,7 +92,7 @@ func (b *fakeBackend) RunEnodeSh(ctx context.Context, containerID string) (strin
 	return "enode://a61215641fb8714a373c80edbfa0ea8878243193f57c96eeb44d0bc019ef295abd4e044fd619bfc4c59731a73fb79afe84e9ab6da0c743ceb479cbb6d263fa91@192.0.2.1:30303", nil
 }
 
-func (b *fakeBackend) RunProgram(ctx context.Context, containerID string, cmd string) (*libhive.ExecInfo, error) {
+func (b *fakeBackend) RunProgram(ctx context.Context, containerID string, cmd []string) (*libhive.ExecInfo, error) {
 	if b.hooks.RunProgram != nil {
 		return b.hooks.RunProgram(containerID, cmd)
 	}

--- a/internal/fakes/backend.go
+++ b/internal/fakes/backend.go
@@ -15,7 +15,7 @@ type BackendHooks struct {
 	StartContainer  func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error)
 	DeleteContainer func(containerID string) error
 	RunEnodeSh      func(containerID string) (string, error)
-	RunProgram      func(containerID string, opt libhive.ExecOptions) (*libhive.ExecInfo, error)
+	RunProgram      func(containerID string, cmd string) (*libhive.ExecInfo, error)
 
 	NetworkNameToID     func(string) (string, error)
 	CreateNetwork       func(string) (string, error)
@@ -92,10 +92,9 @@ func (b *fakeBackend) RunEnodeSh(ctx context.Context, containerID string) (strin
 	return "enode://a61215641fb8714a373c80edbfa0ea8878243193f57c96eeb44d0bc019ef295abd4e044fd619bfc4c59731a73fb79afe84e9ab6da0c743ceb479cbb6d263fa91@192.0.2.1:30303", nil
 }
 
-func (b *fakeBackend) RunProgram(ctx context.Context, containerID string,
-	opt libhive.ExecOptions) (*libhive.ExecInfo, error) {
+func (b *fakeBackend) RunProgram(ctx context.Context, containerID string, cmd string) (*libhive.ExecInfo, error) {
 	if b.hooks.RunProgram != nil {
-		return b.hooks.RunProgram(containerID, opt)
+		return b.hooks.RunProgram(containerID, cmd)
 	}
 	return &libhive.ExecInfo{StdOut: "std output", StdErr: "std err", ExitCode: 0}, nil
 }

--- a/internal/fakes/backend.go
+++ b/internal/fakes/backend.go
@@ -15,6 +15,7 @@ type BackendHooks struct {
 	StartContainer  func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error)
 	DeleteContainer func(containerID string) error
 	RunEnodeSh      func(containerID string) (string, error)
+	RunProgram      func(containerID string, opt libhive.ExecOptions) (*libhive.ExecInfo, error)
 
 	NetworkNameToID     func(string) (string, error)
 	CreateNetwork       func(string) (string, error)
@@ -89,6 +90,14 @@ func (b *fakeBackend) RunEnodeSh(ctx context.Context, containerID string) (strin
 		return b.hooks.RunEnodeSh(containerID)
 	}
 	return "enode://a61215641fb8714a373c80edbfa0ea8878243193f57c96eeb44d0bc019ef295abd4e044fd619bfc4c59731a73fb79afe84e9ab6da0c743ceb479cbb6d263fa91@192.0.2.1:30303", nil
+}
+
+func (b *fakeBackend) RunProgram(ctx context.Context, containerID string,
+	opt libhive.ExecOptions) (*libhive.ExecInfo, error) {
+	if b.hooks.RunProgram != nil {
+		return b.hooks.RunProgram(containerID, opt)
+	}
+	return &libhive.ExecInfo{StdOut: "std output", StdErr: "std err", ExitCode: 0}, nil
 }
 
 func (b *fakeBackend) NetworkNameToID(name string) (string, error) {

--- a/internal/fakes/backend.go
+++ b/internal/fakes/backend.go
@@ -96,7 +96,7 @@ func (b *fakeBackend) RunProgram(ctx context.Context, containerID string, cmd st
 	if b.hooks.RunProgram != nil {
 		return b.hooks.RunProgram(containerID, cmd)
 	}
-	return &libhive.ExecInfo{StdOut: "std output", StdErr: "std err", ExitCode: 0}, nil
+	return &libhive.ExecInfo{Stdout: "std output", Stderr: "std err", ExitCode: 0}, nil
 }
 
 func (b *fakeBackend) NetworkNameToID(name string) (string, error) {

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -57,6 +58,47 @@ func (b *ContainerBackend) RunEnodeSh(ctx context.Context, containerID string) (
 		return "", fmt.Errorf("can't run enode.sh in %s: %v", containerID, err)
 	}
 	return outputBuf.String(), nil
+}
+
+func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string,
+	opt libhive.ExecOptions) (*libhive.ExecInfo, error) {
+	exec, err := b.client.CreateExec(docker.CreateExecOptions{
+		Context:      ctx,
+		AttachStdout: true,
+		AttachStderr: true,
+		Tty:          false,
+		Privileged:   opt.Privileged,
+		Cmd:          opt.Cmd,
+		User:         opt.User,
+		Container:    containerID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't create '%s' exec in %s: %v",
+			strings.Join(opt.Cmd, " "), containerID, err)
+	}
+	outputBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	err = b.client.StartExec(exec.ID, docker.StartExecOptions{
+		Context:      ctx,
+		Detach:       false,
+		OutputStream: outputBuf,
+		ErrorStream:  errBuf,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't run '%s' in %s: %v",
+			strings.Join(opt.Cmd, " "), containerID, err)
+	}
+	insp, err := b.client.InspectExec(exec.ID)
+	if err != nil {
+		return nil, fmt.Errorf("can't check execution result of '%s' in '%s': %v",
+			strings.Join(opt.Cmd, " "), containerID, err)
+	}
+
+	return &libhive.ExecInfo{
+		StdOut:   outputBuf.String(),
+		StdErr:   errBuf.String(),
+		ExitCode: insp.ExitCode,
+	}, nil
 }
 
 // CreateContainer creates a docker container.

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -60,21 +59,17 @@ func (b *ContainerBackend) RunEnodeSh(ctx context.Context, containerID string) (
 	return outputBuf.String(), nil
 }
 
-func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string,
-	opt libhive.ExecOptions) (*libhive.ExecInfo, error) {
+func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string, cmd string) (*libhive.ExecInfo, error) {
 	exec, err := b.client.CreateExec(docker.CreateExecOptions{
 		Context:      ctx,
 		AttachStdout: true,
 		AttachStderr: true,
 		Tty:          false,
-		Privileged:   opt.Privileged,
-		Cmd:          opt.Cmd,
-		User:         opt.User,
+		Cmd:          []string{cmd},
 		Container:    containerID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("can't create '%s' exec in %s: %v",
-			strings.Join(opt.Cmd, " "), containerID, err)
+		return nil, fmt.Errorf("can't create '%s' exec in %s: %v", cmd, containerID, err)
 	}
 	outputBuf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -85,13 +80,11 @@ func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string,
 		ErrorStream:  errBuf,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("can't run '%s' in %s: %v",
-			strings.Join(opt.Cmd, " "), containerID, err)
+		return nil, fmt.Errorf("can't run '%s' in %s: %v", cmd, containerID, err)
 	}
 	insp, err := b.client.InspectExec(exec.ID)
 	if err != nil {
-		return nil, fmt.Errorf("can't check execution result of '%s' in '%s': %v",
-			strings.Join(opt.Cmd, " "), containerID, err)
+		return nil, fmt.Errorf("can't check execution result of '%s' in '%s': %v", cmd, containerID, err)
 	}
 
 	return &libhive.ExecInfo{

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -59,17 +59,17 @@ func (b *ContainerBackend) RunEnodeSh(ctx context.Context, containerID string) (
 	return outputBuf.String(), nil
 }
 
-func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string, cmd string) (*libhive.ExecInfo, error) {
+func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string, cmd []string) (*libhive.ExecInfo, error) {
 	exec, err := b.client.CreateExec(docker.CreateExecOptions{
 		Context:      ctx,
 		AttachStdout: true,
 		AttachStderr: true,
 		Tty:          false,
-		Cmd:          []string{cmd},
+		Cmd:          cmd,
 		Container:    containerID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("can't create '%s' exec in %s: %v", cmd, containerID, err)
+		return nil, fmt.Errorf("can't create exec %v: %v", cmd, err)
 	}
 	outputBuf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -80,11 +80,11 @@ func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string, c
 		ErrorStream:  errBuf,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("can't run '%s' in %s: %v", cmd, containerID, err)
+		return nil, fmt.Errorf("can't run exec %v: %v", cmd, err)
 	}
 	insp, err := b.client.InspectExec(exec.ID)
 	if err != nil {
-		return nil, fmt.Errorf("can't check execution result of '%s' in '%s': %v", cmd, containerID, err)
+		return nil, fmt.Errorf("can't check execution result of %v: %v", cmd, err)
 	}
 
 	return &libhive.ExecInfo{

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -88,8 +88,8 @@ func (b *ContainerBackend) RunProgram(ctx context.Context, containerID string, c
 	}
 
 	return &libhive.ExecInfo{
-		StdOut:   outputBuf.String(),
-		StdErr:   errBuf.String(),
+		Stdout:   outputBuf.String(),
+		Stderr:   errBuf.String(),
 		ExitCode: insp.ExitCode,
 	}, nil
 }

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -33,6 +33,7 @@ func newSimulationAPI(b ContainerBackend, env SimEnv, tm *TestManager) http.Hand
 	// API routes.
 	router := mux.NewRouter()
 	router.HandleFunc("/clients", api.getClientTypes).Methods("GET")
+	router.HandleFunc("/testsuite/{suite}/test/{test}/node/{node}/exec", api.execInClient).Methods("POST")
 	router.HandleFunc("/testsuite/{suite}/test/{test}/node/{node}", api.getEnodeURL).Methods("GET")
 	router.HandleFunc("/testsuite/{suite}/test/{test}/node", api.startClient).Methods("POST")
 	router.HandleFunc("/testsuite/{suite}/test/{test}/node/{node}", api.stopClient).Methods("DELETE")
@@ -363,6 +364,49 @@ func (api *simAPI) getEnodeURL(w http.ResponseWriter, r *http.Request) {
 	// This is required because the client usually doesn't know its own IP.
 	fixedIP := enode.NewV4(n.Pubkey(), net.ParseIP(nodeInfo.IP), tcpPort, udpPort)
 	io.WriteString(w, fixedIP.URLv4())
+}
+
+type execInfo struct {
+	StdOut   string `json:"out"`
+	StdErr   string `json:"err"`
+	ExitCode int    `json:"code"`
+}
+
+func (api *simAPI) execInClient(w http.ResponseWriter, r *http.Request) {
+	suiteID, testID, err := api.requestSuiteAndTest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	node := mux.Vars(r)["node"]
+	nodeInfo, err := api.tm.GetNodeInfo(suiteID, testID, node)
+	if err != nil {
+		log15.Error("API: can't find node", "node", node, "error", err)
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	q := r.URL.Query()
+	cmdStr := q.Get("cmd")
+	if cmdStr == "" {
+		log15.Error("API: no program cmd specified", "node", node, "error", err)
+		http.Error(w, "no program cmd specified", http.StatusBadRequest)
+		return
+	}
+	inf, err := api.backend.RunProgram(r.Context(), nodeInfo.ID, ExecOptions{
+		Privileged: q.Get("privileged") == "true",
+		User:       q.Get("user"),
+		Cmd:        []string{cmdStr},
+	})
+	if err != nil {
+		log15.Error("API: error running program", "node", node, "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	out := execInfo{inf.StdOut, inf.StdErr, inf.ExitCode}
+	if err := json.NewEncoder(w).Encode(&out); err != nil {
+		log15.Error("API: failed to write output of running program", "node", node, "error", err)
+		return
+	}
 }
 
 // networkCreate creates a docker network.

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -66,12 +67,14 @@ func (api *simAPI) getClientTypes(w http.ResponseWriter, r *http.Request) {
 		for _, def := range api.env.Definitions {
 			clients = append(clients, def)
 		}
+		sort.Slice(clients, func(i, j int) bool { return clients[i].Name < clients[j].Name })
 		json.NewEncoder(w).Encode(clients)
 	} else {
 		clients := make([]string, 0, len(api.env.Definitions))
 		for name := range api.env.Definitions {
 			clients = append(clients, name)
 		}
+		sort.Strings(clients)
 		json.NewEncoder(w).Encode(clients)
 	}
 }

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -392,11 +392,7 @@ func (api *simAPI) execInClient(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no program cmd specified", http.StatusBadRequest)
 		return
 	}
-	inf, err := api.backend.RunProgram(r.Context(), nodeInfo.ID, ExecOptions{
-		Privileged: q.Get("privileged") == "true",
-		User:       q.Get("user"),
-		Cmd:        []string{cmdStr},
-	})
+	inf, err := api.backend.RunProgram(r.Context(), nodeInfo.ID, cmdStr)
 	if err != nil {
 		log15.Error("API: error running program", "node", node, "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -366,12 +366,6 @@ func (api *simAPI) getEnodeURL(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, fixedIP.URLv4())
 }
 
-type execInfo struct {
-	StdOut   string `json:"out"`
-	StdErr   string `json:"err"`
-	ExitCode int    `json:"code"`
-}
-
 func (api *simAPI) execInClient(w http.ResponseWriter, r *http.Request) {
 	suiteID, testID, err := api.requestSuiteAndTest(r)
 	if err != nil {
@@ -398,8 +392,7 @@ func (api *simAPI) execInClient(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	out := execInfo{inf.StdOut, inf.StdErr, inf.ExitCode}
-	if err := json.NewEncoder(w).Encode(&out); err != nil {
+	if err := json.NewEncoder(w).Encode(&inf); err != nil {
 		log15.Error("API: failed to write output of running program", "node", node, "error", err)
 		return
 	}

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -56,3 +56,10 @@ type ClientInfo struct {
 
 	wait func()
 }
+
+// ExecInfo is the result of running a script in a client container.
+type ExecInfo struct {
+	Stdout   string `json:"out"`
+	Stderr   string `json:"err"`
+	ExitCode int    `json:"code"`
+}

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -59,7 +59,7 @@ type ClientInfo struct {
 
 // ExecInfo is the result of running a script in a client container.
 type ExecInfo struct {
-	Stdout   string `json:"out"`
-	Stderr   string `json:"err"`
-	ExitCode int    `json:"code"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int    `json:"exitCode"`
 }

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -32,16 +32,6 @@ type ContainerBackend interface {
 // This error is returned by NetworkNameToID if a docker network is not present.
 var ErrNetworkNotFound = fmt.Errorf("network not found")
 
-// ExecInfo is returned by RunProgram
-type ExecInfo struct {
-	// The std-out output of the program execution
-	StdOut string
-	// The std-err output of the program execution
-	StdErr string
-	// The exit code of the execution
-	ExitCode int
-}
-
 // ContainerOptions contains the launch parameters for docker containers.
 type ContainerOptions struct {
 	// These options apply when creating the container.

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -17,6 +17,9 @@ type ContainerBackend interface {
 	// RunEnodeSh runs the /enode.sh script in the given container and returns its output.
 	RunEnodeSh(ctx context.Context, containerID string) (string, error)
 
+	// RunProgram runs a command in the given container and returns its outputs and exit code.
+	RunProgram(ctx context.Context, containerID string, opt ExecOptions) (*ExecInfo, error)
+
 	// These methods configure docker networks.
 	NetworkNameToID(name string) (string, error)
 	CreateNetwork(name string) (string, error)
@@ -28,6 +31,26 @@ type ContainerBackend interface {
 
 // This error is returned by NetworkNameToID if a docker network is not present.
 var ErrNetworkNotFound = fmt.Errorf("network not found")
+
+// ExecOptions contains the command and settings for executing a command in a running container
+type ExecOptions struct {
+	// Boolean value, runs the exec process with extended privileges.
+	Privileged bool
+	// A string value specifying the user, and optionally, group to run the exec process inside the container. Format is one of: "user", "user:group", "uid", or "uid:gid".
+	User string
+	// Command to run specified as a string or an array of strings.
+	Cmd []string
+}
+
+// ExecInfo is returned by RunProgram
+type ExecInfo struct {
+	// The std-out output of the program execution
+	StdOut string
+	// The std-err output of the program execution
+	StdErr string
+	// The exit code of the execution
+	ExitCode int
+}
 
 // ContainerOptions contains the launch parameters for docker containers.
 type ContainerOptions struct {

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -18,7 +18,7 @@ type ContainerBackend interface {
 	RunEnodeSh(ctx context.Context, containerID string) (string, error)
 
 	// RunProgram runs a command in the given container and returns its outputs and exit code.
-	RunProgram(ctx context.Context, containerID string, opt ExecOptions) (*ExecInfo, error)
+	RunProgram(ctx context.Context, containerID string, cmd string) (*ExecInfo, error)
 
 	// These methods configure docker networks.
 	NetworkNameToID(name string) (string, error)
@@ -31,16 +31,6 @@ type ContainerBackend interface {
 
 // This error is returned by NetworkNameToID if a docker network is not present.
 var ErrNetworkNotFound = fmt.Errorf("network not found")
-
-// ExecOptions contains the command and settings for executing a command in a running container
-type ExecOptions struct {
-	// Boolean value, runs the exec process with extended privileges.
-	Privileged bool
-	// A string value specifying the user, and optionally, group to run the exec process inside the container. Format is one of: "user", "user:group", "uid", or "uid:gid".
-	User string
-	// Command to run specified as a string or an array of strings.
-	Cmd []string
-}
 
 // ExecInfo is returned by RunProgram
 type ExecInfo struct {

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -18,7 +18,7 @@ type ContainerBackend interface {
 	RunEnodeSh(ctx context.Context, containerID string) (string, error)
 
 	// RunProgram runs a command in the given container and returns its outputs and exit code.
-	RunProgram(ctx context.Context, containerID string, cmd string) (*ExecInfo, error)
+	RunProgram(ctx context.Context, containerID string, cmdline []string) (*ExecInfo, error)
 
 	// These methods configure docker networks.
 	NetworkNameToID(name string) (string, error)


### PR DESCRIPTION
Changes:
- ClientRunProgram in hivesim can run a command in a container
- Hive API endpoint to run program in node
- Test backend implements basic mock + hook
- Test to see API work

This is a first attempt to generalize the "enode.sh" functionality (idea from earlier discussion with @fjl).
It misses the scope limit to `/hive-bin/<program>` still, I didn't find a clean way to limit the command (especially if it's shell code).

TODO The API is tested, but the docker backend implementation is not.

This helps:
- Run more advanced eth2 tests, e.g. stop validator, export keystores and slashing DB out of a container, then start again. (and import it into another validator). E.g. `/hive-bin/export-keys.sh`
- Connect eth2 clients. Eth2 nodes don't have an enode-url formatted address, and the beacon API address also needs to be communicated. We can put a `/hive-bin/multiaddr.sh`, `/hive-bin/`
