### PR TITLE
simulators/ethereum/engine: add auth tests, fix re-org tests

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -115,8 +115,11 @@ fi
 # Launch the main client.
 FLAGS="$FLAGS --nat=none"
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
+    echo -n $JWT_SECRET > /jwt.secret
     FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3,engine --engine.addr=0.0.0.0"
     FLAGS="$FLAGS --ws"
+    FLAGS="$FLAGS --authrpc.jwtsecret=/jwt.secret"
 else
     FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3"
     FLAGS="$FLAGS --ws"

--- a/clients/merge-go-ethereum/geth.sh
+++ b/clients/merge-go-ethereum/geth.sh
@@ -153,7 +153,7 @@ FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth
 
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
-    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8550 --authrpc.jwtsecret /jwtsecret"
+    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret /jwtsecret"
 fi
 
 # Configure GraphQL.

--- a/clients/merge-nethermind/Dockerfile
+++ b/clients/merge-nethermind/Dockerfile
@@ -1,5 +1,6 @@
-ARG branch=latest
-FROM nethermindeth/nethermind:kiln_0.5
+# ARG branch=latest
+ARG branch=kiln_merge_sync
+FROM nethermindeth/nethermind:$branch
 
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \

--- a/clients/merge-nethermind/Dockerfile
+++ b/clients/merge-nethermind/Dockerfile
@@ -1,5 +1,5 @@
 # ARG branch=latest
-ARG branch=kiln_merge_sync
+ARG branch=kiln_test
 FROM nethermindeth/nethermind:$branch
 
 RUN apt-get update && apt-get install -y wget

--- a/clients/merge-nethermind/mkconfig.jq
+++ b/clients/merge-nethermind/mkconfig.jq
@@ -21,6 +21,30 @@ def merge_config:
   end
 ;
 
+def merge_block_hash:
+  if env.HIVE_TERMINAL_BLOCK_HASH != null then
+    { 
+      "Merge": {
+        "TerminalBlockHash": env.HIVE_TERMINAL_BLOCK_HASH
+      }
+    }
+  else
+    {}
+  end
+;
+
+def merge_block_number:
+  if env.HIVE_TERMINAL_BLOCK_NUMBER != null then
+    { 
+      "Merge": {
+        "TerminalBlockNumber": env.HIVE_TERMINAL_BLOCK_NUMBER
+      }
+    }
+  else
+    {}
+  end
+;
+
 def json_rpc_config:
   if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then
     {
@@ -71,4 +95,4 @@ def base_config:
 ;
 
 # This is the main expression that outputs the config.
-base_config * keystore_config * merge_config * json_rpc_config
+base_config * keystore_config * merge_config * merge_block_hash * merge_block_number * json_rpc_config

--- a/clients/merge-nethermind/mkconfig.jq
+++ b/clients/merge-nethermind/mkconfig.jq
@@ -25,8 +25,9 @@ def json_rpc_config:
   if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then
     {
       "JsonRpc": {
+        "JwtSecretFile": "/jwt.secret",
         "EnabledModules": ["Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health"],
-        "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|net;eth;subscribe;engine;web3;client", "http://0.0.0.0:8551|http;ws|net;eth;subscribe;engine;web3;client"]
+        "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|net;eth;subscribe;engine;web3;client|no-auth", "http://0.0.0.0:8551|http;ws|net;eth;subscribe;engine;web3;client"]
       }
     }
   else

--- a/clients/merge-nethermind/nethermind.sh
+++ b/clients/merge-nethermind/nethermind.sh
@@ -50,6 +50,12 @@
 # Immediately abort the script on any error encountered
 set -e
 
+# Generate JWT file if necessary
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
+    echo -n $JWT_SECRET > /jwt.secret
+fi
+
 # Generate the genesis and chainspec file.
 mkdir -p /chainspec
 jq -f /mapper.jq /genesis.json > /chainspec/test.json

--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -107,7 +107,7 @@ Verify the Block returned by the Eth RPC after a new SafeBlockHash is set using 
 Verify the Block returned by the Eth RPC after a new FinalizedBlockHash is set using forkchoiceUpdated. Eth RPC should return new block.
 
 - Latest Block after Reorg:  
-Verify the Block returned by the Eth RPC after a forkchoiceUpdated reorgs HeadBlockHash/SafeBlockHash to their previous value. Eth RPC should return previous block.
+Verify the Block returned by the Eth RPC after a forkchoiceUpdated reorgs HeadBlockHash/SafeBlockHash to a sidechain and back. Eth RPC should return the appropriate block everytime.
 
 ### Payload Execution
 - Re-Execute Payload:  

--- a/simulators/ethereum/engine/authtests.go
+++ b/simulators/ethereum/engine/authtests.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// JWT Authentication Tests
+type AuthTestSpec struct {
+	Name                  string
+	TimeDriftSeconds      int64
+	CustomAuthSecretBytes []byte
+	AuthOk                bool
+}
+
+var authTestSpecs = []AuthTestSpec{
+	{
+		Name:                  "JWT Authentication: No time drift, correct secret",
+		TimeDriftSeconds:      0,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                true,
+	},
+	{
+		Name:                  "JWT Authentication: No time drift, incorrect secret (shorter)",
+		TimeDriftSeconds:      0,
+		CustomAuthSecretBytes: []byte("secretsecretsecretsecretsecrets"),
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: No time drift, incorrect secret (longer)",
+		TimeDriftSeconds:      0,
+		CustomAuthSecretBytes: append([]byte{0}, []byte("secretsecretsecretsecretsecretse")...),
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: Negative time drift, exceeding limit, correct secret",
+		TimeDriftSeconds:      -1 - maxTimeDriftSeconds,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: Negative time drift, within limit, correct secret",
+		TimeDriftSeconds:      1 - maxTimeDriftSeconds,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                true,
+	},
+	{
+		Name:                  "JWT Authentication: Positive time drift, exceeding limit, correct secret",
+		TimeDriftSeconds:      maxTimeDriftSeconds + 1,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: Positive time drift, within limit, correct secret",
+		TimeDriftSeconds:      maxTimeDriftSeconds - 1,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                true,
+	},
+}
+
+var authTests = func() []TestSpec {
+	testSpecs := make([]TestSpec, 0)
+	for _, authTest := range authTestSpecs {
+		testSpecs = append(testSpecs, GenerateAuthTestSpec(authTest))
+	}
+	return testSpecs
+}()
+
+func GenerateAuthTestSpec(authTestSpec AuthTestSpec) TestSpec {
+	runFunc := func(t *TestEnv) {
+		// Default values
+		var (
+			// All test cases send a simple TransitionConfigurationV1 to check the Authentication mechanism (JWT)
+			tConf = TransitionConfigurationV1{
+				TerminalTotalDifficulty: t.MainTTD(),
+				TerminalBlockHash:       common.Hash{},
+				TerminalBlockNumber:     0,
+			}
+			testSecret = authTestSpec.CustomAuthSecretBytes
+			testTime   = time.Now()
+		)
+		if testSecret == nil {
+			testSecret = defaultJwtTokenSecretBytes
+		}
+		if authTestSpec.TimeDriftSeconds != 0 {
+			testTime = testTime.Add(time.Second * time.Duration(authTestSpec.TimeDriftSeconds))
+		}
+		if err := t.Engine.PrepareAuthCallToken(testSecret, testTime); err != nil {
+			t.Fatalf("FAIL (%s): Unable to prepare the auth token: %v", t.TestName, err)
+		}
+		err := t.Engine.c.CallContext(t.Engine.Ctx(), &tConf, "engine_exchangeTransitionConfigurationV1", tConf)
+		if authTestSpec.AuthOk {
+			if err != nil {
+				t.Fatalf("FAIL (%s): Authentication was supposed to pass authentication but failed: %v", t.TestName, err)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("FAIL (%s): Authentication was supposed to fail authentication but passed", t.TestName)
+			}
+		}
+	}
+	return TestSpec{
+		Name: authTestSpec.Name,
+		Run:  runFunc,
+	}
+}

--- a/simulators/ethereum/engine/clmock.go
+++ b/simulators/ethereum/engine/clmock.go
@@ -28,6 +28,10 @@ type CLMocker struct {
 	PrevRandaoHistory      map[uint64]common.Hash
 	ExecutedPayloadHistory map[uint64]ExecutableDataV1
 
+	// Transition Information
+	TerminalBlockNumber *uint64
+	TerminalBlockHash   *common.Hash
+
 	// Latest broadcasted data using the PoS Engine API
 	LatestFinalizedNumber *big.Int
 	LatestFinalizedHeader *types.Header
@@ -137,6 +141,11 @@ func (cl *CLMocker) setTTDBlockClient(ec *EngineClient) {
 	if !anySuccess {
 		cl.Fatalf("CLMocker: None of the clients accepted forkchoiceUpdated")
 	}
+
+	// Save the transition information
+	transitionBlockNumber := cl.LatestFinalizedNumber.Uint64()
+	cl.TerminalBlockNumber = &transitionBlockNumber
+	cl.TerminalBlockHash = &cl.LatestForkchoice.HeadBlockHash
 }
 
 // This method waits for TTD in at least one of the clients, then sends the

--- a/simulators/ethereum/engine/engineclient.go
+++ b/simulators/ethereum/engine/engineclient.go
@@ -18,8 +18,7 @@ import (
 
 // https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/specification.md
 var EthPortHTTP = 8545
-var EnginePortHTTP = 8550
-var EnginePortWS = 8551
+var EnginePortHTTP = 8551
 
 // EngineClient wrapper for Ethereum Engine RPC for testing purposes.
 type EngineClient struct {

--- a/simulators/ethereum/engine/engineclient.go
+++ b/simulators/ethereum/engine/engineclient.go
@@ -242,10 +242,9 @@ type TransitionConfigurationV1Marshaling struct {
 }
 
 // JWT Tokens
-func GetNewToken() (string, error) {
-	jwtSecretBytes := common.FromHex(defaultJwtTokenSecret)
+func GetNewToken(jwtSecretBytes []byte, iat time.Time) (string, error) {
 	newToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"iat": time.Now().Unix(),
+		"iat": iat.Unix(),
 	})
 	tokenString, err := newToken.SignedString(jwtSecretBytes)
 	if err != nil {
@@ -254,8 +253,8 @@ func GetNewToken() (string, error) {
 	return tokenString, nil
 }
 
-func (ec *EngineClient) PrepareAuthCallToken() error {
-	newTokenString, err := GetNewToken()
+func (ec *EngineClient) PrepareAuthCallToken(jwtSecretBytes []byte, iat time.Time) error {
+	newTokenString, err := GetNewToken(jwtSecretBytes, iat)
 	if err != nil {
 		return err
 	}
@@ -263,10 +262,15 @@ func (ec *EngineClient) PrepareAuthCallToken() error {
 	return nil
 }
 
+func (ec *EngineClient) PrepareDefaultAuthCallToken() error {
+	ec.PrepareAuthCallToken(defaultJwtTokenSecretBytes, time.Now())
+	return nil
+}
+
 // Engine API Call Methods
 func (ec *EngineClient) EngineForkchoiceUpdatedV1(ctx context.Context, fcState *ForkchoiceStateV1, pAttributes *PayloadAttributesV1) (ForkChoiceResponse, error) {
 	var result ForkChoiceResponse
-	if err := ec.PrepareAuthCallToken(); err != nil {
+	if err := ec.PrepareDefaultAuthCallToken(); err != nil {
 		return result, err
 	}
 	err := ec.c.CallContext(ctx, &result, "engine_forkchoiceUpdatedV1", fcState, pAttributes)
@@ -275,7 +279,7 @@ func (ec *EngineClient) EngineForkchoiceUpdatedV1(ctx context.Context, fcState *
 
 func (ec *EngineClient) EngineGetPayloadV1(ctx context.Context, payloadId *PayloadID) (ExecutableDataV1, error) {
 	var result ExecutableDataV1
-	if err := ec.PrepareAuthCallToken(); err != nil {
+	if err := ec.PrepareDefaultAuthCallToken(); err != nil {
 		return result, err
 	}
 	err := ec.c.CallContext(ctx, &result, "engine_getPayloadV1", payloadId)
@@ -284,18 +288,18 @@ func (ec *EngineClient) EngineGetPayloadV1(ctx context.Context, payloadId *Paylo
 
 func (ec *EngineClient) EngineNewPayloadV1(ctx context.Context, payload *ExecutableDataV1) (PayloadStatusV1, error) {
 	var result PayloadStatusV1
-	if err := ec.PrepareAuthCallToken(); err != nil {
+	if err := ec.PrepareDefaultAuthCallToken(); err != nil {
 		return result, err
 	}
 	err := ec.c.CallContext(ctx, &result, "engine_newPayloadV1", payload)
 	return result, err
 }
 
-func (ec *EngineClient) EngineExchangeTransitionConfigurationV1(ctx context.Context, t *TransitionConfigurationV1) (TransitionConfigurationV1, error) {
+func (ec *EngineClient) EngineExchangeTransitionConfigurationV1(ctx context.Context, tConf *TransitionConfigurationV1) (TransitionConfigurationV1, error) {
 	var result TransitionConfigurationV1
-	if err := ec.PrepareAuthCallToken(); err != nil {
+	if err := ec.PrepareDefaultAuthCallToken(); err != nil {
 		return result, err
 	}
-	err := ec.c.CallContext(ctx, &result, "engine_exchangeTransitionConfigurationV1", t)
+	err := ec.c.CallContext(ctx, &result, "engine_exchangeTransitionConfigurationV1", tConf)
 	return result, err
 }

--- a/simulators/ethereum/engine/engineclient.go
+++ b/simulators/ethereum/engine/engineclient.go
@@ -293,6 +293,9 @@ func (ec *EngineClient) EngineNewPayloadV1(ctx context.Context, payload *Executa
 
 func (ec *EngineClient) EngineExchangeTransitionConfigurationV1(ctx context.Context, t *TransitionConfigurationV1) (TransitionConfigurationV1, error) {
 	var result TransitionConfigurationV1
+	if err := ec.PrepareAuthCallToken(); err != nil {
+		return result, err
+	}
 	err := ec.c.CallContext(ctx, &result, "engine_exchangeTransitionConfigurationV1", t)
 	return result, err
 }

--- a/simulators/ethereum/engine/engineclient.go
+++ b/simulators/ethereum/engine/engineclient.go
@@ -230,9 +230,9 @@ type payloadAttributesMarshaling struct {
 
 //go:generate go run github.com/fjl/gencodec -type TransitionConfigurationV1 -field-override TransitionConfigurationV1Marshaling -out gen_transitionconf.go
 type TransitionConfigurationV1 struct {
-	TerminalTotalDifficulty *big.Int     `json:"terminalTotalDifficulty" gencodec:"required"`
-	TerminalBlockHash       *common.Hash `json:"terminalBlockHash"       gencodec:"required"`
-	TerminalBlockNumber     uint64       `json:"terminalBlockNumber"     gencodec:"required"`
+	TerminalTotalDifficulty *big.Int    `json:"terminalTotalDifficulty" gencodec:"required"`
+	TerminalBlockHash       common.Hash `json:"terminalBlockHash"       gencodec:"required"`
+	TerminalBlockNumber     uint64      `json:"terminalBlockNumber"     gencodec:"required"`
 }
 
 // JSON type overrides for TransitionConfigurationV1.

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -185,6 +185,18 @@ var engineTests = []TestSpec{
 		Run:  postMergeSync,
 		TTD:  10,
 	},
+
+	// Exchange Transition Configuration tests
+	{
+		Name: "Exchange Transition Configuration PreMerge",
+		Run:  exTransitionConfigPreMerge,
+		TTD:  1000000,
+	},
+	{
+		Name: "Exchange Transition Configuration PostMerge",
+		Run:  exTransitionConfigPostMerge,
+		TTD:  10,
+	},
 }
 
 // Invalid Terminal Block in ForkchoiceUpdated: Client must reject ForkchoiceUpdated directives if the referenced HeadBlockHash does not meet the TTD requirement.
@@ -1530,4 +1542,16 @@ func postMergeSync(t *TestEnv) {
 			}
 		}
 	}
+}
+
+func exTransitionConfigPreMerge(t *TestEnv) {
+	// Verify transition information
+	t.VerifyTransitionInformation(t.Engine)
+}
+
+func exTransitionConfigPostMerge(t *TestEnv) {
+	// Wait for TTD to happen
+	t.CLMock.waitForTTD()
+	// Verify transition information
+	t.VerifyTransitionInformation(t.Engine)
 }

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -188,14 +188,15 @@ var engineTests = []TestSpec{
 
 	// Exchange Transition Configuration tests
 	{
-		Name: "Exchange Transition Configuration PreMerge",
-		Run:  exTransitionConfigPreMerge,
-		TTD:  1000000,
+		Name:              "Exchange Transition Configuration Set",
+		Run:               exTransitionConfig,
+		TTD:               1000000,
+		TerminalBlockHash: common.Hash{1},
 	},
 	{
-		Name: "Exchange Transition Configuration PostMerge",
-		Run:  exTransitionConfigPostMerge,
-		TTD:  10,
+		Name: "Exchange Transition Configuration Unset",
+		Run:  exTransitionConfig,
+		TTD:  1000000,
 	},
 }
 
@@ -1200,10 +1201,10 @@ func multipleNewCanonicalPayloads(t *TestEnv) {
 				}
 				newPayloadResp, err := t.Engine.EngineNewPayloadV1(t.Engine.Ctx(), newPayload)
 				if err != nil {
-					t.Fatalf("FAIL (%s): Unable to send new valid payload extending canonical chain: %v", err)
+					t.Fatalf("FAIL (%s): Unable to send new valid payload extending canonical chain: %v", t.TestName, err)
 				}
 				if newPayloadResp.Status != "VALID" {
-					t.Fatalf("FAIL (%s): Unexpected status after trying to send new valid payload extending canonical chain: %v", newPayloadResp)
+					t.Fatalf("FAIL (%s): Unexpected status after trying to send new valid payload extending canonical chain: %v", t.TestName, newPayloadResp)
 				}
 			}
 		},
@@ -1562,14 +1563,7 @@ func postMergeSync(t *TestEnv) {
 	}
 }
 
-func exTransitionConfigPreMerge(t *TestEnv) {
-	// Verify transition information
-	t.VerifyTransitionInformation(t.Engine)
-}
-
-func exTransitionConfigPostMerge(t *TestEnv) {
-	// Wait for TTD to happen
-	t.CLMock.waitForTTD()
+func exTransitionConfig(t *TestEnv) {
 	// Verify transition information
 	t.VerifyTransitionInformation(t.Engine)
 }

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -677,7 +677,7 @@ func invalidPayloadTestCaseGen(payloadField string) func(*TestEnv) {
 					t.Fatalf("FAIL (%s): Invalid test case: %s", t.TestName, payloadField)
 				}
 
-				t.Logf("INFO (%v) customizing payload using: %v\n", t.TestName, customPayloadMod)
+				t.Logf("INFO (%v) customizing payload using: %s\n", t.TestName, customPayloadMod.String())
 				alteredPayload, err := customizePayload(&t.CLMock.LatestPayloadBuilt, customPayloadMod)
 				t.Logf("INFO (%v) latest real getPayload (not executed): hash=%v contents=%v\n", t.TestName, t.CLMock.LatestPayloadBuilt.BlockHash, t.CLMock.LatestPayloadBuilt)
 				t.Logf("INFO (%v) customized payload: hash=%v contents=%v\n", t.TestName, alteredPayload.BlockHash, alteredPayload)
@@ -912,10 +912,38 @@ func blockStatusReorg(t *TestEnv) {
 	t.CLMock.produceBlocks(5, BlockProcessCallbacks{})
 
 	t.CLMock.produceSingleBlock(BlockProcessCallbacks{
-		// Run test after a forkchoice with new HeadBlockHash has been broadcasted
-		OnHeadBlockForkchoiceBroadcast: func() {
+		OnGetPayload: func() {
+			// Run using an alternative Payload, verify that the latest info is updated after re-org
+			customRandom := common.Hash{}
+			rand.Read(customRandom[:])
+			customizedPayload, err := customizePayload(&t.CLMock.LatestPayloadBuilt, &CustomPayloadData{
+				PrevRandao: &customRandom,
+			})
+			if err != nil {
+				t.Fatalf("FAIL (%s): Unable to customize payload: %v", t.TestName, err)
+			}
+
+			// Send custom payload and fcU to it
+			t.CLMock.broadcastNewPayload(customizedPayload)
+			t.CLMock.broadcastForkchoiceUpdated(&ForkchoiceStateV1{
+				HeadBlockHash:      customizedPayload.BlockHash,
+				SafeBlockHash:      t.CLMock.LatestForkchoice.SafeBlockHash,
+				FinalizedBlockHash: t.CLMock.LatestForkchoice.FinalizedBlockHash,
+			}, nil)
 
 			// Verify the client is serving the latest HeadBlock
+			currentBlockHeader, err := t.Eth.HeaderByNumber(t.Ctx(), nil)
+			if err != nil {
+				t.Fatalf("FAIL (%s): Unable to get latest block header: %v", t.TestName, err)
+			}
+			if currentBlockHeader.Hash() != customizedPayload.BlockHash {
+				t.Fatalf("FAIL (%s): latest block header doesn't match HeadBlock hash: %v, %v", t.TestName, currentBlockHeader.Hash(), t.CLMock.LatestForkchoice)
+			}
+
+		},
+		OnHeadBlockForkchoiceBroadcast: func() {
+			// At this point, we have re-org'd to the payload that the CLMocker was originally planning to send,
+			// verify that the client is serving the latest HeadBlock.
 			currentBlockHeader, err := t.Eth.HeaderByNumber(t.Ctx(), nil)
 			if err != nil {
 				t.Fatalf("FAIL (%s): Unable to get latest block header: %v", t.TestName, err)
@@ -926,52 +954,12 @@ func blockStatusReorg(t *TestEnv) {
 				t.Fatalf("FAIL (%s): latest block header doesn't match HeadBlock hash: %v, %v", t.TestName, currentBlockHeader.Hash(), t.CLMock.LatestForkchoice)
 			}
 
-			// Reorg back to the previous block (FinalizedBlock)
-			reorgForkchoice := ForkchoiceStateV1{
-				HeadBlockHash:      t.CLMock.LatestForkchoice.FinalizedBlockHash,
-				SafeBlockHash:      t.CLMock.LatestForkchoice.FinalizedBlockHash,
-				FinalizedBlockHash: t.CLMock.LatestForkchoice.FinalizedBlockHash,
-			}
-			resp, err := t.Engine.EngineForkchoiceUpdatedV1(t.Engine.Ctx(), &reorgForkchoice, nil)
-			if err != nil {
-				t.Fatalf("FAIL (%s): Could not send forkchoiceUpdatedV1: %v", t.TestName, err)
-			}
-			if resp.PayloadStatus.Status != "VALID" {
-				t.Fatalf("FAIL (%s): Incorrect status returned after a HeadBlockHash reorg: %v", t.TestName, resp.PayloadStatus.Status)
-			}
-			if *resp.PayloadStatus.LatestValidHash != reorgForkchoice.HeadBlockHash {
-				t.Fatalf("FAIL (%s): Incorrect latestValidHash returned after a HeadBlockHash reorg: %v!=%v", t.TestName, resp.PayloadStatus.LatestValidHash, reorgForkchoice.HeadBlockHash)
-			}
-
-			// Check that we reorg to the previous block
-			currentBlockHeader, err = t.Eth.HeaderByNumber(t.Ctx(), nil)
-			if err != nil {
-				t.Fatalf("FAIL (%s): Unable to get latest block header: %v", t.TestName, err)
-			}
-
-			if currentBlockHeader.Hash() != reorgForkchoice.HeadBlockHash {
-				t.Fatalf("FAIL (%s): `latest` block hash doesn't match reorg hash: %v, %v", t.TestName, currentBlockHeader.Hash(), reorgForkchoice.HeadBlockHash)
-			}
-
-			// Send the HeadBlock again to leave everything back the way it was
-			resp, err = t.Engine.EngineForkchoiceUpdatedV1(t.Engine.Ctx(), &t.CLMock.LatestForkchoice, nil)
-			if err != nil {
-				t.Fatalf("FAIL (%s): Could not send forkchoiceUpdatedV1: %v", t.TestName, err)
-			}
-			if resp.PayloadStatus.Status != "VALID" {
-				t.Fatalf("FAIL (%s): Incorrect status returned after a HeadBlockHash reorg: %v", t.TestName, resp.PayloadStatus.Status)
-			}
-
-			if *resp.PayloadStatus.LatestValidHash != t.CLMock.LatestForkchoice.HeadBlockHash {
-				t.Fatalf("FAIL (%s): Incorrect latestValidHash returned after a HeadBlockHash reorg: %v!=%v", t.TestName, resp.PayloadStatus.LatestValidHash, t.CLMock.LatestForkchoice.FinalizedBlockHash)
-			}
-
 		},
 	})
 
 }
 
-// Test transaction status after a forkchoiceUpdated re-orgs to previous hash
+// Test transaction status after a forkchoiceUpdated re-orgs to an alternative hash where a transaction is not present
 func transactionReorg(t *TestEnv) {
 	// Wait until this client catches up with latest PoS
 	t.CLMock.waitForTTD()
@@ -983,93 +971,100 @@ func transactionReorg(t *TestEnv) {
 	var (
 		txCount            = 5
 		sstoreContractAddr = common.HexToAddress("0000000000000000000000000000000000000317")
-		receipts           = make([]*types.Receipt, txCount)
 	)
 
-	var txs = make([]*types.Transaction, txCount)
 	for i := 0; i < txCount; i++ {
-		// Data is the key where a `1` will be stored
-		data := common.LeftPadBytes([]byte{byte(i)}, 32)
-		t.Logf("transactionReorg, i=%v, data=%v\n", i, data)
-		tx := t.makeNextTransaction(sstoreContractAddr, big0, data)
-		txs[i] = tx
+		var (
+			noTxnPayload ExecutableDataV1
+			tx           *types.Transaction
+		)
+		// Generate two payloads, one with the transaction and the other one without it
+		t.CLMock.produceSingleBlock(BlockProcessCallbacks{
+			OnPayloadProducerSelected: func() {
+				// At this point we have not broadcast the transaction,
+				// therefore any payload we get should not contain any
+				t.CLMock.getNextPayloadID()
+				t.CLMock.getNextPayload()
+				noTxnPayload = t.CLMock.LatestPayloadBuilt
+				if len(noTxnPayload.Transactions) != 0 {
+					t.Fatalf("FAIL (%s): Empty payload contains transactions: %v", t.TestName, noTxnPayload)
+				}
 
-		// Send the transaction
-		if err := t.Eth.SendTransaction(t.Ctx(), tx); err != nil {
-			t.Fatalf("FAIL (%s): Unable to send transaction: %v", t.TestName, err)
-		}
-		// Produce the block containing the transaction
-		t.CLMock.produceSingleBlock(BlockProcessCallbacks{})
+				// At this point we can broadcast the transaction and it will be included in the next payload
+				// Data is the key where a `1` will be stored
+				data := common.LeftPadBytes([]byte{byte(i)}, 32)
+				t.Logf("transactionReorg, i=%v, data=%v\n", i, data)
+				tx = t.makeNextTransaction(sstoreContractAddr, big0, data)
 
-		// Get the receipt
-		receipt, err := t.Eth.TransactionReceipt(t.Ctx(), tx.Hash())
-		if err != nil {
-			t.Fatalf("FAIL (%s): Unable to obtain transaction receipt: %v", t.TestName, err)
-		}
-		receipts[i] = receipt
+				// Send the transaction
+				if err := t.Eth.SendTransaction(t.Ctx(), tx); err != nil {
+					t.Fatalf("FAIL (%s): Unable to send transaction: %v", t.TestName, err)
+				}
+				// Get the receipt
+				receipt, _ := t.Eth.TransactionReceipt(t.Ctx(), tx.Hash())
+				if receipt != nil {
+					t.Fatalf("FAIL (%s): Receipt obtained before tx included in block: %v", t.TestName, receipt)
+				}
+			},
+			OnGetPayload: func() {
+				// Check that indeed the payload contains the transaction
+				if !TransactionInPayload(&t.CLMock.LatestPayloadBuilt, tx) {
+					t.Fatalf("FAIL (%s): Payload built does not contain the transaction: %v", t.TestName, t.CLMock.LatestPayloadBuilt)
+				}
+			},
+			OnHeadBlockForkchoiceBroadcast: func() {
+				// Transaction is now in the head of the canonical chain, re-org and verify it's removed
+				// Get the receipt
+				_, err := t.Eth.TransactionReceipt(t.Ctx(), tx.Hash())
+				if err != nil {
+					t.Fatalf("FAIL (%s): Unable to obtain transaction receipt: %v", t.TestName, err)
+				}
+
+				if noTxnPayload.ParentHash != t.CLMock.LatestPayloadBuilt.ParentHash {
+					t.Fatalf("FAIL (%s): Incorrect parent hash for payloads: %v != %v", t.TestName, noTxnPayload.ParentHash, t.CLMock.LatestPayloadBuilt.ParentHash)
+				}
+				if noTxnPayload.BlockHash == t.CLMock.LatestPayloadBuilt.BlockHash {
+					t.Fatalf("FAIL (%s): Incorrect hash for payloads: %v == %v", t.TestName, noTxnPayload.BlockHash, t.CLMock.LatestPayloadBuilt.BlockHash)
+				}
+
+				status, err := t.Engine.EngineNewPayloadV1(t.Engine.Ctx(), &noTxnPayload)
+				if err != nil {
+					t.Fatalf("FAIL (%s): Error sending no-txn payload: %v", t.TestName, err)
+				}
+				if status.Status != "VALID" {
+					t.Fatalf("FAIL (%s): Invalid status on sending no-txn payload: %v", t.TestName, status.Status)
+				}
+				resp, err := t.Engine.EngineForkchoiceUpdatedV1(t.Engine.Ctx(), &ForkchoiceStateV1{
+					HeadBlockHash:      noTxnPayload.BlockHash,
+					SafeBlockHash:      t.CLMock.LatestForkchoice.SafeBlockHash,
+					FinalizedBlockHash: t.CLMock.LatestForkchoice.FinalizedBlockHash,
+				}, nil)
+				if err != nil {
+					t.Fatalf("FAIL (%s): Error during forkchoiceUpdated to no-txn payload: %v", t.TestName, err)
+				}
+				if resp.PayloadStatus.Status != "VALID" {
+					t.Fatalf("FAIL (%s): Invalid status on forkchoiceUpdated for no-txn payload: %v", t.TestName, resp.PayloadStatus.Status)
+				}
+
+				latestBlock, err := t.Eth.BlockByNumber(t.Engine.Ctx(), nil)
+				if err != nil {
+					t.Fatalf("FAIL (%s): Error getting latest block after no-txn payload: %v", t.TestName, err)
+				}
+				if latestBlock.Hash() != noTxnPayload.BlockHash {
+					t.Fatalf("FAIL (%s): Incorrect block after re-org: %v != %v", t.TestName, latestBlock.Hash(), noTxnPayload.BlockHash)
+				}
+				reorgReceipt, err := t.Eth.TransactionReceipt(t.Ctx(), tx.Hash())
+				if reorgReceipt != nil {
+					t.Fatalf("FAIL (%s): Receipt was obtained when the tx had been re-org'd out: %v", t.TestName, reorgReceipt)
+				}
+
+				// Re-org back
+				t.CLMock.broadcastForkchoiceUpdated(&t.CLMock.LatestForkchoice, nil)
+			},
+		})
+
 	}
 
-	for i := 0; i < txCount; i++ {
-		// The sstore contract stores a `1` to key specified in data
-		storageKey := common.Hash{}
-		storageKey[31] = byte(i)
-
-		valueWithTxApplied, err := getBigIntAtStorage(t.Eth, t.Ctx(), sstoreContractAddr, storageKey, nil)
-		if err != nil {
-			t.Fatalf("FAIL (%s): Could not get storage: %v", t.TestName, err)
-		}
-		t.Logf("transactionReorg, stor[%v]: %v\n", i, valueWithTxApplied)
-
-		if valueWithTxApplied.Cmp(common.Big1) != 0 {
-			t.Fatalf("FAIL (%s): Expected storage not set after transaction (before re-org): %v", t.TestName, valueWithTxApplied)
-		}
-
-		// Get value at a block before the tx was included
-		reorgBlock, err := t.Eth.BlockByNumber(t.Ctx(), receipts[i].BlockNumber.Sub(receipts[i].BlockNumber, common.Big1))
-		valueWithoutTxApplied, err := getBigIntAtStorage(t.Eth, t.Ctx(), sstoreContractAddr, storageKey, reorgBlock.Number())
-		if err != nil {
-			t.Fatalf("FAIL (%s): Could not get storage: %v", t.TestName, err)
-		}
-		t.Logf("transactionReorg, stor[%v]: %v\n", i, valueWithoutTxApplied)
-
-		if valueWithoutTxApplied.Cmp(common.Big0) != 0 {
-			t.Fatalf("FAIL (%s): Storage not unset before transaction!: %v", t.TestName, valueWithoutTxApplied)
-		}
-
-		// Re-org back to a previous block where the tx is not included using forkchoiceUpdated
-		reorgForkchoice := ForkchoiceStateV1{
-			HeadBlockHash:      reorgBlock.Hash(),
-			SafeBlockHash:      reorgBlock.Hash(),
-			FinalizedBlockHash: reorgBlock.Hash(),
-		}
-		resp, err := t.Engine.EngineForkchoiceUpdatedV1(t.Engine.Ctx(), &reorgForkchoice, nil)
-		if err != nil {
-			t.Fatalf("FAIL (%s): Could not send forkchoiceUpdatedV1: %v", t.TestName, err)
-		}
-		if resp.PayloadStatus.Status != "VALID" {
-			t.Fatalf("FAIL (%s): Could not send forkchoiceUpdatedV1: %v", t.TestName, err)
-		}
-
-		// Check storage again using `latest`, should be unset
-		valueAfterReOrgBeforeTxApplied, err := getBigIntAtStorage(t.Eth, t.Ctx(), sstoreContractAddr, storageKey, nil)
-		if err != nil {
-			t.Fatalf("FAIL (%s): Could not get storage: %v", t.TestName, err)
-		}
-		t.Logf("transactionReorg, stor[%v]: %v\n", i, valueAfterReOrgBeforeTxApplied)
-
-		if valueAfterReOrgBeforeTxApplied.Cmp(common.Big0) != 0 {
-			t.Fatalf("FAIL (%s): Storage not unset after re-org: %v", t.TestName, valueAfterReOrgBeforeTxApplied)
-		}
-
-		// Re-send latest forkchoice to test next transaction
-		resp, err = t.Engine.EngineForkchoiceUpdatedV1(t.Engine.Ctx(), &t.CLMock.LatestForkchoice, nil)
-		if err != nil {
-			t.Fatalf("FAIL (%s): Could not send forkchoiceUpdatedV1: %v", t.TestName, err)
-		}
-		if resp.PayloadStatus.Status != "VALID" {
-			t.Fatalf("FAIL (%s): Could not send forkchoiceUpdatedV1: %v", t.TestName, err)
-		}
-	}
 }
 
 // Reorg to a Sidechain using ForkchoiceUpdated
@@ -1229,7 +1224,7 @@ func outOfOrderPayloads(t *TestEnv) {
 	rand.Read(recipient[:])
 	amountPerTx := big.NewInt(1000)
 	txPerPayload := 20
-	payloadCount := 10
+	payloadCount := 2
 
 	t.CLMock.produceBlocks(payloadCount, BlockProcessCallbacks{
 		// We send the transactions after we got the Payload ID, before the CLMocker gets the prepared Payload
@@ -1260,8 +1255,13 @@ func outOfOrderPayloads(t *TestEnv) {
 	if err != nil {
 		t.Fatalf("FAIL (%s): Unable to obtain all client types", t.TestName)
 	}
-	for _, client := range allClients {
+
+	secondaryEngineClients := make([]*EngineClient, len(allClients))
+
+	for i, client := range allClients {
 		_, ec, err := t.StartClient(client, t.ClientParams, t.MainTTD())
+		secondaryEngineClients[i] = ec
+
 		if err != nil {
 			t.Fatalf("FAIL (%s): Unable to start client (%v): %v", t.TestName, client, err)
 		}
@@ -1316,7 +1316,16 @@ func outOfOrderPayloads(t *TestEnv) {
 				}
 			}
 		}
+	}
+	// Add the clients to the CLMocker
+	for _, ec := range secondaryEngineClients {
+		t.CLMock.AddEngineClient(t.T, ec.Client, t.MainTTD())
+	}
 
+	// Produce a single block on top of the canonical chain, all clients must accept this
+	t.CLMock.produceSingleBlock(BlockProcessCallbacks{})
+
+	for _, ec := range secondaryEngineClients {
 		// At this point we should have our funded account balance equal to the expected value.
 		bal, err := ec.Eth.BalanceAt(ec.Ctx(), recipient, nil)
 		if err != nil {
@@ -1343,11 +1352,20 @@ func suggestedFeeRecipient(t *TestEnv) {
 
 	// Send multiple transactions
 	for i := 0; i < txCount; i++ {
-		// Empty self tx
 		tx := t.makeNextTransaction(vaultAccountAddr, big0, nil)
-		if err := t.Eth.SendTransaction(t.Ctx(), tx); err != nil {
-			t.Fatalf("FAIL (%s): unable to send transaction: %v", t.TestName, err)
+		// Empty self tx
+		for {
+			err := t.Eth.SendTransaction(t.Ctx(), tx)
+			if err == nil {
+				break
+			}
+			select {
+			case <-time.After(time.Second):
+			case <-t.Timeout:
+				t.Fatalf("FAIL (%s): Timeout while waiting to send transaction: %v", t.TestName, err)
+			}
 		}
+
 	}
 	// Produce the next block with the fee recipient set
 	t.CLMock.NextFeeRecipient = feeRecipient

--- a/simulators/ethereum/engine/gen_transitionconf.go
+++ b/simulators/ethereum/engine/gen_transitionconf.go
@@ -17,7 +17,7 @@ var _ = (*TransitionConfigurationV1Marshaling)(nil)
 func (t TransitionConfigurationV1) MarshalJSON() ([]byte, error) {
 	type TransitionConfigurationV1 struct {
 		TerminalTotalDifficulty *hexutil.Big   `json:"terminalTotalDifficulty" gencodec:"required"`
-		TerminalBlockHash       *common.Hash   `json:"terminalBlockHash"       gencodec:"required"`
+		TerminalBlockHash       common.Hash    `json:"terminalBlockHash"       gencodec:"required"`
 		TerminalBlockNumber     hexutil.Uint64 `json:"terminalBlockNumber"     gencodec:"required"`
 	}
 	var enc TransitionConfigurationV1
@@ -45,7 +45,7 @@ func (t *TransitionConfigurationV1) UnmarshalJSON(input []byte) error {
 	if dec.TerminalBlockHash == nil {
 		return errors.New("missing required field 'terminalBlockHash' for TransitionConfigurationV1")
 	}
-	t.TerminalBlockHash = dec.TerminalBlockHash
+	t.TerminalBlockHash = *dec.TerminalBlockHash
 	if dec.TerminalBlockNumber == nil {
 		return errors.New("missing required field 'terminalBlockNumber' for TransitionConfigurationV1")
 	}

--- a/simulators/ethereum/engine/helper.go
+++ b/simulators/ethereum/engine/helper.go
@@ -378,3 +378,48 @@ func (tdh *TotalDifficultyHeader) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+// Check transition information exchange for a given client
+func (t *TestEnv) VerifyTransitionInformation(ec *EngineClient) {
+	// Send a simple Exchange Transition Configuration directive before the merge takes place
+	trConfResp, err := ec.EngineExchangeTransitionConfigurationV1(ec.Ctx(), &TransitionConfigurationV1{
+		TerminalTotalDifficulty: t.MainTTD(),
+		TerminalBlockHash:       common.Hash{},
+		TerminalBlockNumber:     0,
+	})
+	if err != nil {
+		t.Fatalf("FAIL (%s): Unable to get Exchange Transition Configuration: %v", t.TestName, err)
+	}
+
+	// Returned terminal block hash must be equal to what the CLMocker observed so far
+	if t.CLMock.TerminalBlockHash == nil {
+		// We haven't gone through the transition, returned hash must be zeros
+		emptyHash := common.Hash{}
+		if trConfResp.TerminalBlockHash != emptyHash {
+			t.Fatalf("FAIL (%s): TerminalBlockHash is not empty even though we have not gone through the transition: %v", t.TestName, trConfResp.TerminalBlockHash)
+		}
+	} else {
+		// We have gone through the transition, returned hash must be equal to what the CL observed
+		if trConfResp.TerminalBlockHash != *t.CLMock.TerminalBlockHash {
+			t.Fatalf("FAIL (%s): TerminalBlockHash does not match what the CLMocker observed: %v != %v", t.TestName, trConfResp.TerminalBlockHash, t.CLMock.TerminalBlockHash)
+		}
+	}
+
+	// Returned terminal block number must be equal to what the CLMocker observed so far
+	if t.CLMock.TerminalBlockNumber == nil {
+		// We haven't gone through the transition, returned number must be zero
+		if trConfResp.TerminalBlockNumber != 0 {
+			t.Fatalf("FAIL (%s): TerminalBlockNumber is not zero even though we have not gone through the transition: %v", t.TestName, trConfResp.TerminalBlockNumber)
+		}
+	} else {
+		// We have gone through the transition, returned hash must be equal to what the CL observed
+		if trConfResp.TerminalBlockNumber != *t.CLMock.TerminalBlockNumber {
+			t.Fatalf("FAIL (%s): TerminalBlockNumber does not match what the CLMocker observed: %v != %v", t.TestName, trConfResp.TerminalBlockNumber, t.CLMock.TerminalBlockNumber)
+		}
+	}
+
+	// Returned TTD must be equal to what we have configured, regardless of whether we have transitioned or not
+	if trConfResp.TerminalTotalDifficulty.Cmp(ec.TerminalTotalDifficulty) != 0 {
+		t.Fatalf("FAIL (%s): TerminalTotalDifficulty does not match expected configuration: %v != %v", t.TestName, trConfResp.TerminalTotalDifficulty, t.MainTTD())
+	}
+}

--- a/simulators/ethereum/engine/helper.go
+++ b/simulators/ethereum/engine/helper.go
@@ -448,35 +448,11 @@ func (t *TestEnv) VerifyTransitionInformation(ec *EngineClient) {
 		t.Fatalf("FAIL (%s): Unable to get Exchange Transition Configuration: %v", t.TestName, err)
 	}
 
-	// Returned terminal block hash must be equal to what the CLMocker observed so far
-	if t.CLMock.TerminalBlockHash == nil {
-		// We haven't gone through the transition, returned hash must be zeros
-		emptyHash := common.Hash{}
-		if trConfResp.TerminalBlockHash != emptyHash {
-			t.Fatalf("FAIL (%s): TerminalBlockHash is not empty even though we have not gone through the transition: %v", t.TestName, trConfResp.TerminalBlockHash)
-		}
-	} else {
-		// We have gone through the transition, returned hash must be equal to what the CL observed
-		if trConfResp.TerminalBlockHash != *t.CLMock.TerminalBlockHash {
-			t.Fatalf("FAIL (%s): TerminalBlockHash does not match what the CLMocker observed: %v != %v", t.TestName, trConfResp.TerminalBlockHash, t.CLMock.TerminalBlockHash)
-		}
+	if trConfResp.TerminalBlockHash != t.TestSpec.TerminalBlockHash {
+		t.Fatalf("FAIL (%s): Incorrect TerminalBlockHash %v != %v", t.TestName, trConfResp.TerminalBlockHash, t.TestSpec.TerminalBlockHash)
+	}
+	if trConfResp.TerminalBlockNumber != t.TestSpec.TerminalBlockNumber {
+		t.Fatalf("FAIL (%s): Incorrect TerminalBlockNumber: %d != %d", t.TestName, trConfResp.TerminalBlockNumber, t.TestSpec.TerminalBlockNumber)
 	}
 
-	// Returned terminal block number must be equal to what the CLMocker observed so far
-	if t.CLMock.TerminalBlockNumber == nil {
-		// We haven't gone through the transition, returned number must be zero
-		if trConfResp.TerminalBlockNumber != 0 {
-			t.Fatalf("FAIL (%s): TerminalBlockNumber is not zero even though we have not gone through the transition: %v", t.TestName, trConfResp.TerminalBlockNumber)
-		}
-	} else {
-		// We have gone through the transition, returned hash must be equal to what the CL observed
-		if trConfResp.TerminalBlockNumber != *t.CLMock.TerminalBlockNumber {
-			t.Fatalf("FAIL (%s): TerminalBlockNumber does not match what the CLMocker observed: %v != %v", t.TestName, trConfResp.TerminalBlockNumber, t.CLMock.TerminalBlockNumber)
-		}
-	}
-
-	// Returned TTD must be equal to what we have configured, regardless of whether we have transitioned or not
-	if trConfResp.TerminalTotalDifficulty.Cmp(ec.TerminalTotalDifficulty) != 0 {
-		t.Fatalf("FAIL (%s): TerminalTotalDifficulty does not match expected configuration: %v != %v", t.TestName, trConfResp.TerminalTotalDifficulty, t.MainTTD())
-	}
 }

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -37,8 +37,9 @@ var (
 	minerPKHex   = "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
 	minerAddrHex = "658bdf435d810c91414ec09147daa6db62406379"
 
-	// JWT Token Secret for authenticated Engine API calls
-	defaultJwtTokenSecret = "0x7365637265747365637265747365637265747365637265747365637265747365" // secretsecretsecretsecretsecretse
+	// JWT Authentication Related
+	defaultJwtTokenSecretBytes = []byte("secretsecretsecretsecretsecretse") // secretsecretsecretsecretsecretse
+	maxTimeDriftSeconds        = int64(5)
 )
 
 var clientEnv = hivesim.Params{
@@ -93,7 +94,10 @@ type TestSpec struct {
 
 var allTests = append(
 	engineTests,
-	mergeTests...,
+	append(
+		mergeTests,
+		authTests...,
+	)...,
 )
 
 func main() {

--- a/simulators/ethereum/engine/mergetests.go
+++ b/simulators/ethereum/engine/mergetests.go
@@ -220,6 +220,8 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 		if !mergeTestSpec.SkipMainClientFcU {
 			// Set the head of the CLMocker to the head of the main client
 			t.CLMock.setTTDBlockClient(t.Engine)
+			// Check the transition information exchange
+			t.VerifyTransitionInformation(t.Engine)
 		}
 
 		// At this point, Head must be main client's HeadBlockHash, but this can change depending on the
@@ -291,6 +293,10 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 			if header, err := t.Eth.HeaderByNumber(t.Ctx(), nil); err == nil {
 				if header.Hash() == mustHeadHash {
 					t.Logf("INFO (%s): Main client is now synced to the expected head, %v", t.TestName, header.Hash())
+					if mergeTestSpec.SecondaryClientSpecs.AnyPoSChainOnTop() {
+						// We are synced, but also check that the transition information was updated
+						t.VerifyTransitionInformation(t.Engine)
+					}
 					break
 				}
 			} else {

--- a/simulators/ethereum/engine/mergetests.go
+++ b/simulators/ethereum/engine/mergetests.go
@@ -221,7 +221,7 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 			// Set the head of the CLMocker to the head of the main client
 			t.CLMock.setTTDBlockClient(t.Engine)
 			// Check the transition information exchange
-			t.VerifyTransitionInformation(t.Engine)
+			// t.VerifyTransitionInformation(t.Engine)
 		}
 
 		// At this point, Head must be main client's HeadBlockHash, but this can change depending on the
@@ -295,7 +295,7 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 					t.Logf("INFO (%s): Main client is now synced to the expected head, %v", t.TestName, header.Hash())
 					if mergeTestSpec.SecondaryClientSpecs.AnyPoSChainOnTop() {
 						// We are synced, but also check that the transition information was updated
-						t.VerifyTransitionInformation(t.Engine)
+						// t.VerifyTransitionInformation(t.Engine)
 					}
 					break
 				}


### PR DESCRIPTION
This PR adds JWT authentication to all supported clients and also adds tests for the authentication as defined in the spec.
Basic tests for the ExchangeTransitionConfiguration but these are at the moment failing -- need to ask client devs regarding the expected outcome of these tests.
Existing re-org tests are now modified so the forkchoiceUpdated directive does not re-org back into the canonical chain, but always attempts to re-org to a new payload (sidechain).