### PR TITLE
Match Engine API Port Across Simulators/Clients

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -24,6 +24,6 @@ RUN chmod +x /hive-bin/enode.sh
 RUN /usr/local/bin/erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
 
 # Export the usual networking ports to allow outside access to the node.
-EXPOSE 8545 8546 8550 30303 30303/udp
+EXPOSE 8545 8546 8551 30303 30303/udp
 
 ENTRYPOINT ["/erigon.sh"]

--- a/clients/ethereumjs/Dockerfile
+++ b/clients/ethereumjs/Dockerfile
@@ -18,7 +18,7 @@ RUN chmod +x /hive-bin/enode.sh
 ADD genesis.json /genesis.json
 
 # Export the usual networking ports to allow outside access to the node
-EXPOSE 8545 8546 8550 8547 30303 30303/udp
+EXPOSE 8545 8546 8551 8547 30303 30303/udp
 
 # NodeJS applications have a default memory limit of 2.5GB.
 # This limit is bit tight, it is recommended to raise the limit

--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -43,7 +43,7 @@ RUN chmod +x /hive-bin/enode.sh
 ADD genesis.json /genesis.json
 
 # Export the usual networking ports to allow outside access to the node
-EXPOSE 8545 8546 8547 8550 30303 30303/udp
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
 
 # Generate the ethash verification caches
 RUN \

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -153,7 +153,7 @@ FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth
 
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
-    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8550 --authrpc.jwtsecret /jwtsecret"
+    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret /jwtsecret"
 fi
 
 # Configure GraphQL.

--- a/simulators/eth2/testnet/nodes.go
+++ b/simulators/eth2/testnet/nodes.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	PortUserRPC      = 8545
-	PortEngineRPC    = 8550
+	PortEngineRPC    = 8551
 	PortBeaconTCP    = 9000
 	PortBeaconUDP    = 9000
 	PortBeaconAPI    = 4000


### PR DESCRIPTION
This PR fixes the value of the Engine API Port across all the Simulators/Clients, making the following changes:

- Simulators
  - eth2/testnet: 8550 -> 8551
  - ethereum/engine: 8551 (No change)
- Clients
   - go-ethereum: 8550 -> 8551
   - nethermind: 8551 (No change)
   - ethereumjs: Expose port 8551
   - erigon: Expose port 8551