### PR TITLE
clients/erigon: engine/merge erigon changes

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -24,6 +24,6 @@ RUN chmod +x /hive-bin/enode.sh
 RUN /usr/local/bin/erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
 
 # Export the usual networking ports to allow outside access to the node.
-EXPOSE 8545 8546 30303 30303/udp
+EXPOSE 8545 8546 8550 30303 30303/udp
 
 ENTRYPOINT ["/erigon.sh"]

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -37,7 +37,6 @@
 set -e
 
 erigon=/usr/local/bin/erigon
-rpcdaemon=/usr/local/bin/rpcdaemon
 
 if [ "$HIVE_LOGLEVEL" != "" ]; then
     FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"
@@ -115,14 +114,12 @@ fi
 
 # Launch the main client.
 FLAGS="$FLAGS --nat=none"
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3,engine --engine.addr=0.0.0.0"
+    FLAGS="$FLAGS --ws"
+else
+    FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3"
+    FLAGS="$FLAGS --ws"
+fi
 echo "Running erigon with flags $FLAGS"
-$erigon $FLAGS &
-
-# Give it some time to start.
-sleep 0.3
-
-# Launch rpcdaemon.
-RPC_FLAGS="--http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,net,txpool,web3"
-RPC_FLAGS="$RPC_FLAGS --ws --datadir /erigon-hive-datadir"
-echo "Running rpcdaemon with flags $RPC_FLAGS"
-$rpcdaemon $RPC_FLAGS
+$erigon $FLAGS

--- a/clients/erigon/mapper.jq
+++ b/clients/erigon/mapper.jq
@@ -50,5 +50,6 @@ def to_bool:
     "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
     "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
   }|remove_empty
 }

--- a/simulators/ethereum/engine/go.mod
+++ b/simulators/ethereum/engine/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/cespare/cp v1.1.1 // indirect
 	github.com/ethereum/go-ethereum v1.10.15
-	github.com/ethereum/hive v0.0.0-20220202182836-b91b7d136d82
+	github.com/ethereum/hive v0.0.0-20220216101708-2784ea3e7eea
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/status-im/keycard-go v0.0.0-20190424133014-d95853db0f48 // indirect

--- a/simulators/ethereum/engine/go.sum
+++ b/simulators/ethereum/engine/go.sum
@@ -321,8 +321,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethereum/hive v0.0.0-20220202182836-b91b7d136d82 h1:UAZFucT3azefKPsXZutB7fB6oZHAY5+2+I883xXPKRo=
-github.com/ethereum/hive v0.0.0-20220202182836-b91b7d136d82/go.mod h1:xptEyWnRW33B208ZrXXvkDpnP/BCvsigi/vir2TxruM=
+github.com/ethereum/hive v0.0.0-20220216101708-2784ea3e7eea h1:B41/UTJw3AV/zXFNgh2rrF+UvW2T0cZSfufgSKWk2+0=
+github.com/ethereum/hive v0.0.0-20220216101708-2784ea3e7eea/go.mod h1:xptEyWnRW33B208ZrXXvkDpnP/BCvsigi/vir2TxruM=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=


### PR DESCRIPTION
This PR adds changes required to Erigon client to support the Engine API.
The rpcdaemon is also removed since this is now part of the main Erigon binary when the --http flag is added.