### PR TITLE
simulators: decrease eth simulator loglevel a bit

### DIFF
--- a/simulators/devp2p/eth/eth.go
+++ b/simulators/devp2p/eth/eth.go
@@ -26,7 +26,7 @@ Results from the test tool are reported as individual sub-tests.`,
 			"HIVE_FORK_TANGERINE": "0",
 			"HIVE_FORK_SPURIOUS":  "0",
 			"HIVE_FORK_BYZANTIUM": "0",
-			"HIVE_LOGLEVEL":       "5",
+			"HIVE_LOGLEVEL":       "4",
 		},
 		Files: map[string]string{
 			"genesis.json": "./init/genesis.json",


### PR DESCRIPTION
The lastest besu logfile from the eth protoocol is `59Mb`. Let's decrease that a bit