### PR TITLE
simulators/ethereum/engine: Add ForkchoiceUpdated with Invalid Payload Attributes Test

### DIFF
--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -66,6 +66,7 @@ Perform a forkchoiceUpdated call with an unknown (random) FinalizedBlockHash, th
 
 - Invalid Payload Attributes:
 Perform a forkchoiceUpdated call with valid forkchoice but invalid payload attributes.
+Expected outcome is that the forkchoiceUpdate proceeds, but the call returns an error.
 
 - Pre-TTD Block Hash:  
 Perform a forkchoiceUpdated call using a block hash part of the canonical chain that precedes the block where the TTD occurred. (Behavior is undefined for this edge case and not verified, but should not produce unrecoverable error)

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -418,19 +418,11 @@ func invalidPayloadAttributesGen(syncing bool) func(*TestEnv) {
 					PrevRandao:            common.Hash{},
 					SuggestedFeeRecipient: common.Address{},
 				}
-				// Outcome for this test is not final, at the moment these two options are being discussed:
-				// Option 1
 				// 0) Check headBlock is known and there is no missing data, if not respond with SYNCING
 				// 1) Check headBlock is VALID, if not respond with INVALID
 				// 2) Apply forkchoiceState
 				// 3) Check payloadAttributes, if invalid respond with error: code: Invalid payload attributes
 				// 4) Start payload build process and respond with VALID
-				//
-				// Option 2
-				// 0) Check headBlock is known and there is no missing data, if not respond with SYNCING
-				// 1) Check payloadAttributes (requires a lookup to database to get a timestamp of yet to be applied headBlock), if invalid respond with error: code: Invalid payload attributes
-				// 2) Check headBlock is VALID, if not respond with INVALID
-				// 3) Start payload build process and respond with VALID
 				if syncing {
 					// If we are SYNCING, the outcome should be SYNCING regardless of the validity of the payload atttributes
 					r := t.TestEngine.TestEngineForkchoiceUpdatedV1(&fcu, &attr)
@@ -440,9 +432,9 @@ func invalidPayloadAttributesGen(syncing bool) func(*TestEnv) {
 					r := t.TestEngine.TestEngineForkchoiceUpdatedV1(&fcu, &attr)
 					r.ExpectError()
 
-					// TBD: Check that the forkchoice not applied (Option 2 is implemented here)
+					// Check that the forkchoice was applied, regardless of the error
 					s := t.TestEth.TestHeaderByNumber(nil)
-					s.ExpectHash(t.CLMock.LatestFinalizedHeader.Hash())
+					s.ExpectHash(blockHash)
 				}
 			},
 		})


### PR DESCRIPTION
This PR adds test cases where a ForkchoiceUpdated directive is sent to the EL with invalid payload attributes, `timestamp==0`.

The expected behavior remains undecided with two options proposed, as per @mkalinin:

Option 1

0) Check headBlock is known and there is no missing data, if not respond with SYNCING
1) Check headBlock is VALID, if not respond with INVALID
2) Apply forkchoiceState
3) Check payloadAttributes, if invalid respond with error: code: Invalid payload attributes
4) Start payload build process and respond with VALID

Option 2

0) Check headBlock is known and there is no missing data, if not respond with SYNCING
1) Check payloadAttributes (requires a lookup to database to get a timestamp of yet to be applied headBlock), if invalid respond with error: code: Invalid payload attributes
2) Check headBlock is VALID, if not respond with INVALID
3) Start payload build process and respond with VALID

Currently in this test case Option 2 check is implemented but can be changed as necessary.

Current outcome per client:
- Geth: Error but forkchoice is applied
- Nethermind: Error and forkchoice is rolled back
- Erigon: No error on any timestamp value
- EthJS: No error on any timestamp value

cc @MariusVanDerWijden @MarekM25 