### PR TITLE
clients: add merge-go-ethereum, merge-nethermind

### DIFF
--- a/clients/merge-go-ethereum/Dockerfile
+++ b/clients/merge-go-ethereum/Dockerfile
@@ -1,0 +1,52 @@
+# Docker container spec for building the master branch of go-ethereum.
+#
+# The build process it potentially longer running but every effort was made to
+# produce a very minimalistic container that can be reused many times without
+# needing to constantly rebuild.
+
+FROM alpine:latest
+ARG repo=MariusVanDerWijden/go-ethereum
+ARG branch=kintsugi-v2-sync
+
+# Build go-ethereum on the fly and delete all build tools afterwards
+RUN apk add --update bash curl jq go git make gcc musl-dev          \
+        ca-certificates linux-headers
+
+RUN git clone --depth 1 --branch $branch  https://github.com/$repo && \
+  (cd go-ethereum && make geth)                                  && \
+  (cd go-ethereum                                                && \
+  echo "{}"                                                         \
+  | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}"    \
+  | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"     \
+  | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"                  \
+  > /version.json)                                               && \
+  cp go-ethereum/build/bin/geth /geth
+
+RUN ln -s /geth /usr/local/bin/geth
+
+RUN apk del go git make gcc musl-dev linux-headers
+RUN rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 30303 30303/udp
+
+# Generate the ethash verification caches
+RUN \
+ /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
+ /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/merge-go-ethereum/enode.sh
+++ b/clients/merge-go-ethereum/enode.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Script to retrieve the enode
+# 
+# This is copied into the validator container by Hive
+# and used to provide a client-specific enode id retriever
+#
+
+# Immediately abort the script on any error encountered
+set -e
+
+
+TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}' "localhost:8545" )
+
+
+TARGET_ENODE=$(echo ${TARGET_RESPONSE}| jq -r '.result.enode')
+echo "$TARGET_ENODE"

--- a/clients/merge-go-ethereum/genesis.json
+++ b/clients/merge-go-ethereum/genesis.json
@@ -1,0 +1,15 @@
+{
+    "coinbase"   : "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "difficulty" : "0x020000",
+    "extraData"  : "0x42",
+    "gasLimit"   : "0x2fefd8",
+    "mixHash"    : "0x2c85bcbce56429100b2108254bb56906257582aeafcbd682bc9af67a9f5aee46",
+    "nonce"      : "0x78cc16f7b4f65485",
+    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "timestamp"  : "0x54c98c81",
+    "alloc"      : {
+        "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+            "balance" : "0x09184e72a000"
+        }
+    }
+}

--- a/clients/merge-go-ethereum/geth.sh
+++ b/clients/merge-go-ethereum/geth.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# Startup script to initialize and boot a go-ethereum instance.
+#
+# This script assumes the following files:
+#  - `geth` binary is located in the filesystem root
+#  - `genesis.json` file is located in the filesystem root (mandatory)
+#  - `chain.rlp` file is located in the filesystem root (optional)
+#  - `blocks` folder is located in the filesystem root (optional)
+#  - `keys` folder is located in the filesystem root (optional)
+#
+# This script assumes the following environment variables:
+#
+#  - HIVE_BOOTNODE                enode URL of the remote bootstrap node
+#  - HIVE_NETWORK_ID              network ID number to use for the eth protocol
+#  - HIVE_TESTNET                 whether testnet nonces (2^20) are needed
+#  - HIVE_NODETYPE                sync and pruning selector (archive, full, light)
+#
+# Forks:
+#
+#  - HIVE_FORK_HOMESTEAD          block number of the homestead hard-fork transition
+#  - HIVE_FORK_DAO_BLOCK          block number of the DAO hard-fork transition
+#  - HIVE_FORK_DAO_VOTE           whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_TANGERINE          block number of Tangerine Whistle transition
+#  - HIVE_FORK_SPURIOUS           block number of Spurious Dragon transition
+#  - HIVE_FORK_BYZANTIUM          block number for Byzantium transition
+#  - HIVE_FORK_CONSTANTINOPLE     block number for Constantinople transition
+#  - HIVE_FORK_PETERSBURG         block number for ConstantinopleFix/PetersBurg transition
+#  - HIVE_FORK_ISTANBUL           block number for Istanbul transition
+#  - HIVE_FORK_MUIRGLACIER        block number for Muir Glacier transition
+#  - HIVE_FORK_BERLIN             block number for Berlin transition
+#  - HIVE_FORK_LONDON             block number for London
+#
+# Clique PoA:
+#
+#  - HIVE_CLIQUE_PERIOD           enables clique support. value is block time in seconds.
+#  - HIVE_CLIQUE_PRIVATEKEY       private key for clique mining
+#
+# Other:
+#
+#  - HIVE_MINER                   enable mining. value is coinbase address.
+#  - HIVE_MINER_EXTRA             extra-data field to set for newly minted blocks
+#  - HIVE_SKIP_POW                if set, skip PoW verification during block import
+#  - HIVE_LOGLEVEL                client loglevel (0-5)
+#  - HIVE_GRAPHQL_ENABLED         enables graphql on port 8545
+#  - HIVE_LES_SERVER              set to '1' to enable LES server
+
+# Immediately abort the script on any error encountered
+set -e
+
+geth=/usr/local/bin/geth
+FLAGS="--pcscdpath=\"\""
+
+if [ "$HIVE_LOGLEVEL" != "" ]; then
+    FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"
+fi
+
+# It doesn't make sense to dial out, use only a pre-set bootnode.
+FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
+
+if [ "$HIVE_SKIP_POW" != "" ]; then
+    FLAGS="$FLAGS --fakepow"
+fi
+
+# If a specific network ID is requested, use that
+if [ "$HIVE_NETWORK_ID" != "" ]; then
+    FLAGS="$FLAGS --networkid $HIVE_NETWORK_ID"
+else
+    # Unless otherwise specified by hive, we try to avoid mainnet networkid. If geth detects mainnet network id,
+    # then it tries to bump memory quite a lot
+    FLAGS="$FLAGS --networkid 1337"
+fi
+
+# If the client is to be run in testnet mode, flag it as such
+if [ "$HIVE_TESTNET" == "1" ]; then
+    FLAGS="$FLAGS --testnet"
+fi
+
+# Handle any client mode or operation requests
+if [ "$HIVE_NODETYPE" == "archive" ]; then
+    FLAGS="$FLAGS --syncmode full --gcmode archive"
+fi
+if [ "$HIVE_NODETYPE" == "full" ]; then
+    FLAGS="$FLAGS --syncmode snap"
+fi
+if [ "$HIVE_NODETYPE" == "light" ]; then
+    FLAGS="$FLAGS --syncmode light"
+fi
+
+# Configure the chain.
+mv /genesis.json /genesis-input.json
+jq -f /mapper.jq /genesis-input.json > /genesis.json
+
+# Dump genesis
+echo "Supplied genesis state:"
+cat /genesis.json
+
+# Initialize the local testchain with the genesis state
+echo "Initializing database with genesis state..."
+$geth $FLAGS init /genesis.json
+
+# Don't immediately abort, some imports are meant to fail
+set +e
+
+# Load the test chain if present
+echo "Loading initial blockchain..."
+if [ -f /chain.rlp ]; then
+    $geth $FLAGS --gcmode=archive import /chain.rlp
+else
+    echo "Warning: chain.rlp not found."
+fi
+
+# Load the remainder of the test chain
+echo "Loading remaining individual blocks..."
+if [ -d /blocks ]; then
+    (cd /blocks && $geth $FLAGS --gcmode=archive --verbosity=$HIVE_LOGLEVEL --nocompaction import `ls | sort -n`)
+else
+    echo "Warning: blocks folder not found."
+fi
+
+set -e
+
+# Import clique signing key.
+if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
+    # Create password file.
+    echo "Importing clique key..."
+    echo "secret" > /geth-password-file.txt
+    $geth --nousb account import --password /geth-password-file.txt <(echo "$HIVE_CLIQUE_PRIVATEKEY")
+
+    # Ensure password file is used when running geth in mining mode.
+    if [ "$HIVE_MINER" != "" ]; then
+        FLAGS="$FLAGS --password /geth-password-file.txt --unlock $HIVE_MINER --allow-insecure-unlock"
+    fi
+fi
+
+# Configure any mining operation
+if [ "$HIVE_MINER" != "" ] && [ "$HIVE_NODETYPE" != "light" ]; then
+    FLAGS="$FLAGS --mine --miner.threads 1 --miner.etherbase $HIVE_MINER"
+fi
+if [ "$HIVE_MINER_EXTRA" != "" ]; then
+    FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"
+fi
+FLAGS="$FLAGS --miner.gasprice 16000000000"
+
+# Configure LES.
+if [ "$HIVE_LES_SERVER" == "1" ]; then
+  FLAGS="$FLAGS --light.serve 50 --light.nosyncserve"
+fi
+
+# Configure RPC.
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    FLAGS="$FLAGS --catalyst --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,engine,eth,miner,net,personal,txpool,web3"
+    FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,engine,eth,miner,net,personal,txpool,web3"
+else
+    FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,miner,net,personal,txpool,web3"
+    FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth,miner,net,personal,txpool,web3"
+fi
+if [ "$HIVE_GRAPHQL_ENABLED" != "" ]; then
+    FLAGS="$FLAGS --graphql"
+fi
+# used for the graphql to allow submission of unprotected tx
+if [ "$HIVE_ALLOW_UNPROTECTED_TX" != "" ]; then
+    FLAGS="$FLAGS --rpc.allow-unprotected-txs"
+fi
+
+# Run the go-ethereum implementation with the requested flags.
+FLAGS="$FLAGS --nat=none"
+echo "Running go-ethereum with flags $FLAGS"
+$geth $FLAGS

--- a/clients/merge-go-ethereum/mapper.jq
+++ b/clients/merge-go-ethereum/mapper.jq
@@ -1,0 +1,58 @@
+# Removes all empty keys and values in input.
+def remove_empty:
+  . | walk(
+    if type == "object" then
+      with_entries(
+        select(
+          .value != null and
+          .value != "" and
+          .value != [] and
+          .key != null and
+          .key != ""
+        )
+      )
+    else .
+    end
+  )
+;
+
+# Converts decimal string to number.
+def to_int:
+  if . == null then . else .|tonumber end
+;
+
+# Converts "1" / "0" to boolean.
+def to_bool:
+  if . == null then . else
+    if . == "1" then true else false end
+  end
+;
+
+# Replace config in input.
+. + {
+  "config": {
+    "ethash": (if env.HIVE_CLIQUE_PERIOD then null else {} end),
+    "clique": (if env.HIVE_CLIQUE_PERIOD == null then null else {
+      "period": env.HIVE_CLIQUE_PERIOD|to_int,
+    } end),
+    "chainId": env.HIVE_CHAIN_ID|to_int,
+    "homesteadBlock": env.HIVE_FORK_HOMESTEAD|to_int,
+    "daoForkBlock": env.HIVE_FORK_DAO_BLOCK|to_int,
+    "daoForkSupport": env.HIVE_FORK_DAO_VOTE|to_bool,
+    "eip150Block": env.HIVE_FORK_TANGERINE|to_int,
+    "eip150Hash": env.HIVE_FORK_TANGERINE_HASH,
+    "eip155Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "eip158Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "byzantiumBlock": env.HIVE_FORK_BYZANTIUM|to_int,
+    "constantinopleBlock": env.HIVE_FORK_CONSTANTINOPLE|to_int,
+    "petersburgBlock": env.HIVE_FORK_PETERSBURG|to_int,
+    "istanbulBlock": env.HIVE_FORK_ISTANBUL|to_int,
+    "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
+    "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
+    "yolov2Block": env.HIVE_FORK_BERLIN|to_int,
+    "yolov3Block": env.HIVE_FORK_BERLIN|to_int,
+    "londonBlock": env.HIVE_FORK_LONDON|to_int,
+    "mergeForkBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
+  }|remove_empty
+}

--- a/clients/merge-nethermind/Dockerfile
+++ b/clients/merge-nethermind/Dockerfile
@@ -1,0 +1,28 @@
+ARG branch=latest
+FROM nethermindeth/nethermind:kiln_0.1
+
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
+    echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
+    chmod +x /usr/local/bin/jq
+
+ADD genesis.json /genesis.json
+ADD mapper.jq /mapper.jq
+ADD mkconfig.jq /mkconfig.jq
+ADD enode.sh /enode.sh
+ADD nethermind.sh /nethermind.sh
+
+RUN chmod +x /nethermind.sh
+
+# Add the enode script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Write the version file.
+RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
+
+ENV NETHERMIND_HIVE_ENABLED true
+
+EXPOSE 8545 30303 30303/udp
+ENTRYPOINT ["/nethermind.sh"]

--- a/clients/merge-nethermind/enode.sh
+++ b/clients/merge-nethermind/enode.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Script to retrieve the enode
+# 
+# This is copied into the validator container by Hive
+# and used to provide a client-specific enode id retriever
+#
+
+# Immediately abort the script on any error encountered
+
+
+set -e
+
+TARGET_ENODE=$(sed -n -e 's/^.*This node.*: //p' /log.txt)
+echo ${TARGET_ENODE/|/}
+

--- a/clients/merge-nethermind/genesis.json
+++ b/clients/merge-nethermind/genesis.json
@@ -1,0 +1,15 @@
+{
+    "coinbase"   : "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "difficulty" : "0x020000",
+    "extraData"  : "0x42",
+    "gasLimit"   : "0x2fefd8",
+    "mixHash"    : "0x2c85bcbce56429100b2108254bb56906257582aeafcbd682bc9af67a9f5aee46",
+    "nonce"      : "0x78cc16f7b4f65485",
+    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "timestamp"  : "0x54c98c81",
+    "alloc"      : {
+        "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+            "balance" : "0x09184e72a000"
+        }
+    }
+}

--- a/clients/merge-nethermind/mapper.jq
+++ b/clients/merge-nethermind/mapper.jq
@@ -1,0 +1,219 @@
+# Removes all empty keys and values in input.
+def remove_empty:
+  . | walk(
+    if type == "object" then
+      with_entries(
+        select(
+          .value != null and
+          .value != "" and
+          .value != [] and
+          .key != null and
+          .key != ""
+        )
+      )
+    else .
+    end
+  )
+;
+
+# Converts number to hex, from https://rosettacode.org/wiki/Non-decimal_radices/Convert#jq
+def int_to_hex:
+  def stream:
+    recurse(if . > 0 then ./16|floor else empty end) | . % 16 ;
+  if . == 0 then "0x0"
+  else "0x" + ([stream] | reverse | .[1:] | map(if .<10 then 48+. else 87+. end) | implode)
+  end
+;
+
+# Converts decimal number in string to hex.
+def to_hex:
+  if . != null and startswith("0x") then . else
+    if (. != null and . != "") then .|tonumber|int_to_hex else . end
+  end
+;
+
+# Zero-pads hex string.
+def infix_zeros_to_length(s;l):
+  if . != null then
+    (.[0:s])+("0"*(l-(.|length)))+(.[s:l])
+  else .
+  end
+;
+
+# This gives the consensus engine definition for the ethash engine.
+def ethash_engine:
+  {
+    "Ethash": {
+      "params": {
+        "minimumDifficulty": "0x20000",
+        "difficultyBoundDivisor": "0x800",
+        "durationLimit": "0x0d",
+        "homesteadTransition": env.HIVE_FORK_HOMESTEAD|to_hex,
+        "eip100bTransition": env.HIVE_FORK_BYZANTIUM|to_hex,
+        "daoHardforkTransition": env.HIVE_FORK_DAO_BLOCK|to_hex,
+        "daoHardforkBeneficiary": "0xbf4ed7b27f1d666546e30d74d50d173d20bca754",
+        "blockReward": {
+          "0x0": "0x4563918244F40000",
+          (env.HIVE_FORK_BYZANTIUM|to_hex//""): "0x29A2241AF62C0000",
+          (env.HIVE_FORK_CONSTANTINOPLE|to_hex//""): "0x1BC16D674EC80000",
+        },
+        "difficultyBombDelays": {
+          (env.HIVE_FORK_BYZANTIUM|to_hex//""): 3000000,
+          (env.HIVE_FORK_CONSTANTINOPLE|to_hex//""): 2000000,
+          (env.HIVE_FORK_MUIR_GLACIER|to_hex//""): 4000000,
+          (env.HIVE_FORK_LONDON|to_hex//""): 700000,
+        }
+      }
+    }
+  }
+;
+
+# This gives the consensus engine definition for the clique PoA engine.
+def clique_engine:
+  {
+    "clique": {
+       "params": {
+         "period": env.HIVE_CLIQUE_PERIOD|tonumber,
+         "epoch": 30000,
+         "blockReward": "0x0"
+       }
+    }
+  }
+;
+
+{
+  "version": "1",
+  "engine": (if env.HIVE_CLIQUE_PERIOD then clique_engine else ethash_engine end),
+  "params": {
+    # Tangerine Whistle
+    "eip150Transition": env.HIVE_FORK_TANGERINE|to_hex,
+
+    # Spurious Dragon
+    "eip160Transition": env.HIVE_FORK_SPURIOUS|to_hex,
+    "eip161abcTransition": env.HIVE_FORK_SPURIOUS|to_hex,
+    "eip161dTransition": env.HIVE_FORK_SPURIOUS|to_hex,
+    "eip155Transition": env.HIVE_FORK_SPURIOUS|to_hex,
+    "maxCodeSizeTransition": env.HIVE_FORK_SPURIOUS|to_hex,
+    "maxCodeSize": 24576,
+
+    # Byzantium
+    "eip140Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
+    "eip211Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
+    "eip214Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
+    "eip658Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
+
+    # Constantinople
+    "eip145Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
+    "eip1014Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
+    "eip1052Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
+
+    # Petersburg
+    "eip1283Transition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_CONSTANTINOPLE|to_hex end),
+    "eip1283DisableTransition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_PETERSBURG|to_hex end),
+
+    # Istanbul
+    "eip152Transition": env.HIVE_FORK_ISTANBUL|to_hex,
+    "eip1108Transition": env.HIVE_FORK_ISTANBUL|to_hex,
+    "eip1344Transition": env.HIVE_FORK_ISTANBUL|to_hex,
+    "eip1884Transition": env.HIVE_FORK_ISTANBUL|to_hex,
+    "eip2028Transition": env.HIVE_FORK_ISTANBUL|to_hex,
+    "eip2200Transition": env.HIVE_FORK_ISTANBUL|to_hex,
+
+    # Berlin
+    "eip2565Transition": env.HIVE_FORK_BERLIN|to_hex,
+    "eip2718Transition": env.HIVE_FORK_BERLIN|to_hex,
+    "eip2929Transition": env.HIVE_FORK_BERLIN|to_hex,
+    "eip2930Transition": env.HIVE_FORK_BERLIN|to_hex,
+
+    # London
+    "eip1559Transition": env.HIVE_FORK_LONDON|to_hex,
+    "eip3238Transition": env.HIVE_FORK_LONDON|to_hex,
+    "eip3529Transition": env.HIVE_FORK_LONDON|to_hex,
+    "eip3541Transition": env.HIVE_FORK_LONDON|to_hex,
+    "eip3198Transition": env.HIVE_FORK_LONDON|to_hex,
+
+    # Merge
+    "MergeForkIdTransition": env.HIVE_MERGE_BLOCK_ID|to_hex,
+
+    # Other chain parameters
+    "networkID": env.HIVE_NETWORK_ID|to_hex,
+    "chainID": env.HIVE_CHAIN_ID|to_hex,
+  },
+  "genesis": {
+    "seal": {
+      "ethereum":{
+         "nonce": .nonce|infix_zeros_to_length(2;18),
+         "mixHash": .mixHash,
+      },
+    },
+    "difficulty": .difficulty,
+    "author": .coinbase,
+    "timestamp": .timestamp,
+    "parentHash": .parentHash,
+    "extraData": .extraData,
+    "gasLimit": .gasLimit,
+    "baseFeePerGas": .baseFeePerGas,
+  },
+  "accounts": ((.alloc|with_entries(.key|="0x"+.)) * {
+    "0x0000000000000000000000000000000000000001": {
+      "builtin": {
+        "name": "ecrecover",
+        "pricing": {"linear": {"base": 3000, "word": 0}},
+      }
+    },
+    "0x0000000000000000000000000000000000000002": {
+      "builtin": {
+        "name": "sha256",
+        "pricing": {"linear": {"base": 60, "word": 12}}
+      }
+    },
+    "0x0000000000000000000000000000000000000003": {
+      "builtin": {
+        "name": "ripemd160",
+        "pricing": {"linear": {"base": 600, "word": 120}}
+      }
+    },
+    "0x0000000000000000000000000000000000000004": {
+      "builtin": {
+        "name": "identity",
+        "pricing": {"linear": {"base": 15, "word": 3}}
+      }
+    },
+    "0x0000000000000000000000000000000000000005": {
+      "builtin": {
+        "name": "modexp",
+        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
+        "pricing": {"modexp": {"divisor": 20}}
+      }
+    },
+    "0x0000000000000000000000000000000000000006": {
+      "builtin": {
+        "name": "alt_bn128_add",
+        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
+        "pricing": {"linear": {"base": 500, "word": 0}
+        }
+      }
+    },
+    "0x0000000000000000000000000000000000000007": {
+      "builtin": {
+        "name": "alt_bn128_mul",
+        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
+        "pricing": {"linear": {"base": 40000, "word": 0}}
+      }
+    },
+    "0x0000000000000000000000000000000000000008": {
+      "builtin": {
+        "name": "alt_bn128_pairing",
+        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
+        "pricing": {"alt_bn128_pairing": {"base": 100000, "pair": 80000}}
+      }
+    },
+    "0x0000000000000000000000000000000000000009": {
+      "builtin": {
+        "name": "blake2_f",
+        "activate_at": env.HIVE_FORK_ISTANBUL|to_hex,
+        "pricing": {"blake2_f": {"gas_per_round": 1}}
+      }
+    },
+  }),
+}|remove_empty

--- a/clients/merge-nethermind/mkconfig.jq
+++ b/clients/merge-nethermind/mkconfig.jq
@@ -1,0 +1,72 @@
+# This JQ script generates the Nethermind config file.
+
+def keystore_config:
+  if env.HIVE_CLIQUE_PRIVATEKEY == null then
+    {}
+  else
+    { "KeyStoreConfig": { "TestNodeKey": env.HIVE_CLIQUE_PRIVATEKEY } }
+  end
+;
+
+def merge_config:
+  if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then
+    { 
+      "Merge": {
+        "Enabled": true,
+        "TerminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY,
+      }
+    }
+  else
+    {}
+  end
+;
+
+def json_rpc_config:
+  if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then
+    {
+      "JsonRpc": {
+        "EnabledModules": ["Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Engine"]
+      }
+    }
+  else
+    {
+      "JsonRpc": {
+        "EnabledModules": ["Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health"]
+      }
+    }
+  end
+;
+
+def base_config:
+  {
+    "Init": {
+      "PubSubEnabled": true,
+      "WebSocketsEnabled": true,
+      "IsMining": (env.HIVE_MINER != null),
+      "UseMemDb": true,
+      "ChainSpecPath": "/chainspec/test.json",
+      "BaseDbPath": "nethermind_db/hive",
+      "LogFileName": "/hive.logs.txt"
+    },
+    "JsonRpc": {
+      "Enabled": true,
+      "Host": "0.0.0.0",
+      "Port": 8545,
+      "WebSocketsPort": 8546,
+    },
+    "Network": {
+      "DiscoveryPort": 30303,
+      "P2PPort": 30303,
+      "ExternalIp": "127.0.0.1",
+    },
+    "Hive": {
+      "ChainFile": "/chain.rlp",
+      "GenesisFilePath": "/genesis.json",
+      "BlocksDir": "/blocks",
+      "KeysDir": "/keys"
+    },
+  }
+;
+
+# This is the main expression that outputs the config.
+base_config * keystore_config * merge_config * json_rpc_config

--- a/clients/merge-nethermind/nethermind.sh
+++ b/clients/merge-nethermind/nethermind.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Startup script to initialize and boot a peer instance.
+#
+# This script assumes the following files:
+#  - `nethermind` binary is located in the filesystem root
+#  - `genesis.json` file is located in the filesystem root (mandatory)
+#  - `chain.rlp` file is located in the filesystem root (optional)
+#  - `blocks` folder is located in the filesystem root (optional)
+#  - `keys` folder is located in the filesystem root (optional)
+#
+# This script assumes the following environment variables:
+#
+#  - HIVE_BOOTNODE             enode URL of the remote bootstrap node
+#  - HIVE_NETWORK_ID           network ID number to use for the eth protocol
+#  - HIVE_CHAIN_ID             network ID number to use for the eth protocol
+#  - HIVE_NODETYPE             sync and pruning selector (archive, full, light)
+#  - HIVE_SKIP_POW             If set, skip PoW verification during block import
+#
+# Forks:
+#
+#  - HIVE_FORK_HOMESTEAD       block number of the DAO hard-fork transition
+#  - HIVE_FORK_DAO_BLOCK       block number of the DAO hard-fork transitionnsition
+#  - HIVE_FORK_TANGERINE       block number of TangerineWhistle
+#  - HIVE_FORK_SPURIOUS        block number of SpuriousDragon
+#  - HIVE_FORK_BYZANTIUM       block number for Byzantium transition
+#  - HIVE_FORK_CONSTANTINOPLE  block number for Constantinople transition
+#  - HIVE_FORK_PETERSBURG      block number for ConstantinopleFix/PetersBurg transition
+#  - HIVE_FORK_BERLIN          block number for Berlin transition
+#  - HIVE_FORK_LONDON          block number for London
+#
+# Clique PoA:
+#
+#  - HIVE_CLIQUE_PERIOD        enables clique support. value is block time in seconds.
+#  - HIVE_CLIQUE_PRIVATEKEY    private key for clique mining
+#
+# Other:
+#
+#  - HIVE_MINER                enables mining. value is coinbase address.
+#  - HIVE_MINER_EXTRA          extra-data field to set for newly minted blocks
+#  - HIVE_SKIP_POW             If set, skip PoW verification
+#  - HIVE_LOGLEVEL             Client log level
+#
+# These variables are not supported by Nethermind:
+#
+#  - HIVE_FORK_DAO_VOTE        whether the node support (or opposes) the DAO fork
+#  - HIVE_GRAPHQL_ENABLED      if set, GraphQL is enabled on port 8545
+#  - HIVE_TESTNET              whether testnet nonces (2^20) are needed
+
+# Immediately abort the script on any error encountered
+set -e
+
+# Generate the genesis and chainspec file.
+mkdir -p /chainspec
+jq -f /mapper.jq /genesis.json > /chainspec/test.json
+jq . /chainspec/test.json
+
+# Generate the config file.
+mkdir /configs
+jq -n -f /mkconfig.jq > /configs/test.cfg
+
+# Set bootnode.
+if [ -n "$HIVE_BOOTNODE" ]; then
+    mkdir -p /nethermind/Data
+    echo "[\"$HIVE_BOOTNODE\"]" > /nethermind/Data/static-nodes.json
+fi
+
+echo "Running Nethermind..."
+# The output is tee:d, via /log.txt, because the enode script uses that logfile to parse out the enode id
+dotnet /nethermind/Nethermind.Runner.dll --config /configs/test.cfg 2>&1 | tee /log.txt

--- a/clients/merge-nethermind/oldtest.cfg
+++ b/clients/merge-nethermind/oldtest.cfg
@@ -1,0 +1,32 @@
+[
+  {
+    "ConfigModule": "InitConfig",
+    "ConfigItems": {
+      "JsonRpcEnabled": true,
+      "WebSocketsEnabled": true,
+      "IsMining": false,
+      "DiscoveryPort": 30303,
+      "P2PPort": 30303,
+      "HttpHost": "127.0.0.1",
+      "HttpPort": 8545,
+      "ChainSpecPath": "/chainspec/test.json",
+     
+      "BaseDbPath": "nethermind_db/hive",
+      "LogFileName": "hive.logs.txt",
+      "StoreReceipts": true,
+      
+    }
+  },
+  {
+    "ConfigModule": "SyncConfig",
+    "ConfigItems": {
+      "FastSync": false
+    }
+  },
+  {
+    "ConfigModule": "KeyStoreConfig",
+    "ConfigItems": {
+      "TestNodeKey": "0x010102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f",
+    }
+  }
+]

--- a/clients/merge-nethermind/test.cfg
+++ b/clients/merge-nethermind/test.cfg
@@ -1,0 +1,27 @@
+{
+  "Init": {
+    "PubSubEnabled": false,
+    "WebSocketsEnabled": false,
+    "IsMining": false,
+    "UseMemDb": true,
+    "ChainSpecPath": "/chainspec/test.json",
+    "BaseDbPath": "nethermind_db/hive",
+    "LogFileName": "/hive.logs.txt"
+  },
+  "JsonRpc": {
+    "Enabled": true,
+    "Host": "0.0.0.0",
+    "Port": 8545,
+  },
+  "Network": {
+    "DiscoveryPort": 30303,
+    "P2PPort": 30303,
+    "ExternalIp": "127.0.0.1",
+  },
+  "Hive": {
+    "ChainFile": "/chain.rlp",
+    "GenesisFilePath": "/genesis.json",
+    "BlocksDir": "/blocks",
+    "KeysDir": "/keys"
+  }
+}


### PR DESCRIPTION
Add clients that use branches which contain Merge functionality:
- merge-go-ethereum: Github branch MariusVanDerWijden/go-ethereum
- merge-nethermind: Docker image nethermindeth/nethermind:kiln_0.1

At the moment, most of the changes in the configuration are triggered by only two HIVE_* configuration variables:
- HIVE_MERGE_BLOCK_ID
- HIVE_TERMINAL_TOTAL_DIFFICULTY

Please suggest on whether we should disable any of these configuration variables by adding a general merge variable, e.g. HIVE_MERGE.