### PR TITLE
simulators/ethereum/engine: Add PoW Merge Transition Test Cases for Coverage Increase

### DIFF
--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -245,7 +245,7 @@ ForkchoiceUpdated is sent to Client 1 with C as Head.
 PoS Chain is continued on top of C.
 Verification is made that Client 1 Re-orgs to chain G -> C -> ...  
 
-- Transition on an Chain with Invalid Terminal Block, Incorrectly Configured Higher Total Difficulty
+- Transition to a Chain with Invalid Terminal Block, Incorrectly Configured Higher Total Difficulty
 Client 1 starts with chain G -> A, Client 2 starts with chain G -> A -> B.  
 Client 1's configured TTD is reached by A.
 Client 2's configured TTD is reached by B.
@@ -253,7 +253,7 @@ ForkchoiceUpdated is sent to both clients with B as Head.
 PoS chain is continued on top of B.
 Verification is made that Client 1 never re-orgs to chain G -> A -> B due to incorrect Terminal block.  
 
-- Transition on an Chain with Invalid Terminal Block, Incorrectly Configured Lower Total Difficulty
+- Transition to a Chain with Invalid Terminal Block, Incorrectly Configured Lower Total Difficulty
 Client 1 starts with chain G -> A -> B, Client 2 starts with chain G -> A.  
 Client 1's configured TTD is reached by B.
 Client 2's configured TTD is reached by A.

--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -199,11 +199,67 @@ ForkchoiceUpdated is sent to Client 1 with C as Head.
 Verification is made that Client 1 Re-orgs to chain G -> B -> C.  
 
 - Two Block PoW Re-org to Lower-Height Chain:  
- Client 1 starts with chain G -> A -> B, Client 2 starts with chain G -> C.  
- Blocks B and C reach TTD, but block B has higher height than C.  
- ForkchoiceUpdated is sent to Client 1 with B as Head.  
- ForkchoiceUpdated is sent to Client 1 with C as Head.  
- Verification is made that Client 1 Re-orgs to chain G -> C.  
+Client 1 starts with chain G -> A -> B, Client 2 starts with chain G -> C.  
+Blocks B and C reach TTD, but block B has higher height than C.  
+ForkchoiceUpdated is sent to Client 1 with B as Head.  
+ForkchoiceUpdated is sent to Client 1 with C as Head.  
+Verification is made that Client 1 Re-orgs to chain G -> C.  
+
+- Two Block Post-PoS Re-org to Higher-Total-Difficulty PoW Chain:
+Client 1 starts with chain G -> A.
+ForkchoiceUpdated is sent to Client 1 with A as Head.
+Two PoS blocks are produced on top of A.
+Client 2 starts with chain G -> B.  
+Blocks A and B reach TTD, but block B has higher difficulty than A.  
+ForkchoiceUpdated is sent to Client 1 with B as Head.  
+PoS Chain is continued on top of B.
+Verification is made that Client 1 Re-orgs to chain G -> B -> ... 
+
+- Two Block Post-PoS Re-org to Lower-Total-Difficulty PoW Chain:
+Client 1 starts with chain G -> A.
+ForkchoiceUpdated is sent to Client 1 with A as Head.
+Two PoS blocks are produced on top of A.
+Client 2 starts with chain G -> B.  
+Blocks A and B reach TTD, but block A has higher difficulty than B.  
+ForkchoiceUpdated is sent to Client 1 with B as Head.  
+PoS Chain is continued on top of B.
+Verification is made that Client 1 Re-orgs to chain G -> B -> ... 
+
+- Two Block Post-PoS Re-org to Higher-Height PoW Chain:
+Client 1 starts with chain G -> A.
+ForkchoiceUpdated is sent to Client 1 with A as Head.
+Two PoS blocks are produced on top of A.
+Client 2 starts with chain G -> B -> C.  
+Blocks A and C reach TTD, but have different heights.  
+ForkchoiceUpdated is sent to Client 1 with C as Head.  
+PoS Chain is continued on top of C.
+Verification is made that Client 1 Re-orgs to chain G -> B -> C -> ...  
+
+- Two Block Post-PoS Re-org to Lower-Height PoW Chain:
+Client 1 starts with chain G -> A -> B.
+ForkchoiceUpdated is sent to Client 1 with B as Head.
+Two PoS blocks are produced on top of B.
+Client 2 starts with chain G -> C.  
+Blocks B and C reach TTD, but have different heights.  
+ForkchoiceUpdated is sent to Client 1 with C as Head.  
+PoS Chain is continued on top of C.
+Verification is made that Client 1 Re-orgs to chain G -> C -> ...  
+
+- Transition on an Chain with Invalid Terminal Block, Incorrectly Configured Higher Total Difficulty
+Client 1 starts with chain G -> A, Client 2 starts with chain G -> A -> B.  
+Client 1's configured TTD is reached by A.
+Client 2's configured TTD is reached by B.
+ForkchoiceUpdated is sent to both clients with B as Head.  
+PoS chain is continued on top of B.
+Verification is made that Client 1 never re-orgs to chain G -> A -> B due to incorrect Terminal block.  
+
+- Transition on an Chain with Invalid Terminal Block, Incorrectly Configured Lower Total Difficulty
+Client 1 starts with chain G -> A -> B, Client 2 starts with chain G -> A.  
+Client 1's configured TTD is reached by B.
+Client 2's configured TTD is reached by A.
+ForkchoiceUpdated is sent to both clients with A as Head.  
+PoS chain is continued on top of A.
+Verification is made that Client 1 never re-orgs to chain G -> A -> ... due to incorrect Terminal block. 
 
 - Halt following PoW chain:  
  Client 1 starts with chain G -> A, Client 2 starts with chain G -> A -> B.  

--- a/simulators/ethereum/engine/mergetests.go
+++ b/simulators/ethereum/engine/mergetests.go
@@ -259,7 +259,7 @@ var mergeTestSpecs = []MergeTestSpec{
 		},
 	},
 	{
-		Name:                     "Transition on an Chain with Invalid Terminal Block, Higher Configured Total Difficulty",
+		Name:                     "Transition to a Chain with Invalid Terminal Block, Higher Configured Total Difficulty",
 		TTD:                      196608,
 		MainChainFile:            "blocks_1_td_196608.rlp",
 		MainClientPoSBlocks:      1,
@@ -275,7 +275,7 @@ var mergeTestSpecs = []MergeTestSpec{
 		},
 	},
 	{
-		Name:                     "Transition on an Chain with Invalid Terminal Block, Lower Configured Total Difficulty",
+		Name:                     "Transition to a Chain with Invalid Terminal Block, Lower Configured Total Difficulty",
 		TTD:                      393120,
 		MainChainFile:            "blocks_2_td_393120.rlp",
 		MainClientPoSBlocks:      1,


### PR DESCRIPTION
Adds the following test cases:
- Two Block Post-PoS Re-org to Higher-Total-Difficulty PoW Chain
- Two Block Post-PoS Re-org to Lower-Total-Difficulty PoW Chain
- Two Block Post-PoS Re-org to Higher-Height PoW Chain
- Two Block Post-PoS Re-org to Lower-Height PoW Chain
- Transition on an Chain with Invalid Terminal Block, Incorrectly Configured Higher Total Difficulty
- Transition on an Chain with Invalid Terminal Block, Incorrectly Configured Lower Total Difficulty

The first four test cases attempt to re-org a client to a valid side-chain after a couple of PoS blocks were already produced on the canonical chain, where the side chain and the canonical chain have different Total Difficulty and/or different heights.

The last two test cases attempt to re-org onto an invalid PoW chain with an invalid Terminal Block, where the last block of the PoW has either (a) not enough difficulty or (b) a parent that is a valid Terminal block.

Details of each test case are included in the README.

Also included is a small change on how the tests check that the client does not re-org to an invalid chain.

Client status:
Geth: Both test cases with the invalid terminal block are failing because geth re-orgs to the invalid chain.
Nethermind: `Two Block Post-PoS Re-org to Higher-Height PoW Chain` test cases is currently failing due to client not being able to re-org to the side chain as expected.

cc @mkalinin @MariusVanDerWijden @MarekM25 