### PR TITLE
clients/merge-nethermind: update docker branch, increase extradata for clique

### DIFF
--- a/clients/merge-nethermind/Dockerfile
+++ b/clients/merge-nethermind/Dockerfile
@@ -1,5 +1,5 @@
 # ARG branch=latest
-ARG branch=kiln_test
+ARG branch=kiln_shadowfork
 FROM nethermindeth/nethermind:$branch
 
 RUN apt-get update && apt-get install -y wget

--- a/clients/merge-nethermind/mapper.jq
+++ b/clients/merge-nethermind/mapper.jq
@@ -95,6 +95,7 @@ def clique_engine:
     "eip155Transition": env.HIVE_FORK_SPURIOUS|to_hex,
     "maxCodeSizeTransition": env.HIVE_FORK_SPURIOUS|to_hex,
     "maxCodeSize": 24576,
+    "maximumExtraDataSize": "0x400",
 
     # Byzantium
     "eip140Transition": env.HIVE_FORK_BYZANTIUM|to_hex,


### PR DESCRIPTION
This PR updates the merge-nethermind branch to kiln_shadowfork.

Also, HIVE_MAX_EXTRA_DATA_SIZE was implemented to allow nethermind to sync pre-merge blocks that were generated using clique, which have an extradata size higher than the default of 32.