### PR TITLE
clients/nethermind, clients/openethereum: fix eip1283 activation block

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -108,8 +108,8 @@ def clique_engine:
     "eip1052Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
 
     # Petersburg
-    "eip1283Transition": (if env.HIVE_FORK_ISTANBUL then "0x0" else env.HIVE_FORK_CONSTANTINOPLE|to_hex end),
-    "eip1283DisableTransition": (if env.HIVE_FORK_ISTANBUL then "0x0" else env.HIVE_FORK_PETERSBURG|to_hex end),
+    "eip1283Transition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_CONSTANTINOPLE|to_hex end),
+    "eip1283DisableTransition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_PETERSBURG|to_hex end),
 
     # Istanbul
     "eip152Transition": env.HIVE_FORK_ISTANBUL|to_hex,

--- a/clients/openethereum/mapper.jq
+++ b/clients/openethereum/mapper.jq
@@ -122,8 +122,8 @@ def clique_engine:
     "eip1052Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
 
     # Petersburg
-    "eip1283Transition": (if env.HIVE_FORK_ISTANBUL then "0x0" else env.HIVE_FORK_CONSTANTINOPLE|to_hex end),
-    "eip1283DisableTransition": (if env.HIVE_FORK_ISTANBUL then "0x0" else env.HIVE_FORK_PETERSBURG|to_hex end),
+    "eip1283Transition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_CONSTANTINOPLE|to_hex end),
+    "eip1283DisableTransition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_PETERSBURG|to_hex end),
 
     # Istanbul
     "eip1283ReenableTransition": env.HIVE_FORK_ISTANBUL|to_hex,


### PR DESCRIPTION
Nethermind and Openethereum are failing some hive consensus tests (Constantinople and transition ones), because values of `eip1283Transition` and `eip1283DisableTransition` are always `"0x0"`. This PR is fixing this issue.