### PR TITLE
clients/go-ethereum: set yolov3Block in chain config

### DIFF
--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -50,5 +50,6 @@ def to_bool:
     "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
     "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
     "yolov2Block": env.HIVE_FORK_BERLIN|to_int,
+    "yolov3Block": env.HIVE_FORK_BERLIN|to_int,
   }|remove_empty
 }


### PR DESCRIPTION
This should unbreak the Berlin consensus tests with geth.