### PR TITLE
clients/nethermind: more flexible parsing of enode from logs

### DIFF
--- a/clients/nethermind/enode.sh
+++ b/clients/nethermind/enode.sh
@@ -11,6 +11,6 @@
 
 set -e
 
-TARGET_ENODE=$(sed -n -e 's/^.*This node.*: //p' /log.txt)
-echo ${TARGET_ENODE/|/}
+TARGET_ENODE=$(sed -n -e 's/^.*\(enode.*\)$/\1/p' /log.txt | tr -d ' ')
+echo $TARGET_ENODE
 

--- a/clients/nethermind/enode.sh
+++ b/clients/nethermind/enode.sh
@@ -11,6 +11,6 @@
 
 set -e
 
-TARGET_ENODE=$(sed -n -e 's/^.*\(enode.*\)$/\1/p' /log.txt | tr -d ' ')
+TARGET_ENODE=$(sed -n -e 's/^.*\(enode.*\) $/\1/p' /log.txt | head -n 1)
 echo $TARGET_ENODE
 


### PR DESCRIPTION
When nethermind logging is set to INFO (default), the client reports its enode like:
```
======================== Nethermind initialization completed ========================
Version      : 1.10.74-11-d0d6df863-20210709/X64-Linux/5.0.7
This node    : enode://41472c4a4dc32a8a4d92f0c19e9fcd26b6f1d5f6bf4996f25a1bdedf809675f03bada98bd774d13501515420469b5b37c2c85247b538757889cad992389324b8@127.0.0.1:30303
...
...
=====================================================================================

```

However, when it is increased to TRACE, the enode appears in the output like:
```
2021-07-09 06:02:37.0017|Created MasterNode: enode://af9f0d602baaa8b4a11a7c983eeee6387722953f2b1030ad07541efb7d23a9166a3b16bfcb86dd5f575ea2796b5547b6c0d8e6ebde7da7b82c8d00f4c2be3349@127.0.0.1:30303
```

Making the regex that parses it more flexible is nice to have when the log verbosity needs to be upped to get better insight into what the client is doing.

The assumption here is that the first outputted `enode://...` is that of the client.