### PR TITLE
simulators/ethereum/engine: fix loop variable override

### DIFF
--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -1183,8 +1183,8 @@ func outOfOrderPayloads(t *TestEnv) {
 		r.ExpectNoValidationError()
 
 		// Send all the payloads in the opposite order
-		for i := t.CLMock.LatestExecutedPayload.Number; i > 0; i-- {
-			payload := t.CLMock.ExecutedPayloadHistory[i]
+		for k := t.CLMock.LatestExecutedPayload.Number; k > 0; k-- {
+			payload := t.CLMock.ExecutedPayloadHistory[k]
 
 			if i > 1 {
 				r := secondaryTestEngineClients[i].TestEngineNewPayloadV1(&payload)

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -1186,7 +1186,7 @@ func outOfOrderPayloads(t *TestEnv) {
 		for k := t.CLMock.LatestExecutedPayload.Number; k > 0; k-- {
 			payload := t.CLMock.ExecutedPayloadHistory[k]
 
-			if i > 1 {
+			if k > 1 {
 				r := secondaryTestEngineClients[i].TestEngineNewPayloadV1(&payload)
 				r.ExpectStatusEither(Accepted, Syncing)
 				r.ExpectLatestValidHash(nil)


### PR DESCRIPTION
The "Out of Order Payload Execution (go-ethereum)" test fails with this panic. I think it is because of this line https://github.com/ethereum/hive/blob/82fd6c45cc8b459c58344efbfa464c22ea963421/simulators/ethereum/engine/enginetests.go#L1190 which probably accesses the engine client array out of bounds. We overwrote the i value in the inner loop

```
panic: runtime error: index out of range [10] with length 1

goroutine 536 [running]:
github.com/ethereum/hive/hivesim.runTest.func2.1()
	/go/pkg/mod/github.com/ethereum/hive@v0.0.0-20220216101708-2784ea3e7eea/hivesim/testapi.go:327 +0x7b
panic({0x839740, 0xc0000260c0})
	/usr/local/go/src/runtime/panic.go:838 +0x207
main.outOfOrderPayloads(0xc000220630)
	/source/enginetests.go:1190 +0x9aa
main.RunTest({0x86da77, 0x1e}, 0xb?, 0xc0001a8f70?, 0xc00002c5c0, 0xc000362410, 0x89b8e0, 0xc0003229f0, 0xc000322330)
	/source/testenv.go:127 +0x668
main.main.func1(0xc00002c5c0?, 0xc0004042f0?)
	/source/main.go:142 +0xc9
github.com/ethereum/hive/hivesim.ClientTestSpec.runTest.func1(0x0?)
	/go/pkg/mod/github.com/ethereum/hive@v0.0.0-20220216101708-2784ea3e7eea/hivesim/testapi.go:359 +0xa6
github.com/ethereum/hive/hivesim.runTest.func2()
	/go/pkg/mod/github.com/ethereum/hive@v0.0.0-20220216101708-2784ea3e7eea/hivesim/testapi.go:333 +0x71
created by github.com/ethereum/hive/hivesim.runTest
	/go/pkg/mod/github.com/ethereum/hive@v0.0.0-20220216101708-2784ea3e7eea/hivesim/testapi.go:323 +0x2ca
```