### PR TITLE
internal/libhive: add client option for initially connected networks

### DIFF
--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -268,11 +268,18 @@ func (sim *Simulation) ContainerNetworkIP(testSuite SuiteID, network, containerI
 	if err != nil {
 		return "", err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	bodyBytes, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
 	if err != nil {
 		return "", err
 	}
-	return string(body), nil
+	body := strings.TrimSpace(string(bodyBytes))
+
+	if resp.StatusCode >= 400 {
+		return "", errors.New(body)
+	}
+	return body, nil
 }
 
 func (setup *clientSetup) postWithFiles(url string) (string, error) {

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -88,27 +88,16 @@ func TestEnodeReplaceIP(t *testing.T) {
 // This test checks the usage of common client start options.
 func TestStartClientStartOptions(t *testing.T) {
 	var lastOptions libhive.ContainerOptions
-	var lastConnectedNetworks map[string]bool
 	tm, srv := newFakeAPI(&fakes.BackendHooks{
 		StartContainer: func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
 			lastOptions = opt
 			return &libhive.ContainerInfo{}, nil
 		},
-		ConnectContainer: func(containerID string, networkID string) error {
-			lastConnectedNetworks[networkID] = true
-			return nil
-		},
-		ContainerIP: func(containerID string, networkID string) (net.IP, error) {
-			if _, ok := lastConnectedNetworks[networkID]; ok {
-				return net.IP{203, 0, 113, 2}, nil
-			}
-			return nil, errors.New("container not connected")
-		},
 	})
 	defer srv.Close()
 	defer tm.Terminate()
 
-	// Start the client.
+	// Start the suite and test.
 	sim := NewAt(srv.URL)
 	suiteID, err := sim.StartSuite("suite", "", "")
 	if err != nil {
@@ -154,30 +143,6 @@ func TestStartClientStartOptions(t *testing.T) {
 		}
 		if got := lastOptions.Env["HIVE_BAR"]; got != "2" {
 			t.Fatalf("non-overwritten option changed or went missing, got: %s", got)
-		}
-	})
-
-	t.Run("initial_networks_option", func(t *testing.T) {
-		sim.CreateNetwork(suiteID, "Init Network 1")
-		sim.CreateNetwork(suiteID, "Init Network 2")
-		sim.CreateNetwork(suiteID, "Init Network 3")
-		defer sim.RemoveNetwork(suiteID, "Init Network 1")
-		defer sim.RemoveNetwork(suiteID, "Init Network 2")
-		defer sim.RemoveNetwork(suiteID, "Init Network 3")
-		lastConnectedNetworks = make(map[string]bool)
-		containerID, _, err := sim.StartClientWithOptions(suiteID, testID, "client-1",
-			WithInitialNetworks([]string{"Init Network 1", "Init Network 3"}))
-		if err != nil {
-			t.Fatalf("failed to start client with initial networks: %v", err)
-		}
-		if ip, _ := sim.ContainerNetworkIP(suiteID, "Init Network 1", containerID); ip != "203.0.113.2" {
-			t.Fatalf("network was not connected at start: %v", ip)
-		}
-		if ip, _ := sim.ContainerNetworkIP(suiteID, "Init Network 2", containerID); ip == "203.0.113.2" {
-			t.Fatalf("network was incorrectly connected at start: %v", ip)
-		}
-		if ip, _ := sim.ContainerNetworkIP(suiteID, "Init Network 3", containerID); ip != "203.0.113.2" {
-			t.Fatalf("network was not connected at start: %v", ip)
 		}
 	})
 
@@ -334,6 +299,66 @@ func TestStartClientErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown 'CLIENT'") {
 		t.Fatalf("wrong error for GetNode with unknown CLIENT parameter: %q", err.Error())
+	}
+}
+
+func TestStartClientInitialNetworks(t *testing.T) {
+	var (
+		connections = make(map[string]net.IP)
+		ipcounter   byte
+	)
+	tm, srv := newFakeAPI(&fakes.BackendHooks{
+		StartContainer: func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
+			return &libhive.ContainerInfo{}, nil
+		},
+		ConnectContainer: func(containerID string, networkID string) error {
+			ipcounter++
+			connections[containerID+networkID] = net.IP{203, 0, 113, ipcounter}
+			return nil
+		},
+		ContainerIP: func(containerID string, networkID string) (net.IP, error) {
+			ip, ok := connections[containerID+networkID]
+			if !ok {
+				return nil, errors.New("container not connected")
+			}
+			return ip, nil
+		},
+	})
+	defer srv.Close()
+	defer tm.Terminate()
+
+	sim := NewAt(srv.URL)
+	suiteID, err := sim.StartSuite("suite", "", "")
+	if err != nil {
+		t.Fatal("can't start suite:", err)
+	}
+	testID, err := sim.StartTest(suiteID, "test", "")
+	if err != nil {
+		t.Fatal("can't start test:", err)
+	}
+
+	// Create networks.
+	sim.CreateNetwork(suiteID, "Init Network 1")
+	sim.CreateNetwork(suiteID, "Init Network 2")
+	sim.CreateNetwork(suiteID, "Init Network 3")
+	defer sim.RemoveNetwork(suiteID, "Init Network 1")
+	defer sim.RemoveNetwork(suiteID, "Init Network 2")
+	defer sim.RemoveNetwork(suiteID, "Init Network 3")
+
+	// Start the client.
+	opt := WithInitialNetworks([]string{"Init Network 1", "Init Network 3"})
+	containerID, _, err := sim.StartClientWithOptions(suiteID, testID, "client-1", opt)
+	if err != nil {
+		t.Fatalf("failed to start client: %v", err)
+	}
+	if ip, _ := sim.ContainerNetworkIP(suiteID, "Init Network 1", containerID); ip != "203.0.113.1" {
+		t.Fatalf("network 1 was not connected at start: %v", ip)
+	}
+	if ip, _ := sim.ContainerNetworkIP(suiteID, "Init Network 2", containerID); ip != "" {
+		t.Fatalf("network 2 was incorrectly connected at start: %v", ip)
+	}
+	if ip, _ := sim.ContainerNetworkIP(suiteID, "Init Network 3", containerID); ip != "203.0.113.2" {
+		t.Fatalf("network 3 was not connected at start: %v", ip)
 	}
 }
 

--- a/hivesim/options.go
+++ b/hivesim/options.go
@@ -28,7 +28,7 @@ func fileAsSrc(path string) func() (io.ReadCloser, error) {
 	}
 }
 
-// WithInitialNetworks adds a list of network names as the initial networks the client must be connected before starting.
+// WithInitialNetworks configures networks that the client is initially connected to.
 func WithInitialNetworks(networks []string) StartOption {
 	return optionFunc(func(setup *clientSetup) {
 		setup.parameters["NETWORKS"] = strings.Join(networks, ",")

--- a/hivesim/options.go
+++ b/hivesim/options.go
@@ -3,6 +3,7 @@ package hivesim
 import (
 	"io"
 	"os"
+	"strings"
 )
 
 // clientSetup collects client options.
@@ -25,6 +26,13 @@ func fileAsSrc(path string) func() (io.ReadCloser, error) {
 	return func() (io.ReadCloser, error) {
 		return os.Open(path)
 	}
+}
+
+// WithInitialNetworks adds a list of network names as the initial networks the client must be connected before starting.
+func WithInitialNetworks(networks []string) StartOption {
+	return optionFunc(func(setup *clientSetup) {
+		setup.parameters["NETWORKS"] = strings.Join(networks, ",")
+	})
 }
 
 // WithStaticFiles adds files from the local filesystem to the client. Map: destination file path -> source file path.

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -340,12 +340,7 @@ func (api *simAPI) checkClientNetworks(r *http.Request, w http.ResponseWriter) (
 		return nil, nil
 	}
 
-	var networks []string
-	err := json.Unmarshal([]byte(networksStr), &networks)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return nil, err
-	}
+	networks := strings.Split(networksStr, ",")
 
 	if len(networks) == 0 {
 		return nil, nil

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -251,13 +251,11 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	options.LogFile = logFilePath
 
 	// Connect to the networks if requested, so it is started already joined to each one.
-	if networks != nil {
-		for _, network := range networks {
-			if err := api.tm.ConnectContainer(suiteID, network, containerID); err != nil {
-				log15.Error("API: failed to connect container", "network", network, "container", containerID, "error", err)
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
+	for _, network := range networks {
+		if err := api.tm.ConnectContainer(suiteID, network, containerID); err != nil {
+			log15.Error("API: failed to connect container", "network", network, "container", containerID, "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 	}
 

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -223,7 +223,7 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	// Get the network names, if any, for the container to be connected to at start.
 	networks, err := api.checkClientNetworks(r, suiteID)
 	if err != nil {
-		log15.Error("API: " + err.Error())
+		log15.Error("API: "+err.Error(), "client", clientDef.Name)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -292,6 +292,20 @@ func (manager *TestManager) ConnectContainer(testSuite TestSuiteID, networkName,
 	return manager.backend.ConnectContainer(containerID, networkID)
 }
 
+// Returns whether a network exists in the current test context.
+func (manager *TestManager) NetworkExists(testSuite TestSuiteID, networkName string) (bool, error) {
+	manager.networkMutex.RLock()
+	defer manager.networkMutex.RUnlock()
+
+	_, ok := manager.IsTestSuiteRunning(testSuite)
+	if !ok {
+		return false, ErrNoSuchTestSuite
+	}
+
+	_, exists := manager.networks[testSuite][networkName]
+	return exists, nil
+}
+
 // DisconnectContainer disconnects the given container from the given network.
 func (manager *TestManager) DisconnectContainer(testSuite TestSuiteID, networkName, containerID string) error {
 	manager.networkMutex.RLock()

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -292,18 +292,13 @@ func (manager *TestManager) ConnectContainer(testSuite TestSuiteID, networkName,
 	return manager.backend.ConnectContainer(containerID, networkID)
 }
 
-// Returns whether a network exists in the current test context.
-func (manager *TestManager) NetworkExists(testSuite TestSuiteID, networkName string) (bool, error) {
+// NetworkExists reports whether a network exists in the current test context.
+func (manager *TestManager) NetworkExists(testSuite TestSuiteID, networkName string) bool {
 	manager.networkMutex.RLock()
 	defer manager.networkMutex.RUnlock()
 
-	_, ok := manager.IsTestSuiteRunning(testSuite)
-	if !ok {
-		return false, ErrNoSuchTestSuite
-	}
-
 	_, exists := manager.networks[testSuite][networkName]
-	return exists, nil
+	return exists
 }
 
 // DisconnectContainer disconnects the given container from the given network.


### PR DESCRIPTION
Adds an option to the StartClient API to include a set of networks in the request to which the new client must already be connected at startup.

The added "NETWORKS" form value must be an array of strings containing the names of existing networks to which the new client will be connected before it starts to run.

Example application of this new feature includes Consensus client Lighthouse where enr-address is passed as command line parameter for the client to generate a valid ENR in a different network than the default.