### PR TITLE
simulators/ethereum/graphql/testcases: change block number input to number instead of hexadecimal

### DIFF
--- a/simulators/ethereum/graphql/testcases/02_eth_call_Block8.json
+++ b/simulators/ethereum/graphql/testcases/02_eth_call_Block8.json
@@ -1,5 +1,5 @@
 {
-  "request": "{block(number :\"0x8\") {number call (data : {from : \"a94f5374fce5edbc8e2a8697c15331677e6ebf0b\", to: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\", data :\"0x12a7b914\"}){data status}}}"
+  "request": "{block(number :8) {number call (data : {from : \"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b\", to: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\", data :\"0x12a7b914\"}){data status}}}"
   ,
   "responses":[{
     "data" : {

--- a/simulators/ethereum/graphql/testcases/16_eth_getBlock_byNumber.json
+++ b/simulators/ethereum/graphql/testcases/16_eth_getBlock_byNumber.json
@@ -1,7 +1,7 @@
 {
   "request": 
     
-    "{block (number : \"0x1e\") {transactions{hash} timestamp difficulty totalDifficulty gasUsed gasLimit hash nonce ommerCount logsBloom mixHash ommerHash extraData stateRoot receiptsRoot transactionCount transactionsRoot ommers{hash} ommerAt(index : 1){hash} miner{address} account(address: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\"){balance} parent{hash} }} ",
+    "{block (number : 30) {transactions{hash} timestamp difficulty totalDifficulty gasUsed gasLimit hash nonce ommerCount logsBloom mixHash ommerHash extraData stateRoot receiptsRoot transactionCount transactionsRoot ommers{hash} ommerAt(index : 1){hash} miner{address} account(address: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\"){balance} parent{hash} }} ",
 
 
   "responses":[{

--- a/simulators/ethereum/graphql/testcases/17_eth_getBlock_byNumberInvalid.json
+++ b/simulators/ethereum/graphql/testcases/17_eth_getBlock_byNumberInvalid.json
@@ -1,24 +1,31 @@
 {
   "request": "{block (number: 88888888) {number }} ",
-  "responses": [{
-    "errors": [
-      {
-        "message": "Exception while fetching data (/block) : Block number 88888888 was not found",
-        "locations": [
-          {
-            "line": 1,
-            "column": 2
+  "responses": [
+    {
+      "errors": [
+        {
+          "message": "Exception while fetching data (/block) : Block number 88888888 was not found",
+          "locations": [
+            {
+              "line": 1,
+              "column": 2
+            }
+          ],
+          "path": [
+            "block"
+          ],
+          "extensions": {
+            "classification": "DataFetchingException"
           }
-        ],
-        "path": [
-          "block"
-        ],
-        "extensions": {
-          "classification": "DataFetchingException"
         }
+      ],
+      "data": null
+    },
+    {
+      "data": {
+        "block": null
       }
-    ],
-    "data": null
-  }],
+    }
+  ],
   "statusCode": 400
 }

--- a/simulators/ethereum/graphql/testcases/20_eth_getBlockTransactionCount_byNumber.json
+++ b/simulators/ethereum/graphql/testcases/20_eth_getBlockTransactionCount_byNumber.json
@@ -1,7 +1,7 @@
 {
   "request": 
     
-    "{block (number : \"0x1e\") {transactions{hash} timestamp difficulty totalDifficulty gasUsed gasLimit hash nonce ommerCount logsBloom mixHash ommerHash extraData stateRoot receiptsRoot transactionCount transactionsRoot}} ",
+    "{block (number : 30) {transactions{hash} timestamp difficulty totalDifficulty gasUsed gasLimit hash nonce ommerCount logsBloom mixHash ommerHash extraData stateRoot receiptsRoot transactionCount transactionsRoot}} ",
 
 
   "responses":  [{

--- a/simulators/ethereum/graphql/testcases/23_eth_getLogs_matchTopic.json
+++ b/simulators/ethereum/graphql/testcases/23_eth_getLogs_matchTopic.json
@@ -1,5 +1,5 @@
 {
-  "request": "{  block(number: \"0x17\") { logs( filter: {  topics :  [[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\", \"0x65c9ac8011e286e89d02a269890f41d67ca2cc597b2c76c7c69321ff492be580\"]]}) { index  topics  data account{address} transaction{hash} }  } }",
+  "request": "{  block(number: 23) { logs( filter: {  topics :  [[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\", \"0x65c9ac8011e286e89d02a269890f41d67ca2cc597b2c76c7c69321ff492be580\"]]}) { index  topics  data account{address} transaction{hash} }  } }",
   "responses": [{
     "data" : {
       "block" : {

--- a/simulators/ethereum/graphql/testcases/28_eth_getTransaction_byBlockNumberAndIndex.json
+++ b/simulators/ethereum/graphql/testcases/28_eth_getTransaction_byBlockNumberAndIndex.json
@@ -1,7 +1,7 @@
 {
   "request": 
     
-  "{ block(number: \"0x1e\") { transactionAt(index: 0) {block{hash}  hash} } }",
+  "{ block(number: 30) { transactionAt(index: 0) {block{hash}  hash} } }",
 
   "responses":[{
     "data" : {

--- a/simulators/ethereum/graphql/testcases/29_eth_getTransaction_byBlockNumberAndInvalidIndex.json
+++ b/simulators/ethereum/graphql/testcases/29_eth_getTransaction_byBlockNumberAndInvalidIndex.json
@@ -1,7 +1,7 @@
 {
   "request": 
     
-  "{ block(number: \"0x1e\") { transactionAt(index: 1) {block{hash}  hash} } }",
+  "{ block(number: 30) { transactionAt(index: 1) {block{hash}  hash} } }",
 
   "responses":[{
     "data" : {


### PR DESCRIPTION
This PR changes the following test cases to use number instead of hexadecimal as the input parameter for block number: 

* `02_eth_call_Block8 `
* `16_eth_getBlock_byNumber`
* `20_eth_getBlockTransactionCount_byNumber`
* `23_eth_getLogs_matchTopic`
* `28_eth_getTransaction_byBlockNumberAndIndex`
* `29_eth_getTransaction_byBlockNumberAndInvalidIndex`

With [this PR](https://github.com/ethereum/go-ethereum/pull/21883), geth no longer accepts strings for the block number parameter. Besu accepts both. 

Additionally, I added an additional valid response for `17_eth_getBlock_byNumberInvalid`, but it is still failing as there is a discrepancy in error reporting between Besu and Geth (discussed [here](https://github.com/ethereum/hive/pull/426#issuecomment-775074987)) that will hopefully be solved soon.
