### PR TITLE
hivesim: add get client enode in specific network / clients: add symlink to enode.sh in hive-bin

### DIFF
--- a/clients/aleth/Dockerfile
+++ b/clients/aleth/Dockerfile
@@ -15,6 +15,8 @@ ADD genesis.json /genesis.json
 # Add the enode URL retriever script.
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh
+RUN mkdir /hive-bin
+RUN ln -s /enode.sh /hive-bin/enode.sh
 
 # Copy buildinfo into version.json, and also remove the 'bool' field is_prerelease.
 RUN jq -r '.version' /usr/share/aleth/buildinfo.json > /version.txt

--- a/clients/besu/Dockerfile
+++ b/clients/besu/Dockerfile
@@ -16,6 +16,8 @@ ADD genesis.json /genesis.json
 # Inject the enode URL retriever script.
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh
+RUN mkdir /hive-bin
+RUN ln -s /enode.sh /hive-bin/enode.sh
 
 RUN ./bin/besu --version > /version.txt
 

--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -38,6 +38,8 @@ RUN chmod +x /geth.sh
 # Inject the enode id retriever script
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh
+RUN mkdir /hive-bin
+RUN ln -s /enode.sh /hive-bin/enode.sh
 
 ADD genesis.json /genesis.json
 

--- a/clients/nethermind/Dockerfile
+++ b/clients/nethermind/Dockerfile
@@ -14,6 +14,8 @@ ADD nethermind.sh /nethermind.sh
 
 RUN chmod +x /nethermind.sh
 RUN chmod +x /enode.sh
+RUN mkdir /hive-bin
+RUN ln -s /enode.sh /hive-bin/enode.sh
 
 # Write the version file.
 RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt

--- a/clients/openethereum/Dockerfile
+++ b/clients/openethereum/Dockerfile
@@ -23,6 +23,8 @@ ADD mapper.jq /mapper.jq
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh
 RUN chmod 777 /enode.sh
+RUN mkdir /hive-bin
+RUN ln -s /enode.sh /hive-bin/enode.sh
 
 # Add dummy /version.json
 RUN ./openethereum --version > /raw_version.txt

--- a/clients/trinity/Dockerfile
+++ b/clients/trinity/Dockerfile
@@ -21,6 +21,8 @@ ADD trinity.sh /trinity.sh
 RUN chmod +x /trinity.sh
 ADD enode.sh /enode.sh
 RUN chmod +x /enode.sh
+RUN mkdir /hive-bin
+RUN ln -s /enode.sh /hive-bin/enode.sh
 
 # Write the version file.
 RUN echo "branch: "$(git rev-parse --abbrev-ref HEAD)", commit: "$(git rev-parse HEAD)"" > /version.txt

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -100,9 +100,14 @@ type Client struct {
 	test *T
 }
 
-// EnodeURL returns the peer-to-peer endpoint of the client.
+// EnodeURL returns the default peer-to-peer endpoint of the client.
 func (c *Client) EnodeURL() (string, error) {
 	return c.test.Sim.ClientEnodeURL(c.test.SuiteID, c.test.TestID, c.Container)
+}
+
+// EnodeURL returns the peer-to-peer endpoint of the client on a specific network.
+func (c *Client) EnodeURLNetwork(network string) (string, error) {
+	return c.test.Sim.ClientEnodeURLNetwork(c.test.SuiteID, c.test.TestID, c.Container, network)
 }
 
 // RPC returns an RPC client connected to the client's RPC server.


### PR DESCRIPTION
Add API HTTP endpoint to fetch the eth client's enode/IP on a custom docker network.

This addition will be useful to create test cases where a secondary network is used as the main connection between clients, and can be disconnected on demand to simulate network partitioning.