### PR TITLE
hivesim: StartOption for client configuration

### DIFF
--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -17,6 +17,15 @@ type TestResult struct {
 // a global variable and then customize them for specific clients.
 type Params map[string]string
 
+var _ StartOption = (Params)(nil)
+
+// Apply adds the Params to the environment of a client start, making Params a StartOption.
+func (p Params) Apply(setup *clientSetup) {
+	for k, v := range p {
+		setup.parameters[k] = v
+	}
+}
+
 // Set returns a copy of the parameters with 'key' set to 'value'.
 func (p Params) Set(key, value string) Params {
 	cpy := p.Copy()

--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -19,7 +19,7 @@ type Params map[string]string
 
 var _ StartOption = (Params)(nil)
 
-// Apply adds the Params to the environment of a client start, making Params a StartOption.
+// Apply implements StartOption.
 func (p Params) Apply(setup *clientSetup) {
 	for k, v := range p {
 		setup.parameters[k] = v

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -264,6 +264,15 @@ func (fn StartOptionFn) Apply(setup *clientSetup) {
 	fn(setup)
 }
 
+// Bundle combines start options, e.g. to bundle files together as option.
+func Bundle(option ...StartOption) StartOption {
+	return StartOptionFn(func(setup *clientSetup) {
+		for _, opt := range option {
+			opt.Apply(setup)
+		}
+	})
+}
+
 func fileAsSrc(path string) func() (io.ReadCloser, error) {
 	return func() (io.ReadCloser, error) {
 		return os.Open(path)

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -3,6 +3,7 @@ package hivesim
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -141,7 +143,25 @@ func (sim *Simulation) ClientTypes() (availableClients []*ClientDefinition, err 
 // GetClientTypes. The input is used as environment variables in the new container.
 // Returns container id and ip.
 func (sim *Simulation) StartClient(testSuite SuiteID, test TestID, parameters map[string]string, initFiles map[string]string) (string, net.IP, error) {
-	data, err := postWithFiles(fmt.Sprintf("%s/testsuite/%d/test/%d/node", sim.url, testSuite, test), parameters, initFiles)
+	clientType, ok := parameters["CLIENT"]
+	if !ok {
+		return "", nil, errors.New("missing 'CLIENT' parameter")
+	}
+	return sim.StartClientWithOptions(testSuite, test, clientType, Params(parameters), WithStaticFiles(initFiles))
+}
+
+// StartClientWithOptions starts a new node (or other container) with specified options.
+// Returns container id and ip.
+func (sim *Simulation) StartClientWithOptions(testSuite SuiteID, test TestID, clientType string, options ...StartOption) (string, net.IP, error) {
+	setup := &clientSetup{
+		parameters: make(map[string]string),
+		files:      make(map[string]func() (io.ReadCloser, error)),
+	}
+	setup.parameters["CLIENT"] = clientType
+	for _, opt := range options {
+		opt.Apply(setup)
+	}
+	data, err := setup.postWithFiles(fmt.Sprintf("%s/testsuite/%d/test/%d/node", sim.url, testSuite, test))
 	if err != nil {
 		return "", nil, err
 	}
@@ -227,20 +247,62 @@ func (sim *Simulation) ContainerNetworkIP(testSuite SuiteID, network, containerI
 	return string(body), nil
 }
 
-func postWithFiles(url string, values map[string]string, files map[string]string) (string, error) {
+// collects client setup options
+type clientSetup struct {
+	parameters map[string]string
+	// destination path -> open data function
+	files map[string]func() (io.ReadCloser, error)
+}
+
+type StartOption interface {
+	Apply(setup *clientSetup)
+}
+
+type StartOptionFn func(setup *clientSetup)
+
+func (fn StartOptionFn) Apply(setup *clientSetup) {
+	fn(setup)
+}
+
+func fileAsSrc(path string) func() (io.ReadCloser, error) {
+	return func() (io.ReadCloser, error) {
+		return os.Open(path)
+	}
+}
+
+// WithStaticFiles adds files from the local filesystem to the client. Map: destination file path -> source file path.
+func WithStaticFiles(initFiles map[string]string) StartOption {
+	return StartOptionFn(func(setup *clientSetup) {
+		for k, v := range initFiles {
+			setup.files[k] = fileAsSrc(v)
+		}
+	})
+}
+
+// WithDynamicFile adds a file to a client, sourced dynamically from the given src function,
+// called upon usage of the returned StartOption.
+//
+// A StartOption, and thus the src function, should be reusable and safe to use in parallel.
+// Dynamic files can override static file sources (see WithStaticFiles) and vice-versa.
+func WithDynamicFile(dstPath string, src func() (io.ReadCloser, error)) StartOption {
+	return StartOptionFn(func(setup *clientSetup) {
+		setup.files[dstPath] = src
+	})
+}
+
+func (setup *clientSetup) postWithFiles(url string) (string, error) {
 	var err error
 
 	// make a dictionary of readers
 	formValues := make(map[string]io.Reader)
-	for key, s := range values {
+	for key, s := range setup.parameters {
 		formValues[key] = strings.NewReader(s)
 	}
-	for key, filename := range files {
-		filereader, err := os.Open(filename)
+	for key, src := range setup.files {
+		filereader, err := src()
 		if err != nil {
 			return "", err
 		}
-		//fi, err := filereader.Stat()
 		formValues[key] = filereader
 	}
 
@@ -252,8 +314,8 @@ func postWithFiles(url string, values map[string]string, files map[string]string
 		if x, ok := r.(io.Closer); ok {
 			defer x.Close()
 		}
-		if x, ok := r.(*os.File); ok {
-			if fw, err = w.CreateFormFile(key, x.Name()); err != nil {
+		if _, ok := setup.files[key]; ok {
+			if fw, err = w.CreateFormFile(key, filepath.Base(key)); err != nil {
 				return "", err
 			}
 		} else {

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -105,6 +105,21 @@ func TestStartClientStartOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("bundle_options", func(t *testing.T) {
+		// Params with overrides
+		_, _, err = sim.StartClientWithOptions(suiteID, testID, "client-1",
+			Bundle(Params{"HIVE_FOO": "1"}, Params{"HIVE_BAR": "2"}))
+		if err != nil {
+			t.Fatalf("failed to start client: %v", err)
+		}
+		if got := lastOptions.Env["HIVE_FOO"]; got != "1" {
+			t.Fatalf("wrong HIVE_FOO, got: %s", got)
+		}
+		if got := lastOptions.Env["HIVE_BAR"]; got != "2" {
+			t.Fatalf("wrong HIVE_BAR, got: %s", got)
+		}
+	})
+
 	t.Run("params_options", func(t *testing.T) {
 		// Params with overrides
 		_, _, err = sim.StartClientWithOptions(suiteID, testID, "client-1",

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -1,7 +1,10 @@
 package hivesim
 
 import (
+	"io"
+	"io/ioutil"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -70,6 +73,121 @@ func TestEnodeReplaceIP(t *testing.T) {
 	if url != want {
 		t.Fatalf("wrong enode URL %q\nwant %q", url, want)
 	}
+}
+
+// This test checks the usage of common client start options.
+func TestStartClientStartOptions(t *testing.T) {
+	var lastOptions libhive.ContainerOptions
+	tm, srv := newFakeAPI(&fakes.BackendHooks{
+		StartContainer: func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
+			lastOptions = opt
+			return &libhive.ContainerInfo{}, nil
+		},
+	})
+	defer srv.Close()
+	defer tm.Terminate()
+
+	sim := NewAt(srv.URL)
+	suiteID, err := sim.StartSuite("suite", "", "")
+	if err != nil {
+		t.Fatal("can't start suite:", err)
+	}
+	testID, err := sim.StartTest(suiteID, "test", "")
+	if err != nil {
+		t.Fatal("can't start test:", err)
+	}
+
+	t.Run("empty_options", func(t *testing.T) {
+		// Empty options
+		_, _, err = sim.StartClientWithOptions(suiteID, testID, "client-2")
+		if err != nil {
+			t.Fatalf("failed to start client without any options: %v", err)
+		}
+	})
+
+	t.Run("params_options", func(t *testing.T) {
+		// Params with overrides
+		_, _, err = sim.StartClientWithOptions(suiteID, testID, "client-1",
+			Params{"HIVE_FOO": "1", "HIVE_BAR": "2"}, Params{"HIVE_FOO": "3"})
+		if err != nil {
+			t.Fatalf("failed to start client: %v", err)
+		}
+		if got := lastOptions.Env["HIVE_FOO"]; got != "3" {
+			t.Fatalf("2nd option failed to overwrite param of 1st option, got: %s", got)
+		}
+		if got := lastOptions.Env["HIVE_BAR"]; got != "2" {
+			t.Fatalf("non-overwritten option changed or went missing, got: %s", got)
+		}
+	})
+
+	t.Run("files_options", func(t *testing.T) {
+		file1, err := ioutil.TempFile("", "hivesim_test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file1.WriteString("aaa"); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file1.Name())
+
+		file2, err := ioutil.TempFile("", "hivesim_test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file2.WriteString("bb"); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file2.Name())
+
+		t.Run("static", func(t *testing.T) {
+			// Static files with override of /data/foo
+			_, _, err = sim.StartClientWithOptions(suiteID, testID, "client-1",
+				WithStaticFiles(map[string]string{"/data/foo": "/tmp/bad", "foo": file1.Name()}),
+				WithStaticFiles(map[string]string{"/data/foo": file2.Name()}))
+			if err != nil {
+				t.Fatalf("failed to start client: %v", err)
+			}
+			got, ok := lastOptions.Files["/data/foo"]
+			if !ok {
+				t.Fatal("missing /data/foo")
+			}
+			if got.Size != 2 {
+				t.Fatalf("expected 2 bytes for '/data/foo', got: %d", got.Size)
+			}
+			got, ok = lastOptions.Files["foo"]
+			if !ok {
+				t.Fatal("missing foo") // same file name as /data/foo, but no path, thus different.
+			}
+			if got.Size != 3 {
+				t.Fatalf("expected 3 bytes for 'foo', got: %d", got.Size)
+			}
+		})
+
+		mockSrc := func(content string) func() (io.ReadCloser, error) {
+			return func() (io.ReadCloser, error) { return ioutil.NopCloser(strings.NewReader(content)), nil }
+		}
+
+		t.Run("dynamic", func(t *testing.T) {
+			// Dynamic files with override of /data/bar, and override static file too.
+			_, _, err = sim.StartClientWithOptions(suiteID, testID, "client-1",
+				WithDynamicFile("/data/bar", func() (io.ReadCloser, error) {
+					t.Fatal("this should have been overridden")
+					return nil, nil
+				}),
+				WithStaticFiles(map[string]string{"/data/bar": file1.Name()}),
+				WithDynamicFile("/data/bar", mockSrc("dddddd")))
+			if err != nil {
+				t.Fatalf("failed to start client: %v", err)
+			}
+			got, ok := lastOptions.Files["/data/bar"]
+			if !ok {
+				t.Fatal("missing /data/bar")
+			}
+			if got.Size != 6 {
+				t.Fatalf("expected 6 bytes for '/data/bar', got %d", got.Size)
+			}
+		})
+	})
 }
 
 // This test checks for some common errors returned by StartClient.

--- a/hivesim/options.go
+++ b/hivesim/options.go
@@ -1,0 +1,57 @@
+package hivesim
+
+import (
+	"io"
+	"os"
+)
+
+// clientSetup collects client options.
+type clientSetup struct {
+	parameters map[string]string
+	// destination path -> open data function
+	files map[string]func() (io.ReadCloser, error)
+}
+
+// StartOption is a parameter for starting a client.
+type StartOption interface {
+	Apply(setup *clientSetup)
+}
+
+type optionFunc func(setup *clientSetup)
+
+func (fn optionFunc) Apply(setup *clientSetup) { fn(setup) }
+
+func fileAsSrc(path string) func() (io.ReadCloser, error) {
+	return func() (io.ReadCloser, error) {
+		return os.Open(path)
+	}
+}
+
+// WithStaticFiles adds files from the local filesystem to the client. Map: destination file path -> source file path.
+func WithStaticFiles(initFiles map[string]string) StartOption {
+	return optionFunc(func(setup *clientSetup) {
+		for k, v := range initFiles {
+			setup.files[k] = fileAsSrc(v)
+		}
+	})
+}
+
+// WithDynamicFile adds a file to a client, sourced dynamically from the given src function,
+// called upon usage of the returned StartOption.
+//
+// A StartOption, and thus the src function, should be reusable and safe to use in parallel.
+// Dynamic files can override static file sources (see WithStaticFiles) and vice-versa.
+func WithDynamicFile(dstPath string, src func() (io.ReadCloser, error)) StartOption {
+	return optionFunc(func(setup *clientSetup) {
+		setup.files[dstPath] = src
+	})
+}
+
+// Bundle combines start options, e.g. to bundle files together as option.
+func Bundle(option ...StartOption) StartOption {
+	return optionFunc(func(setup *clientSetup) {
+		for _, opt := range option {
+			opt.Apply(setup)
+		}
+	})
+}

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -138,6 +138,14 @@ func (t *T) StartClient(clientType string, parameters Params, files map[string]s
 	return &Client{Type: clientType, Container: container, IP: ip, test: t}
 }
 
+func (t *T) StartClientWithOptions(clientType string, option ...StartOption) *Client {
+	container, ip, err := t.Sim.StartClientWithOptions(t.SuiteID, t.TestID, clientType, option...)
+	if err != nil {
+		t.Fatalf("can't launch node (type %s): %v", clientType, err)
+	}
+	return &Client{Type: clientType, Container: container, IP: ip, test: t}
+}
+
 // RunClient runs the given client test against a single client type.
 // It waits for the subtest to complete.
 func (t *T) RunClient(clientType string, spec ClientTestSpec) {

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -128,17 +128,8 @@ type T struct {
 	result  TestResult
 }
 
-// StartClient starts a client. If the client cannot by started, the test fails immediately.
-func (t *T) StartClient(clientType string, parameters Params, files map[string]string) *Client {
-	params := parameters.Set("CLIENT", clientType)
-	container, ip, err := t.Sim.StartClient(t.SuiteID, t.TestID, params, files)
-	if err != nil {
-		t.Fatalf("can't launch node (type %s): %v", clientType, err)
-	}
-	return &Client{Type: clientType, Container: container, IP: ip, test: t}
-}
-
-func (t *T) StartClientWithOptions(clientType string, option ...StartOption) *Client {
+// StartClient starts a client instance. If the client cannot by started, the test fails immediately.
+func (t *T) StartClient(clientType string, option ...StartOption) *Client {
 	container, ip, err := t.Sim.StartClientWithOptions(t.SuiteID, t.TestID, clientType, option...)
 	if err != nil {
 		t.Fatalf("can't launch node (type %s): %v", clientType, err)
@@ -150,7 +141,7 @@ func (t *T) StartClientWithOptions(clientType string, option ...StartOption) *Cl
 // It waits for the subtest to complete.
 func (t *T) RunClient(clientType string, spec ClientTestSpec) {
 	runTest(t.Sim, t.SuiteID, spec.Name, spec.Description, func(t *T) {
-		client := t.StartClient(clientType, spec.Parameters, spec.Files)
+		client := t.StartClient(clientType, spec.Parameters, WithStaticFiles(spec.Files))
 		spec.Run(t, client)
 	})
 }
@@ -281,7 +272,7 @@ func (spec ClientTestSpec) runTest(host *Simulation, suite SuiteID) error {
 		}
 		name := clientTestName(spec.Name, clientDef.Name)
 		err := runTest(host, suite, name, spec.Description, func(t *T) {
-			client := t.StartClient(clientDef.Name, spec.Parameters, spec.Files)
+			client := t.StartClient(clientDef.Name, spec.Parameters, WithStaticFiles(spec.Files))
 			spec.Run(t, client)
 		})
 		if err != nil {

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -273,7 +273,7 @@ func (b *ContainerBackend) uploadFiles(ctx context.Context, id string, files map
 	// Create a tarball archive with all the data files
 	tarball := new(bytes.Buffer)
 	tw := tar.NewWriter(tarball)
-	for fileName, fileHeader := range files {
+	for filePath, fileHeader := range files {
 		// Fetch the next file to inject into the container
 		file, err := fileHeader.Open()
 		if err != nil {
@@ -287,7 +287,7 @@ func (b *ContainerBackend) uploadFiles(ctx context.Context, id string, files map
 		}
 		// Insert the file into the tarball archive
 		header := &tar.Header{
-			Name: fileName, //filepath.Base(fileHeader.Filename),
+			Name: filePath,
 			Mode: int64(0777),
 			Size: int64(len(data)),
 		}


### PR DESCRIPTION
TLDR: introduce Option pattern to client-start, to allow dynamic file sources, and easily extend/compose many options.

Changes:
- `Params` is a `StartOption`
- File options:
  - Static files can be added (defined as a `dst path -> src path` dict like before)
  - New: Dynamic files can be added (defined as a `dst path -> open function` dict)
- `StartOptionFn` to define minimal start options (the `setup` struct is usage is limited to the hivesim package). (should we hide this function type from public API?)
- `Bundle` options together to make test preparation easy. A 1000 keystore files to worry about? Bundle them. A repeated test with configuration files and parameters? Bundle them.
  - Replaces Tar file support to do multiple files like in previous draft.
- Parameters can override parameters, files can override files (dynamic and static are interchangeable), based on destination-path name.
- Test all start options, incl. static files (was not tested before)


TODO: defined `StartClientWithOptions` to not break `StartClient`, but it may just be worth the breaking change (won't ever break again, new options can be added in future thanks to Option pattern).


*This is part of a set of features for Eth2 and Eth1-Eth2-merge simulators.*