### PR TITLE
internal/libhive: client definitions, metadata file loading, client-roles

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -41,11 +41,27 @@ configurable in certain ways. In order to run tests against multiple Ethereum cl
 example, the simulator needs to be able to configure all clients for a specific blockchain
 and make them join the peer-to-peer network used for testing.
 
+## Client Metadata
+
+Metadata is used to express client differences. E.g. clients can have different roles
+within the Ethereum ecosystem, each of which can have different tests,
+some even capturing interactions between multiple roles.
+
+Client metadata is defined with a `hive.yaml` file in the client directory (next to the 
+`Dockerfile`). This optional, by default each client is assumed to only have an `eth1` role.
+
+The YAML fields are:
+```yaml
+roles: ["eth1", "example", "eth1_light_client"]  # a list of strings, applicable roles
+```
+
+This metadata is available through the `/clients` Hive endpoint.
+
 ## Eth1 Client Requirements
 
 This section describes the requirements for Ethereum 1.x client wrappers in hive. Client
 entry point scripts must support this interface in order to be tested by existing Ethereum
-1.x-specific simulators.
+1.x-specific simulators. The simulators require the `eth1` client role.
 
 Clients must provide JSON-RPC over HTTP on TCP port 8545. They may also support JSON-RPC
 over WebSocket on port 8546, but this is not strictly required.

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -44,13 +44,15 @@ and make them join the peer-to-peer network used for testing.
 ## Client Metadata
 
 Metadata is used to express client differences. E.g. clients can have different roles
-within the Ethereum ecosystem, each of which can have different tests,
-some even capturing interactions between multiple roles.
+within the Ethereum ecosystem, each of which can have different tests, some even capturing
+interactions between multiple roles.
 
-Client metadata is defined with a `hive.yaml` file in the client directory (next to the 
-`Dockerfile`). This optional, by default each client is assumed to only have an `eth1` role.
+Client metadata is defined with a `hive.yaml` file in the client directory (next to the
+`Dockerfile`). This optional, by default each client is assumed to only have an `eth1`
+role.
 
 The YAML fields are:
+
 ```yaml
 roles: ["eth1", "example", "eth1_light_client"]  # a list of strings, applicable roles
 ```

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -151,14 +151,18 @@ Response:
 
     GET /clients
 
-This returns a JSON array of client names available to the simulation run.
+This returns a JSON array of client definitions available to the simulation run.
+Clients have a `name`, `version`, and `meta` for metadata as defined in the [client interface documentation].
 
 Response
 
     200 OK
     content-type: application/json
 
-    ["go-ethereum","besu"]
+    [
+     {"name":"go-ethereum", "version":"Geth/v1.10.0-unstable-8e547eec-20210224/linux-amd64/go1.16", "meta": {"roles":["eth1"]}},
+     {"name": "besu", "version": "besu/v21.1.1-dev-f1c74ed2/linux-x86_64/oracle_openjdk-java-11", "meta": {"roles": ["eth1"]}}
+    ]
 
 #### Starting a client container
 

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -152,7 +152,8 @@ Response:
     GET /clients
 
 This returns a JSON array of client definitions available to the simulation run.
-Clients have a `name`, `version`, and `meta` for metadata as defined in the [client interface documentation].
+Clients have a `name`, `version`, and `meta` for metadata as defined
+in the [client interface documentation].
 
 Response
 
@@ -160,8 +161,24 @@ Response
     content-type: application/json
 
     [
-     {"name":"go-ethereum", "version":"Geth/v1.10.0-unstable-8e547eec-20210224/linux-amd64/go1.16", "meta": {"roles":["eth1"]}},
-     {"name": "besu", "version": "besu/v21.1.1-dev-f1c74ed2/linux-x86_64/oracle_openjdk-java-11", "meta": {"roles": ["eth1"]}}
+      {
+        "name": "go-ethereum",
+        "version": "Geth/v1.10.0-unstable-8e547eec-20210224/linux-amd64/go1.16",
+        "meta": {
+          "roles": [
+            "eth1"
+          ]
+        }
+      },
+      {
+        "name": "besu",
+        "version": "besu/v21.1.1-dev-f1c74ed2/linux-x86_64/oracle_openjdk-java-11",
+        "meta": {
+          "roles": [
+            "eth1"
+          ]
+        }
+      }
     ]
 
 #### Starting a client container

--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,5 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 	gopkg.in/inconshreveable/log15.v2 v2.0.0-20200109203555-b30bc20e4fd1
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -120,7 +120,7 @@ func (m *ClientDefinition) HasRole(role string) bool {
 // ClientTypes returns all client types available to this simulator run. This depends on
 // both the available client set and the command line filters.
 func (sim *Simulation) ClientTypes() (availableClients []*ClientDefinition, err error) {
-	resp, err := http.Get(fmt.Sprintf("%s/clients", sim.url))
+	resp, err := http.Get(fmt.Sprintf("%s/clients?metadata=1", sim.url))
 	if err != nil {
 		return nil, err
 	}

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -96,9 +96,21 @@ func (sim *Simulation) StartTest(testSuite SuiteID, name string, description str
 	return TestID(testID), nil
 }
 
+// ClientMetadata is part of the ClientDefinition and lists metadata
+type ClientMetadata struct {
+	Role string `yaml:"role" json:"role"`
+}
+
+// ClientDefinition is served by the /clients API endpoint to list the available clients
+type ClientDefinition struct {
+	Name    string         `json:"name"`
+	Version string         `json:"version"`
+	Meta    ClientMetadata `json:"meta"`
+}
+
 // ClientTypes returns all client types available to this simulator run. This depends on
 // both the available client set and the command line filters.
-func (sim *Simulation) ClientTypes() (availableClients []string, err error) {
+func (sim *Simulation) ClientTypes() (availableClients []*ClientDefinition, err error) {
 	resp, err := http.Get(fmt.Sprintf("%s/clients", sim.url))
 	if err != nil {
 		return nil, err

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -98,7 +98,7 @@ func (sim *Simulation) StartTest(testSuite SuiteID, name string, description str
 
 // ClientMetadata is part of the ClientDefinition and lists metadata
 type ClientMetadata struct {
-	Role string `yaml:"role" json:"role"`
+	Roles []string `yaml:"roles" json:"roles"`
 }
 
 // ClientDefinition is served by the /clients API endpoint to list the available clients
@@ -106,6 +106,15 @@ type ClientDefinition struct {
 	Name    string         `json:"name"`
 	Version string         `json:"version"`
 	Meta    ClientMetadata `json:"meta"`
+}
+
+func (m *ClientDefinition) HasRole(role string) bool {
+	for _, m := range m.Meta.Roles {
+		if m == role {
+			return true
+		}
+	}
+	return false
 }
 
 // ClientTypes returns all client types available to this simulator run. This depends on

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -23,9 +23,9 @@ func TestClientTypes(t *testing.T) {
 	}
 	if !reflect.DeepEqual(ctypes, []*ClientDefinition{
 		{Name: "client-1", Version: "client-1-version",
-			Meta: ClientMetadata{Role: "eth1"}},
+			Meta: ClientMetadata{Roles: []string{"eth1"}}},
 		{Name: "client-2", Version: "client-2-version",
-			Meta: ClientMetadata{Role: "beacon"}},
+			Meta: ClientMetadata{Roles: []string{"beacon"}}},
 	}) {
 		t.Fatal("wrong client types:", ctypes)
 	}
@@ -112,8 +112,8 @@ func TestStartClientErrors(t *testing.T) {
 func newFakeAPI(hooks *fakes.BackendHooks) (*libhive.TestManager, *httptest.Server) {
 	env := libhive.SimEnv{
 		Definitions: map[string]*libhive.ClientDefinition{
-			"client-1": {Name: "client-1", Image: "/ignored/in/api", Version: "client-1-version", Meta: libhive.ClientMetadata{Role: "eth1"}},
-			"client-2": {Name: "client-2", Image: "/not/exposed/", Version: "client-2-version", Meta: libhive.ClientMetadata{Role: "beacon"}},
+			"client-1": {Name: "client-1", Image: "/ignored/in/api", Version: "client-1-version", Meta: libhive.ClientMetadata{Roles: []string{"eth1"}}},
+			"client-2": {Name: "client-2", Image: "/not/exposed/", Version: "client-2-version", Meta: libhive.ClientMetadata{Roles: []string{"beacon"}}},
 		},
 	}
 	backend := fakes.NewContainerBackend(hooks)

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -21,7 +21,12 @@ func TestClientTypes(t *testing.T) {
 	if err != nil {
 		t.Fatal("can't get client types:", err)
 	}
-	if !reflect.DeepEqual(ctypes, []string{"client-1", "client-2"}) {
+	if !reflect.DeepEqual(ctypes, []*ClientDefinition{
+		{Name: "client-1", Version: "client-1-version",
+			Meta: ClientMetadata{Role: "eth1"}},
+		{Name: "client-2", Version: "client-2-version",
+			Meta: ClientMetadata{Role: "beacon"}},
+	}) {
 		t.Fatal("wrong client types:", ctypes)
 	}
 }
@@ -106,9 +111,9 @@ func TestStartClientErrors(t *testing.T) {
 
 func newFakeAPI(hooks *fakes.BackendHooks) (*libhive.TestManager, *httptest.Server) {
 	env := libhive.SimEnv{
-		Images: map[string]string{
-			"client-1": "client-1-image",
-			"client-2": "client-2-image",
+		Definitions: map[string]*libhive.ClientDefinition{
+			"client-1": {Name: "client-1", Image: "/ignored/in/api", Version: "client-1-version", Meta: libhive.ClientMetadata{Role: "eth1"}},
+			"client-2": {Name: "client-2", Image: "/not/exposed/", Version: "client-2-version", Meta: libhive.ClientMetadata{Role: "beacon"}},
 		},
 	}
 	backend := fakes.NewContainerBackend(hooks)

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -268,7 +268,7 @@ func (spec ClientTestSpec) runTest(host *Simulation, suite SuiteID) error {
 	for _, clientDef := range clients {
 		// 'role' is an optional filter, so eth1 tests, beacon node tests,
 		// validator tests, etc. can all live in harmony.
-		if meta := clientDef.Meta; spec.Role != "" && meta.Role != spec.Role {
+		if spec.Role != "" && !clientDef.HasRole(spec.Role) {
 			continue
 		}
 		name := clientTestName(spec.Name, clientDef.Name)

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -76,11 +76,13 @@ type TestSpec struct {
 // ClientTestSpec is a test against a single client. You can either put this in your suite
 // directly, or launch it using RunClient or RunAllClients from another test.
 //
-// When used as a test in a suite, the test runs against all available client types.
+// When used as a test in a suite, the test runs against all available client types,
+// with the specified Role. If no Role is specified, the test runs with all available clients.
 //
 // If the Name of the test includes "CLIENT", it is replaced by the client name being tested.
 type ClientTestSpec struct {
 	Name        string
+	Role        string
 	Description string
 	Parameters  Params
 	Files       map[string]string
@@ -145,7 +147,7 @@ func (t *T) RunClient(clientType string, spec ClientTestSpec) {
 	})
 }
 
-// RunAllClients runs the given client test against all available client type.
+// RunAllClients runs the given client test against all available client types.
 // It waits for all subtests to complete.
 func (t *T) RunAllClients(spec ClientTestSpec) {
 	spec.runTest(t.Sim, t.SuiteID)
@@ -263,10 +265,15 @@ func (spec ClientTestSpec) runTest(host *Simulation, suite SuiteID) error {
 	if err != nil {
 		return err
 	}
-	for _, clientType := range clients {
-		name := clientTestName(spec.Name, clientType)
+	for _, clientDef := range clients {
+		// 'role' is an optional filter, so eth1 tests, beacon node tests,
+		// validator tests, etc. can all live in harmony.
+		if meta := clientDef.Meta; spec.Role != "" && meta.Role != spec.Role {
+			continue
+		}
+		name := clientTestName(spec.Name, clientDef.Name)
 		err := runTest(host, suite, name, spec.Description, func(t *T) {
-			client := t.StartClient(clientType, spec.Parameters, spec.Files)
+			client := t.StartClient(clientDef.Name, spec.Parameters, spec.Files)
 			spec.Run(t, client)
 		})
 		if err != nil {

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -38,7 +38,7 @@ func (b *Builder) ReadClientMetadata(name string) (*libhive.ClientMetadata, erro
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Eth1 client by default.
-			return &libhive.ClientMetadata{Role: "eth1"}, nil
+			return &libhive.ClientMetadata{Roles: []string{"eth1"}}, nil
 		} else {
 			return nil, fmt.Errorf("failed to read hive metadata file in '%s': %v", dir, err)
 		}

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ethereum/hive/internal/libhive"
@@ -27,6 +29,26 @@ func NewBuilder(client *docker.Client, cfg *Config) *Builder {
 		b.logger = log15.Root()
 	}
 	return b
+}
+
+// ReadClientMetadata reads metadata of the given client.
+func (b *Builder) ReadClientMetadata(name string) (*libhive.ClientMetadata, error) {
+	dir := b.config.Inventory.ClientDirectory(name)
+	f, err := os.Open(filepath.Join(dir, "hive.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Eth1 client by default.
+			return &libhive.ClientMetadata{Role: "eth1"}, nil
+		} else {
+			return nil, fmt.Errorf("failed to read hive metadata file in '%s': %v", dir, err)
+		}
+	}
+	defer f.Close()
+	var out libhive.ClientMetadata
+	if err := yaml.NewDecoder(f).Decode(&out); err != nil {
+		return nil, fmt.Errorf("failed to decode hive metadata file in '%s': %v", dir, err)
+	}
+	return &out, nil
 }
 
 // BuildClientImage builds a docker image of the given client.

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -58,11 +58,21 @@ type simAPI struct {
 // getClientTypes returns all known client types.
 func (api *simAPI) getClientTypes(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	clients := make([]*ClientDefinition, 0, len(api.env.Definitions))
-	for _, def := range api.env.Definitions {
-		clients = append(clients, def)
+
+	if r.URL.Query().Get("metadata") != "" {
+		// New-style response with metadata included.
+		clients := make([]*ClientDefinition, 0, len(api.env.Definitions))
+		for _, def := range api.env.Definitions {
+			clients = append(clients, def)
+		}
+		json.NewEncoder(w).Encode(clients)
+	} else {
+		clients := make([]string, 0, len(api.env.Definitions))
+		for name := range api.env.Definitions {
+			clients = append(clients, name)
+		}
+		json.NewEncoder(w).Encode(clients)
 	}
-	json.NewEncoder(w).Encode(clients)
 }
 
 // startSuite starts a suite.

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -30,12 +29,6 @@ const defaultStartTimeout = time.Duration(60 * time.Second)
 // newSimulationAPI creates handlers for the simulation API.
 func newSimulationAPI(b ContainerBackend, env SimEnv, tm *TestManager) http.Handler {
 	api := &simAPI{backend: b, env: env, tm: tm}
-
-	// Collect client types.
-	for name := range env.Images {
-		api.clientTypes = append(api.clientTypes, name)
-	}
-	sort.Strings(api.clientTypes)
 
 	// API routes.
 	router := mux.NewRouter()
@@ -57,16 +50,19 @@ func newSimulationAPI(b ContainerBackend, env SimEnv, tm *TestManager) http.Hand
 }
 
 type simAPI struct {
-	clientTypes []string
-	backend     ContainerBackend
-	env         SimEnv
-	tm          *TestManager
+	backend ContainerBackend
+	env     SimEnv
+	tm      *TestManager
 }
 
 // getClientTypes returns all known client types.
 func (api *simAPI) getClientTypes(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(api.clientTypes)
+	clients := make([]*ClientDefinition, 0, len(api.env.Definitions))
+	for _, def := range api.env.Definitions {
+		clients = append(clients, def)
+	}
+	json.NewEncoder(w).Encode(clients)
 }
 
 // startSuite starts a suite.
@@ -202,7 +198,7 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the client name.
-	name, ok := api.checkClient(r, w)
+	clientDef, ok := api.checkClient(r, w)
 	if !ok {
 		return
 	}
@@ -217,16 +213,16 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 
 	// Create the client container.
 	options := ContainerOptions{Env: env, Files: files}
-	containerID, err := api.backend.CreateContainer(ctx, api.env.Images[name], options)
+	containerID, err := api.backend.CreateContainer(ctx, clientDef.Image, options)
 	if err != nil {
-		log15.Error("API: client container create failed", "client", name, "error", err)
+		log15.Error("API: client container create failed", "client", clientDef.Name, "error", err)
 		http.Error(w, "client container create failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// Set the log file. We need the container ID for this,
 	// so it can only be set after creating the container.
-	logPath, logFilePath := api.clientLogFilePaths(name, containerID)
+	logPath, logFilePath := api.clientLogFilePaths(clientDef.Name, containerID)
 	options.LogFile = logFilePath
 	options.CheckLive = true
 
@@ -236,30 +232,32 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		clientInfo := &ClientInfo{
 			ID:             info.ID,
 			IP:             info.IP,
-			Name:           name,
+			Name:           clientDef.Name,
 			InstantiatedAt: time.Now(),
 			LogFile:        logPath,
 			wait:           info.Wait,
 		}
 		api.tm.testSuiteMutex.Lock()
+
 		// log client version in test suite
 		if suite, ok := api.tm.runningTestSuites[suiteID]; !ok {
 			http.Error(w, ErrNoSuchTestSuite.Error(), http.StatusNotFound)
 			api.tm.testSuiteMutex.Unlock()
 			return
 		} else {
-			suite.ClientVersions[name] = api.env.ClientVersions[name]
+			suite.ClientVersions[clientDef.Name] = clientDef.Version
 		}
 		api.tm.testSuiteMutex.Unlock()
+
 		// register the node
 		api.tm.RegisterNode(testID, info.ID, clientInfo)
 	}
 	if err != nil {
-		log15.Error("API: could not start client", "client", name, "container", containerID[:8], "error", err)
+		log15.Error("API: could not start client", "client", clientDef.Name, "container", containerID[:8], "error", err)
 		http.Error(w, "client did not start: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	log15.Info("API: client "+name+" started", "suite", suiteID, "test", testID, "container", containerID[:8])
+	log15.Info("API: client "+clientDef.Name+" started", "suite", suiteID, "test", testID, "container", containerID[:8])
 	fmt.Fprintf(w, "%s@%s@%s", info.ID, info.IP, info.MAC)
 }
 
@@ -274,22 +272,21 @@ func (api *simAPI) clientLogFilePaths(clientName, containerID string) (jsonPath 
 	return jsonPath, file
 }
 
-func (api *simAPI) checkClient(r *http.Request, w http.ResponseWriter) (string, bool) {
+func (api *simAPI) checkClient(r *http.Request, w http.ResponseWriter) (*ClientDefinition, bool) {
 	name := r.FormValue("CLIENT")
 	if name == "" {
 		log15.Error("API: missing client name in start node request")
 		http.Error(w, "missing 'CLIENT' in request", http.StatusBadRequest)
-		return "", false
+		return nil, false
 	}
-	for _, cn := range api.clientTypes {
-		if cn == name {
-			return name, true
-		}
+	def, ok := api.env.Definitions[name]
+	if ok {
+		return def, true
 	}
 	// Client name not found.
 	log15.Error("API: unknown client name in start node request")
 	http.Error(w, "unknown 'CLIENT' type in request", http.StatusBadRequest)
-	return "", false
+	return nil, false
 }
 
 // stopClient terminates a client container.

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -55,7 +55,7 @@ type ContainerInfo struct {
 
 // ClientMetadata is metadata to describe the client in more detail, configured with a YAML file in the client dir.
 type ClientMetadata struct {
-	Role string `yaml:"role" json:"role"`
+	Roles []string `yaml:"roles" json:"roles"`
 }
 
 // Builder can build docker images of clients and simulators.

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -53,8 +53,14 @@ type ContainerInfo struct {
 	Wait func()
 }
 
+// ClientMetadata is metadata to describe the client in more detail, configured with a YAML file in the client dir.
+type ClientMetadata struct {
+	Role string `yaml:"role" json:"role"`
+}
+
 // Builder can build docker images of clients and simulators.
 type Builder interface {
+	ReadClientMetadata(name string) (*ClientMetadata, error)
 	BuildClientImage(ctx context.Context, name string) (string, error)
 	BuildSimulatorImage(ctx context.Context, name string) (string, error)
 

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -28,6 +28,14 @@ var (
 	ErrTestSuiteLimited         = errors.New("testsuite test count is limited")
 )
 
+// ClientDefinition is served by the /clients API endpoint to list the available clients
+type ClientDefinition struct {
+	Name    string         `json:"name"`
+	Version string         `json:"version"`
+	Image   string         `json:"-"` // not exposed via API
+	Meta    ClientMetadata `json:"meta"`
+}
+
 // SimEnv contains the simulation parameters.
 type SimEnv struct {
 	LogDir string
@@ -41,11 +49,8 @@ type SimEnv struct {
 	// for the client to open port 8545 after launching the container.
 	ClientStartTimeout time.Duration
 
-	// client name -> image name
-	Images map[string]string
-
-	// client name -> version info
-	ClientVersions map[string]string
+	// client name -> client definition
+	Definitions map[string]*ClientDefinition
 }
 
 // TestManager collects test results during a simulation run.


### PR DESCRIPTION
Changes:
- Load clients into single collection of definitions, don't separate versions, images, metadata into different maps.
- List the definitions in the API clients listing, except docker image: metadata such as the role is important for test-suites, docker-strings not so much.
- Update client loading, no changes required to clients. Default metadata is an "eth1" role. 

Eth1 simulators should update like:
```diff
	suite.Add(hivesim.ClientTestSpec{
+               Role: "eth1',
		Run: runDiscoveryTest,
		Parameters: hivesim.Params{
			"HIVE_LOGLEVEL": "5",
		},
	})
```
To ensure the test only ever runs against the intended kind of client. If the test runner does not provide eth2 client names by accident, the old behavior still works.

Next, we can make other tests that consume "beacon", "validator", "shard-node", etc. roles.

For an Eth2 testnet, or Eth1-Eth2 merge test, multiple roles may be involved. The CLI does not change, just give it a list of involved clients. The simulator can e.g. find the first beacon node, first validator, first shard-node to run a simple testnet. Or parametrize by role, to try different combinations (e.g. for Eth2 validator <> beacon API tests, and beacon <> eth1 RPC tests).

TODO:
- Update docs to describe `hive.yaml` in clients.
- More testing. Chicken-egg problem when using it in a simulator and having it in hive.
- Suite files only list the client versions. I kept that as-is, since changing it breaks viewing of existing suite-outputs, and the recent versions support broke the old format already (but gracefully). We have full client info now though, maybe worth listing it in the suite output?
- Thinking of best build-target approach. The metadata file is useful to define builds of the same client and version, but different compile-time arguments (e.g. eth2 minimal/mainnet configuration choice). For another later PR.

