### PR TITLE
simulators/ethereum/engine: Increase bad hash tests coverage

### DIFF
--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -68,7 +68,11 @@ Perform a forkchoiceUpdated call with an unknown (random) FinalizedBlockHash, th
 Perform a forkchoiceUpdated call using a block hash part of the canonical chain that precedes the block where the TTD occurred. (Behavior is undefined for this edge case and not verified, but should not produce unrecoverable error)
 
 - Bad blockhash on NewPayload:  
-Send a NewPayload directive to the client including an incorrect BlockHash, should result in an error.
+Send a NewPayload directive to the client including an incorrect BlockHash, should result in an error in all the following cases:
+   - NewPayload while not syncing, on canonical chain
+   - NewPayload while not syncing, on side chain
+   - NewPayload while syncing, on canonical chain
+   - NewPayload while syncing, on side chain
 
 - ParentHash==BlockHash on NewPayload:  
 Send a NewPayload directive to the client including ParentHash that is equal to the BlockHash (Incorrect hash).


### PR DESCRIPTION
Adds first batch of new tests based on the coverage document by @mkalinin ([link](https://hackmd.io/vjgC9hV_TrK1ZuftVm1rZA)).

Tests added:
- EL Not SYNCING: Invalid hash payload extending side chain
- EL SYNCING: Invalid hash payload extending canonical chain
- EL SYNCING: Invalid hash payload extending side chain chain

Follow up PRs will fill remaining gaps. Please advice if this format is fine: small number of new tests per PR, or a big PR with all test cases is better.