### PR TITLE
simulators/ethereum/graphql/testcases: fix testcases

### DIFF
--- a/simulators/ethereum/graphql/testcases/30_eth_getTransaction_byHash.json
+++ b/simulators/ethereum/graphql/testcases/30_eth_getTransaction_byHash.json
@@ -1,32 +1,64 @@
 {
-  "request":
-    "{transaction (hash : \"0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4\") { block{hash} gas gasPrice hash inputData nonce index value from {address} to {address}  logs{index} status createdContract{address} } } ",
-  "responses":  [ {
-    "data" : {
-      "transaction" : {
-        "block" : {
-          "hash" : "0xc8df1f061abb4d0c107b2b1a794ade8780b3120e681f723fe55a7be586d95ba6"
-        },
-        "gas" : 314159,
-        "gasPrice" : "0x1",
-        "hash" : "0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4",
-        "inputData" : "0xe8beef5b",
-        "nonce" : 29,
-        "index" : 0,
-        "value" : "0xa",
-        "from" : {
-          "address" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
-        },
-        "to" : {
-          "address" : "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"
-        },
-        "logs" : [ {
-          "index" : 0
-        } ],
-        "status" : null,
-        "createdContract" : null
+  "request": "{transaction (hash : \"0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4\") { block{hash} gas gasPrice hash inputData nonce index value from {address} to {address}  logs{index} status createdContract{address} } } ",
+  "responses": [
+    {
+      "data": {
+        "transaction": {
+          "block": {
+            "hash": "0xc8df1f061abb4d0c107b2b1a794ade8780b3120e681f723fe55a7be586d95ba6"
+          },
+          "gas": 314159,
+          "gasPrice": "0x1",
+          "hash": "0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4",
+          "inputData": "0xe8beef5b",
+          "nonce": 29,
+          "index": 0,
+          "value": "0xa",
+          "from": {
+            "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+          },
+          "to": {
+            "address": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"
+          },
+          "logs": [
+            {
+              "index": 0
+            }
+          ],
+          "status": null,
+          "createdContract": null
+        }
+      }
+    },
+    {
+      "data": {
+        "transaction": {
+          "block": {
+            "hash": "0xc8df1f061abb4d0c107b2b1a794ade8780b3120e681f723fe55a7be586d95ba6"
+          },
+          "createdContract": null,
+          "from": {
+            "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+          },
+          "gas": "0x4cb2f",
+          "gasPrice": "0x1",
+          "hash": "0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4",
+          "index": 0,
+          "inputData": "0xe8beef5b",
+          "logs": [
+            {
+              "index": 0
+            }
+          ],
+          "nonce": "0x1d",
+          "status": 0,
+          "to": {
+            "address": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"
+          },
+          "value": "0xa"
+        }
       }
     }
-  }],
+  ],
   "statusCode": 200
 }

--- a/simulators/ethereum/graphql/testcases/35_graphql_pending.json
+++ b/simulators/ethereum/graphql/testcases/35_graphql_pending.json
@@ -1,6 +1,6 @@
 {
   "request":
-    "{ pending { transactionCount transactions { nonce gas } account(address:\"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\") { balance} estimateGas(data:{}) call (data : {from : \"a94f5374fce5edbc8e2a8697c15331677e6ebf0b\", to: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\", data :\"0x12a7b914\"}){data status}} }",
+    "{ pending { transactionCount transactions { nonce gas } account(address:\"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\") { balance} estimateGas(data:{}) call (data : {from : \"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b\", to: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\", data :\"0x12a7b914\"}){data status}} }",
 
   "responses": [{
     "data": {


### PR DESCRIPTION
This PR adds an additional valid response for the `30_eth_getTransaction_byHash` test case and also adds the 0x prefix to the `from` parameter in the `35_graphql_pending` testcase. 

There is still an issue with `35_graphql_pending` where geth returns an empty array of transactions:  

```
HTTP response code: 200 OK
expected value(s):
{
  "data": {
    "pending": {
      "account": {
        "balance": "0x140"
      },
      "call": {
        "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
        "status": 1
      },
      "estimateGas": 21000,
      "transactionCount": 1,
      "transactions": [
        {
          "gas": 1048575,
          "nonce": 50
        }
      ]
    }
  }
} 
_____________________

got: {
  "data": {
    "pending": {
      "account": {
        "balance": "0x140"
      },
      "call": {
        "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
        "status": 1
      },
      "estimateGas": 21000,
      "transactionCount": 0,
      "transactions": []
    }
  }
}
```

This will be investigated further.