### PR TITLE
internal/libhive: fix double delete of failed client container

### DIFF
--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -118,6 +118,8 @@ func (b *ContainerBackend) StartContainer(ctx context.Context, containerID strin
 	if err != nil {
 		waiter.Close()
 		b.DeleteContainer(containerID)
+		info.Wait()
+		info.Wait = nil
 		return info, err
 	}
 	info.IP = container.NetworkSettings.IPAddress
@@ -144,9 +146,10 @@ func (b *ContainerBackend) StartContainer(ctx context.Context, containerID strin
 	case <-ctx.Done():
 		checkErr = errors.New("timed out waiting for container startup")
 	}
-
 	if checkErr != nil {
 		b.DeleteContainer(containerID)
+		info.Wait()
+		info.Wait = nil
 	}
 	return info, checkErr
 }

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -298,19 +298,13 @@ func (api *simAPI) stopClient(w http.ResponseWriter, r *http.Request) {
 	}
 	node := mux.Vars(r)["node"]
 
-	// Get the node.
-	nodeInfo, err := api.tm.GetNodeInfo(suiteID, testID, node)
-	if err != nil {
+	err := api.tm.StopNode(suiteID, testID, node)
+	if err == ErrNoSuchNode {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
-	}
-	// Stop the container.
-	if err = api.backend.DeleteContainer(nodeInfo.ID); err != nil {
-		msg := fmt.Sprintf("unable to stop client: %v", err)
-		http.Error(w, msg, http.StatusInternalServerError)
-	}
-	if nodeInfo.wait != nil {
-		nodeInfo.wait()
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -291,14 +291,14 @@ func (api *simAPI) checkClient(r *http.Request, w http.ResponseWriter) (string, 
 
 // stopClient terminates a client container.
 func (api *simAPI) stopClient(w http.ResponseWriter, r *http.Request) {
-	suiteID, testID, err := api.requestSuiteAndTest(r)
+	_, testID, err := api.requestSuiteAndTest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	node := mux.Vars(r)["node"]
 
-	err := api.tm.StopNode(suiteID, testID, node)
+	err = api.tm.StopNode(testID, node)
 	if err == ErrNoSuchNode {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -446,21 +446,21 @@ func (manager *TestManager) RegisterNode(testID TestID, nodeID string, nodeInfo 
 }
 
 // StopNode stops a client container.
-func (manager *TestManager) StopNode(suiteID SuiteID, testID TestID, nodeID string) error {
+func (manager *TestManager) StopNode(testID TestID, nodeID string) error {
 	manager.testCaseMutex.Lock()
 	defer manager.testCaseMutex.Unlock()
 
-	testCase, ok := manager.runningTestCases[test]
+	testCase, ok := manager.runningTestCases[testID]
 	if !ok {
-		return nil, ErrNoSuchNode
+		return ErrNoSuchNode
 	}
 	nodeInfo, ok := testCase.ClientInfo[nodeID]
 	if !ok {
-		return nil, ErrNoSuchNode
+		return ErrNoSuchNode
 	}
 	// Stop the container.
 	if nodeInfo.wait != nil {
-		if err = manager.backend.DeleteContainer(nodeInfo.ID); err != nil {
+		if err := manager.backend.DeleteContainer(nodeInfo.ID); err != nil {
 			return fmt.Errorf("unable to stop client: %v", err)
 		}
 		nodeInfo.wait()


### PR DESCRIPTION
This restructures things a bit so that `DeleteContainer` will be called exactly once for every client container. This avoids error messages in libdocker saying that deleting the container failed.