### PR TITLE
simulators/engine: Add JWT Authentication tests

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -115,8 +115,11 @@ fi
 # Launch the main client.
 FLAGS="$FLAGS --nat=none"
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
+    echo -n $JWT_SECRET > /jwt.secret
     FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3,engine --engine.addr=0.0.0.0"
     FLAGS="$FLAGS --ws"
+    FLAGS="$FLAGS --authrpc.jwtsecret=/jwt.secret"
 else
     FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3"
     FLAGS="$FLAGS --ws"

--- a/clients/merge-go-ethereum/geth.sh
+++ b/clients/merge-go-ethereum/geth.sh
@@ -153,7 +153,7 @@ FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth
 
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
-    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8550 --authrpc.jwtsecret /jwtsecret"
+    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret /jwtsecret"
 fi
 
 # Configure GraphQL.

--- a/clients/merge-nethermind/Dockerfile
+++ b/clients/merge-nethermind/Dockerfile
@@ -1,5 +1,6 @@
-ARG branch=latest
-FROM nethermindeth/nethermind:kiln_0.5
+# ARG branch=latest
+ARG branch=kiln_test
+FROM nethermindeth/nethermind:$branch
 
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \

--- a/clients/merge-nethermind/mkconfig.jq
+++ b/clients/merge-nethermind/mkconfig.jq
@@ -25,8 +25,9 @@ def json_rpc_config:
   if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then
     {
       "JsonRpc": {
+        "JwtSecretFile": "/jwt.secret",
         "EnabledModules": ["Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health"],
-        "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|net;eth;subscribe;engine;web3;client", "http://0.0.0.0:8551|http;ws|net;eth;subscribe;engine;web3;client"]
+        "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|net;eth;subscribe;engine;web3;client|no-auth", "http://0.0.0.0:8551|http;ws|net;eth;subscribe;engine;web3;client"]
       }
     }
   else

--- a/clients/merge-nethermind/nethermind.sh
+++ b/clients/merge-nethermind/nethermind.sh
@@ -50,6 +50,12 @@
 # Immediately abort the script on any error encountered
 set -e
 
+# Generate JWT file if necessary
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
+    echo -n $JWT_SECRET > /jwt.secret
+fi
+
 # Generate the genesis and chainspec file.
 mkdir -p /chainspec
 jq -f /mapper.jq /genesis.json > /chainspec/test.json

--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -193,3 +193,32 @@ Verification is made that Client 1 Re-orgs to chain G -> B -> C.
  Client 1 starts with chain G -> A, Client 2 starts with chain G -> A -> B.  
  Block A reaches TTD, but Client 2 has a higher TTD and accepts block B (simulating a client not complying with the merge).  
  Verification is made that Client 1 does not follow Client 2 chain to block B.  
+
+## JWT Authentication Tests:
+- No time drift, correct secret:  
+Engine API call where the `iat` claim contains no time drift, and the secret to calculate the token is correct.
+No error is expected.
+
+- No time drift, incorrect secret (shorter):  
+Engine API call where the `iat` claim contains no time drift, but the secret to calculate the token is incorrectly shorter.
+Invalid token error is expected.
+
+- No time drift, incorrect secret (longer):  
+Engine API call where the `iat` claim contains no time drift, but the secret to calculate the token is incorrectly longer.
+Invalid token error is expected.
+
+- Negative time drift, exceeding limit, correct secret:  
+Engine API call where the `iat` claim contains a negative time drift greater than the maximum threshold, but the secret to calculate the token is correct.
+Invalid token error is expected.
+
+- Negative time drift, within limit, correct secret:  
+Engine API call where the `iat` claim contains a negative time drift smaller than the maximum threshold, and the secret to calculate the token is correct.
+No error is expected.
+
+- Positive time drift, exceeding limit, correct secret:  
+Engine API call where the `iat` claim contains a positive time drift greater than the maximum threshold, but the secret to calculate the token is correct.
+Invalid token error is expected.
+
+- Positive time drift, within limit, correct secret:  
+Engine API call where the `iat` claim contains a positive time drift smaller than the maximum threshold, and the secret to calculate the token is correct.
+No error is expected.

--- a/simulators/ethereum/engine/authtests.go
+++ b/simulators/ethereum/engine/authtests.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// JWT Authentication Tests
+type AuthTestSpec struct {
+	Name                  string
+	TimeDriftSeconds      int64
+	CustomAuthSecretBytes []byte
+	AuthOk                bool
+}
+
+var authTestSpecs = []AuthTestSpec{
+	{
+		Name:                  "JWT Authentication: No time drift, correct secret",
+		TimeDriftSeconds:      0,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                true,
+	},
+	{
+		Name:                  "JWT Authentication: No time drift, incorrect secret (shorter)",
+		TimeDriftSeconds:      0,
+		CustomAuthSecretBytes: []byte("secretsecretsecretsecretsecrets"),
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: No time drift, incorrect secret (longer)",
+		TimeDriftSeconds:      0,
+		CustomAuthSecretBytes: append([]byte{0}, []byte("secretsecretsecretsecretsecretse")...),
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: Negative time drift, exceeding limit, correct secret",
+		TimeDriftSeconds:      -1 - maxTimeDriftSeconds,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: Negative time drift, within limit, correct secret",
+		TimeDriftSeconds:      1 - maxTimeDriftSeconds,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                true,
+	},
+	{
+		Name:                  "JWT Authentication: Positive time drift, exceeding limit, correct secret",
+		TimeDriftSeconds:      maxTimeDriftSeconds + 1,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                false,
+	},
+	{
+		Name:                  "JWT Authentication: Positive time drift, within limit, correct secret",
+		TimeDriftSeconds:      maxTimeDriftSeconds - 1,
+		CustomAuthSecretBytes: nil,
+		AuthOk:                true,
+	},
+}
+
+var authTests = func() []TestSpec {
+	testSpecs := make([]TestSpec, 0)
+	for _, authTest := range authTestSpecs {
+		testSpecs = append(testSpecs, GenerateAuthTestSpec(authTest))
+	}
+	return testSpecs
+}()
+
+func GenerateAuthTestSpec(authTestSpec AuthTestSpec) TestSpec {
+	runFunc := func(t *TestEnv) {
+		// Default values
+		var (
+			// All test cases send a simple TransitionConfigurationV1 to check the Authentication mechanism (JWT)
+			tConf = TransitionConfigurationV1{
+				TerminalTotalDifficulty: t.MainTTD(),
+				TerminalBlockHash:       &(common.Hash{}),
+				TerminalBlockNumber:     0,
+			}
+			testSecret = authTestSpec.CustomAuthSecretBytes
+			testTime   = time.Now()
+		)
+		if testSecret == nil {
+			testSecret = defaultJwtTokenSecretBytes
+		}
+		if authTestSpec.TimeDriftSeconds != 0 {
+			testTime = testTime.Add(time.Second * time.Duration(authTestSpec.TimeDriftSeconds))
+		}
+		if err := t.Engine.PrepareAuthCallToken(testSecret, testTime); err != nil {
+			t.Fatalf("FAIL (%s): Unable to prepare the auth token: %v", t.TestName, err)
+		}
+		err := t.Engine.c.CallContext(t.Engine.Ctx(), &tConf, "engine_exchangeTransitionConfigurationV1", tConf)
+		if authTestSpec.AuthOk {
+			if err != nil {
+				t.Fatalf("FAIL (%s): Authentication was supposed to pass authentication but failed: %v", t.TestName, err)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("FAIL (%s): Authentication was supposed to fail authentication but passed", t.TestName)
+			}
+		}
+	}
+	return TestSpec{
+		Name: authTestSpec.Name,
+		Run:  runFunc,
+	}
+}

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -37,8 +37,9 @@ var (
 	minerPKHex   = "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
 	minerAddrHex = "658bdf435d810c91414ec09147daa6db62406379"
 
-	// JWT Token Secret for authenticated Engine API calls
-	defaultJwtTokenSecret = "0x7365637265747365637265747365637265747365637265747365637265747365" // secretsecretsecretsecretsecretse
+	// JWT Authentication Related
+	defaultJwtTokenSecretBytes = []byte("secretsecretsecretsecretsecretse") // secretsecretsecretsecretsecretse
+	maxTimeDriftSeconds        = int64(5)
 )
 
 var clientEnv = hivesim.Params{
@@ -93,7 +94,10 @@ type TestSpec struct {
 
 var allTests = append(
 	engineTests,
-	mergeTests...,
+	append(
+		mergeTests,
+		authTests...,
+	)...,
 )
 
 func main() {


### PR DESCRIPTION
This PR adds the following JWT authentication tests:
- No time drift, correct secret
- No time drift, incorrect secret (shorter)
- No time drift, incorrect secret (longer)
- Negative time drift, exceeding limit, correct secret
- Negative time drift, within limit, correct secret
- Positive time drift, exceeding limit, correct secret
- Positive time drift, within limit, correct secret