### PR TITLE
Switch to using clique for merge transition simulator

### DIFF
--- a/clients/lighthouse-bn/Dockerfile
+++ b/clients/lighthouse-bn/Dockerfile
@@ -9,4 +9,3 @@ RUN chmod +x /lighthouse_bn.sh
 RUN echo "latest" > /version.txt
 
 ENTRYPOINT ["/lighthouse_bn.sh"]
-

--- a/clients/lighthouse-bn/lighthouse_bn.sh
+++ b/clients/lighthouse-bn/lighthouse_bn.sh
@@ -38,8 +38,11 @@ echo "bootnodes: ${HIVE_ETH2_BOOTNODE_ENRS}"
 
 CONTAINER_IP=`hostname -i | awk '{print $1;}'`
 eth1_option=$([[ "$HIVE_ETH2_ETH1_RPC_ADDRS" == "" ]] && echo "--dummy-eth1" || echo "--eth1-endpoints=$HIVE_ETH2_ETH1_RPC_ADDRS")
-merge_option=$([[ "$HIVE_ETH2_MERGE_ENABLED" == "" ]] && echo "" || echo "--merge")
 metrics_option=$([[ "$HIVE_ETH2_METRICS_PORT" == "" ]] && echo "" || echo "--metrics --metrics-address=0.0.0.0 --metrics-port=$HIVE_ETH2_METRICS_PORT --metrics-allow-origin=*")
+if [ "$HIVE_ETH2_MERGE_ENABLED" != "" ]; then
+    echo -n "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
+    merge_option="--merge --execution-endpoints=$HIVE_ETH2_ETH1_ENGINE_RPC_ADDRS --jwt-secrets=/jwtsecret"
+fi
 
 lighthouse \
     --debug-level="$LOG" \

--- a/clients/merge-go-ethereum/Dockerfile
+++ b/clients/merge-go-ethereum/Dockerfile
@@ -5,8 +5,8 @@
 # needing to constantly rebuild.
 
 FROM alpine:latest
-ARG repo=MariusVanDerWijden/go-ethereum
-ARG branch=merge-kiln-v2
+ARG repo=ethereum/go-ethereum
+ARG branch=master
 
 # Build go-ethereum on the fly and delete all build tools afterwards
 RUN apk add --update bash curl jq go git make gcc musl-dev          \

--- a/simulators/eth2/testnet/helper.go
+++ b/simulators/eth2/testnet/helper.go
@@ -9,6 +9,13 @@ import (
 	blsu "github.com/protolambda/bls12-381-util"
 )
 
+type ConsensusType int
+
+const (
+	Ethash ConsensusType = iota
+	Clique
+)
+
 type testSpec struct {
 	Name  string
 	About string
@@ -40,8 +47,8 @@ type config struct {
 
 	// Node configurations to launch. Each node as a proportional share of
 	// validators.
-	Nodes      []node
-	ShouldMine bool
+	Nodes         []node
+	Eth1Consensus ConsensusType
 }
 
 func (c *config) activeFork() string {

--- a/simulators/eth2/testnet/nodes.go
+++ b/simulators/eth2/testnet/nodes.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	PortUserRPC      = 8545
-	PortEngineRPC    = 8600
+	PortEngineRPC    = 8550
 	PortBeaconTCP    = 9000
 	PortBeaconUDP    = 9000
 	PortBeaconAPI    = 4000

--- a/simulators/eth2/testnet/scenarios.go
+++ b/simulators/eth2/testnet/scenarios.go
@@ -11,8 +11,8 @@ import (
 
 var (
 	VALIDATOR_COUNT            uint64 = 64
-	SLOT_TIME                  uint64 = 2
-	TERMINCAL_TOTAL_DIFFICULTY        = big.NewInt(5000000)
+	SLOT_TIME                  uint64 = 3
+	TERMINRAL_TOTAL_DIFFICULTY        = big.NewInt(100)
 )
 
 func startTestnet(t *hivesim.T, env *testEnv, config *config) *Testnet {
@@ -25,7 +25,7 @@ func startTestnet(t *hivesim.T, env *testEnv, config *config) *Testnet {
 
 	// for each key partition, we start a validator client with its own beacon node and eth1 node
 	for i, node := range config.Nodes {
-		prep.startEth1Node(testnet, env.Clients.ClientByNameAndRole(node.ExecutionClient, "eth1"), config.ShouldMine)
+		prep.startEth1Node(testnet, env.Clients.ClientByNameAndRole(node.ExecutionClient, "eth1"), config.Eth1Consensus)
 		prep.startBeaconNode(testnet, env.Clients.ClientByNameAndRole(fmt.Sprintf("%s-bn", node.ConsensusClient), "beacon"), []int{i})
 		prep.startValidatorClient(testnet, env.Clients.ClientByNameAndRole(fmt.Sprintf("%s-vc", node.ConsensusClient), "validator"), i, i)
 	}
@@ -39,12 +39,12 @@ func Phase0Testnet(t *hivesim.T, env *testEnv, n node) {
 		MergeForkEpoch:          20,
 		ValidatorCount:          VALIDATOR_COUNT,
 		SlotTime:                SLOT_TIME,
-		TerminalTotalDifficulty: TERMINCAL_TOTAL_DIFFICULTY,
+		TerminalTotalDifficulty: TERMINRAL_TOTAL_DIFFICULTY,
 		Nodes: []node{
 			n,
 			n,
 		},
-		ShouldMine: true,
+		Eth1Consensus: Clique,
 	}
 
 	testnet := startTestnet(t, env, &config)
@@ -71,12 +71,12 @@ func TransitionTestnet(t *hivesim.T, env *testEnv, n node) {
 		MergeForkEpoch:          0,
 		ValidatorCount:          VALIDATOR_COUNT,
 		SlotTime:                SLOT_TIME,
-		TerminalTotalDifficulty: TERMINCAL_TOTAL_DIFFICULTY,
+		TerminalTotalDifficulty: TERMINRAL_TOTAL_DIFFICULTY,
 		Nodes: []node{
 			n,
 			n,
 		},
-		ShouldMine: true,
+		Eth1Consensus: Clique,
 	}
 
 	testnet := startTestnet(t, env, &config)

--- a/simulators/eth2/testnet/scenarios.go
+++ b/simulators/eth2/testnet/scenarios.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	VALIDATOR_COUNT            uint64 = 64
-	SLOT_TIME                  uint64 = 3
-	TERMINRAL_TOTAL_DIFFICULTY        = big.NewInt(100)
+	VALIDATOR_COUNT           uint64 = 64
+	SLOT_TIME                 uint64 = 3
+	TERMINAL_TOTAL_DIFFICULTY        = big.NewInt(100)
 )
 
 func startTestnet(t *hivesim.T, env *testEnv, config *config) *Testnet {
@@ -39,7 +39,7 @@ func Phase0Testnet(t *hivesim.T, env *testEnv, n node) {
 		MergeForkEpoch:          20,
 		ValidatorCount:          VALIDATOR_COUNT,
 		SlotTime:                SLOT_TIME,
-		TerminalTotalDifficulty: TERMINRAL_TOTAL_DIFFICULTY,
+		TerminalTotalDifficulty: TERMINAL_TOTAL_DIFFICULTY,
 		Nodes: []node{
 			n,
 			n,
@@ -71,7 +71,7 @@ func TransitionTestnet(t *hivesim.T, env *testEnv, n node) {
 		MergeForkEpoch:          0,
 		ValidatorCount:          VALIDATOR_COUNT,
 		SlotTime:                SLOT_TIME,
-		TerminalTotalDifficulty: TERMINRAL_TOTAL_DIFFICULTY,
+		TerminalTotalDifficulty: TERMINAL_TOTAL_DIFFICULTY,
 		Nodes: []node{
 			n,
 			n,


### PR DESCRIPTION
This retains the ability to spawn a testnet using `ethash` for the pre-transitioned portion of the testnet, but in the configurations I've switched to using `clique` instead.