### PR TITLE
simulators/ethereum/engine: allow for SYNCING in invalid payload tests

### DIFF
--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -746,7 +746,7 @@ func invalidPayloadTestCaseGen(payloadField string) func(*TestEnv) {
 				// or INVALID (client still has the payload and can verify that this payload is incorrectly building on top of it),
 				// but a VALID response is incorrect.
 				r := t.TestEngine.TestEngineNewPayloadV1(alteredPayload)
-				r.ExpectStatusEither(Accepted, Invalid)
+				r.ExpectStatusEither(Accepted, Invalid, Syncing)
 
 			},
 		})

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -500,7 +500,7 @@ func badHashOnNewPayloadGen(syncing bool, sidechain bool) func(*TestEnv) {
 				// or INVALID (client still has the payload and can verify that this payload is incorrectly building on top of it),
 				// but a VALID response is incorrect.
 				r := t.TestEngine.TestEngineNewPayloadV1(alteredPayload)
-				r.ExpectStatusEither(Accepted, Invalid)
+				r.ExpectStatusEither(Accepted, Invalid, Syncing)
 
 			},
 		})


### PR DESCRIPTION
As discussed on discord:
```
Geth fails one hive test that we should discuss imo @Mikhail Kalinin [mkalinin] @Mario Vega  maybe @MarekM 
Invalid ParentHash NewPayload: This test inverts a byte in the payloads parentHash which means we can not recognize it as the parentHash anymore. Geth will now on receiving this payload start a sync since we don't have the payload and nothing really speaks against us syncing it (it might be a valid payload with a valid parent). 
The test expects ACCEPTED or INVALID but we return, since we started the sync, SYNCING
Nethermind passes the test, while Erigon also returns SYNCING.
Imo the correct fix would be to modify the test to also accept SYNCING as a return value, since the EL might start a sync
```

```
You're right and SYNCING is totally fine in this case. Engine API spec may be too prescriptive in the response section as it states MUST and matches all responses including to a certain EL state, while SYNCING may be relevant for several cases
Starting SYNCING without receiving an fcU is allowed and is up to EL client implementation
```