### PR TITLE
simulators/ethereum/engine: CLMock safe/finalized Slot Delay

### DIFF
--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -761,15 +761,15 @@ func badHashOnNewPayloadGen(syncing bool, sidechain bool) func(*TestEnv) {
 					// We alter the payload by setting the parent to a known past block in the
 					// canonical chain, which makes this payload a side chain payload, and also an invalid block hash
 					// (because we did not update the block hash appropriately)
-					alteredPayload.ParentHash = t.CLMock.LatestFinalizedHeader.ParentHash
+					alteredPayload.ParentHash = t.CLMock.LatestHeader.ParentHash
 				} else if syncing {
 					// We need to send an fcU to put the client in SYNCING state.
 					randomHeadBlock := common.Hash{}
 					rand.Read(randomHeadBlock[:])
 					fcU := ForkchoiceStateV1{
 						HeadBlockHash:      randomHeadBlock,
-						SafeBlockHash:      t.CLMock.LatestFinalizedHeader.Hash(),
-						FinalizedBlockHash: t.CLMock.LatestFinalizedHeader.Hash(),
+						SafeBlockHash:      t.CLMock.LatestHeader.Hash(),
+						FinalizedBlockHash: t.CLMock.LatestHeader.Hash(),
 					}
 					r := t.TestEngine.TestEngineForkchoiceUpdatedV1(&fcU, nil)
 					r.ExpectPayloadStatus(Syncing)
@@ -778,7 +778,7 @@ func badHashOnNewPayloadGen(syncing bool, sidechain bool) func(*TestEnv) {
 						// Syncing and sidechain, the caonincal head is an unknown payload to us,
 						// but this specific bad hash payload is in theory part of a side chain.
 						// Therefore the parent we use is the head hash.
-						alteredPayload.ParentHash = t.CLMock.LatestFinalizedHeader.Hash()
+						alteredPayload.ParentHash = t.CLMock.LatestHeader.Hash()
 					} else {
 						// The invalid bad-hash payload points to the unknown head, but we know it is
 						// indeed canonical because the head was set using forkchoiceUpdated.
@@ -1257,7 +1257,7 @@ func blockStatusExecPayloadGen(transitionBlock bool) func(t *TestEnv) {
 				r.ExpectHash(t.CLMock.LatestForkchoice.HeadBlockHash)
 
 				s := t.TestEth.TestBlockNumber()
-				s.ExpectNumber(t.CLMock.LatestFinalizedNumber.Uint64())
+				s.ExpectNumber(t.CLMock.LatestHeadNumber.Uint64())
 
 				p := t.TestEth.TestBlockByNumber(nil)
 				p.ExpectHash(t.CLMock.LatestForkchoice.HeadBlockHash)
@@ -1287,7 +1287,7 @@ func blockStatusHeadBlockGen(transitionBlock bool) func(t *TestEnv) {
 				tx = t.sendNextTransaction(t.TestEngine.Engine, (common.Address{}), big1, nil)
 			},
 			// Run test after a forkchoice with new HeadBlockHash has been broadcasted
-			OnHeadBlockForkchoiceBroadcast: func() {
+			OnForkchoiceBroadcast: func() {
 				r := t.TestEth.TestHeaderByNumber(nil)
 				r.ExpectHash(t.CLMock.LatestForkchoice.HeadBlockHash)
 
@@ -1315,7 +1315,7 @@ func blockStatusSafeBlockGen(transitionBlock bool) func(t *TestEnv) {
 				tx = t.sendNextTransaction(t.TestEngine.Engine, (common.Address{}), big1, nil)
 			},
 			// Run test after a forkchoice with new SafeBlockHash has been broadcasted
-			OnSafeBlockForkchoiceBroadcast: func() {
+			OnSafeBlockChange: func() {
 				r := t.TestEth.TestHeaderByNumber(nil)
 				r.ExpectHash(t.CLMock.LatestForkchoice.HeadBlockHash)
 
@@ -1343,7 +1343,7 @@ func blockStatusFinalizedBlockGen(transitionBlock bool) func(t *TestEnv) {
 				tx = t.sendNextTransaction(t.TestEngine.Engine, (common.Address{}), big1, nil)
 			},
 			// Run test after a forkchoice with new FinalizedBlockHash has been broadcasted
-			OnFinalizedBlockForkchoiceBroadcast: func() {
+			OnFinalizedBlockChange: func() {
 				r := t.TestEth.TestHeaderByNumber(nil)
 				r.ExpectHash(t.CLMock.LatestForkchoice.HeadBlockHash)
 
@@ -1388,7 +1388,7 @@ func blockStatusReorg(t *TestEnv) {
 			r.ExpectHash(customizedPayload.BlockHash)
 
 		},
-		OnHeadBlockForkchoiceBroadcast: func() {
+		OnForkchoiceBroadcast: func() {
 			// At this point, we have re-org'd to the payload that the CLMocker was originally planning to send,
 			// verify that the client is serving the latest HeadBlock.
 			r := t.TestEth.TestHeaderByNumber(nil)
@@ -1412,7 +1412,7 @@ func reorgBack(t *TestEnv) {
 
 	// Produce blocks before starting the test (So we don't try to reorg back to the genesis block)
 	t.CLMock.produceBlocks(5, BlockProcessCallbacks{
-		OnHeadBlockForkchoiceBroadcast: func() {
+		OnForkchoiceBroadcast: func() {
 			// Send a fcU with the HeadBlockHash pointing back to the previous block
 			forkchoiceUpdatedBack := ForkchoiceStateV1{
 				HeadBlockHash:      previousHash,
@@ -1530,7 +1530,7 @@ func transactionReorg(t *TestEnv) {
 					t.Fatalf("FAIL (%s): Payload built does not contain the transaction: %v", t.TestName, t.CLMock.LatestPayloadBuilt)
 				}
 			},
-			OnHeadBlockForkchoiceBroadcast: func() {
+			OnForkchoiceBroadcast: func() {
 				// Transaction is now in the head of the canonical chain, re-org and verify it's removed
 				// Get the receipt
 				_, err := t.Eth.TransactionReceipt(t.Ctx(), tx.Hash())
@@ -1595,7 +1595,7 @@ func sidechainReorg(t *TestEnv) {
 
 			r := t.TestEngine.TestEngineForkchoiceUpdatedV1(&t.CLMock.LatestForkchoice,
 				&PayloadAttributesV1{
-					Timestamp:             t.CLMock.LatestFinalizedHeader.Time + 1,
+					Timestamp:             t.CLMock.LatestHeader.Time + 1,
 					PrevRandao:            alternativePrevRandao,
 					SuggestedFeeRecipient: t.CLMock.NextFeeRecipient,
 				})
@@ -1628,7 +1628,7 @@ func sidechainReorg(t *TestEnv) {
 	})
 	// The reorg actually happens after the CLMocker continues,
 	// verify here that the reorg was successful
-	latestBlockNum := t.CLMock.LatestFinalizedNumber.Uint64()
+	latestBlockNum := t.CLMock.LatestHeadNumber.Uint64()
 	checkPrevRandaoValue(t, t.CLMock.PrevRandaoHistory[latestBlockNum], latestBlockNum)
 
 }
@@ -1976,9 +1976,9 @@ func prevRandaoOpcodeTx(t *TestEnv) {
 			txs = append(txs, tx)
 			currentTxIndex++
 		},
-		OnHeadBlockForkchoiceBroadcast: func() {
+		OnForkchoiceBroadcast: func() {
 			// Check the transaction tracing, which is client specific
-			expectedPrevRandao := t.CLMock.PrevRandaoHistory[t.CLMock.LatestFinalizedHeader.Number.Uint64()+1]
+			expectedPrevRandao := t.CLMock.PrevRandaoHistory[t.CLMock.LatestHeader.Number.Uint64()+1]
 			if err := debugPrevRandaoTransaction(t.Engine.Ctx(), t.RPC, t.Engine.Client.Type, txs[currentTxIndex-1],
 				&expectedPrevRandao); err != nil {
 				t.Fatalf("FAIL (%s): Error during transaction tracing: %v", t.TestName, err)
@@ -2040,7 +2040,7 @@ func postMergeSync(t *TestEnv) {
 			if err != nil {
 				t.Fatalf("FAIL (%s): Unable to obtain latest header: %v", t.TestName, err)
 			}
-			if t.CLMock.LatestFinalizedHeader != nil && latestHeader.Hash() == t.CLMock.LatestFinalizedHeader.Hash() {
+			if t.CLMock.LatestHeader != nil && latestHeader.Hash() == t.CLMock.LatestHeader.Hash() {
 				t.Logf("INFO (%v): Client (%v) is now synced to latest PoS block: %v", t.TestName, c.Container, latestHeader.Hash())
 				break syncLoop
 			}

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -78,6 +78,10 @@ type TestSpec struct {
 	// Default: 0
 	TTD int64
 
+	// CL Mocker configuration for slots to `safe` and `finalized` respectively
+	SlotsToSafe      *big.Int
+	SlotsToFinalized *big.Int
+
 	// Test maximum execution time until a timeout is raised.
 	// Default: 60 seconds
 	TimeoutSeconds int
@@ -139,7 +143,7 @@ have reached the Terminal Total Difficulty.`[1:],
 					timeout = time.Second * time.Duration(currentTest.TimeoutSeconds)
 				}
 				// Run the test case
-				RunTest(currentTest.Name, big.NewInt(ttd), timeout, t, c, currentTest.Run, newParams, testFiles)
+				RunTest(currentTest.Name, big.NewInt(ttd), currentTest.SlotsToSafe, currentTest.SlotsToFinalized, timeout, t, c, currentTest.Run, newParams, testFiles)
 			},
 		})
 	}

--- a/simulators/ethereum/engine/mergetests.go
+++ b/simulators/ethereum/engine/mergetests.go
@@ -423,9 +423,9 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 				})
 
 				// If the main client should follow the PoS chain, update the mustHeadHash
-				if mustHeadHash == t.CLMock.LatestFinalizedHeader.ParentHash {
+				if mustHeadHash == t.CLMock.LatestHeader.ParentHash {
 					// Keep following the chain if that is what the test expects
-					mustHeadHash = t.CLMock.LatestFinalizedHeader.Hash()
+					mustHeadHash = t.CLMock.LatestHeader.Hash()
 					t.Logf("INFO (%s): Must head hash updated: %v", t.TestName, mustHeadHash)
 				}
 			}
@@ -457,9 +457,9 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 					})
 
 					// If the main client should follow the PoS chain, update the mustHeadHash
-					if mustHeadHash == t.CLMock.LatestFinalizedHeader.ParentHash {
+					if mustHeadHash == t.CLMock.LatestHeader.ParentHash {
 						// Keep following the chain if that is what the test expects
-						mustHeadHash = t.CLMock.LatestFinalizedHeader.Hash()
+						mustHeadHash = t.CLMock.LatestHeader.Hash()
 						t.Logf("INFO (%s): Must head hash updated: %v", t.TestName, mustHeadHash)
 					}
 

--- a/simulators/ethereum/engine/mergetests.go
+++ b/simulators/ethereum/engine/mergetests.go
@@ -73,6 +73,10 @@ type MergeTestSpec struct {
 	// Requires SkipMainClientFcU==false
 	MainClientPoSBlocks int
 
+	// Slot Safe/Finalized Delays
+	SlotsToSafe      *big.Int
+	SlotsToFinalized *big.Int
+
 	// All secondary clients to be started during the tests with their respective chain files
 	SecondaryClientSpecs SecondaryClientSpecs
 }
@@ -169,6 +173,7 @@ var mergeTestSpecs = []MergeTestSpec{
 		TTD:                 196608,
 		MainChainFile:       "blocks_1_td_196608.rlp",
 		MainClientPoSBlocks: 2,
+		SlotsToFinalized:    big.NewInt(5),
 		SecondaryClientSpecs: []SecondaryClientSpec{
 			{
 				ChainFile:           "blocks_1_td_196704.rlp",
@@ -182,6 +187,7 @@ var mergeTestSpecs = []MergeTestSpec{
 		TTD:                 196608,
 		MainChainFile:       "blocks_1_td_196704.rlp",
 		MainClientPoSBlocks: 2,
+		SlotsToFinalized:    big.NewInt(5),
 		SecondaryClientSpecs: []SecondaryClientSpec{
 			{
 				ChainFile:           "blocks_1_td_196608.rlp",
@@ -195,6 +201,7 @@ var mergeTestSpecs = []MergeTestSpec{
 		TTD:                 196704,
 		MainChainFile:       "blocks_1_td_196704.rlp",
 		MainClientPoSBlocks: 2,
+		SlotsToFinalized:    big.NewInt(5),
 		SecondaryClientSpecs: []SecondaryClientSpec{
 			{
 				ChainFile:           "blocks_2_td_393120.rlp",
@@ -208,6 +215,7 @@ var mergeTestSpecs = []MergeTestSpec{
 		TTD:                 196704,
 		MainChainFile:       "blocks_2_td_393120.rlp",
 		MainClientPoSBlocks: 2,
+		SlotsToFinalized:    big.NewInt(5),
 		SecondaryClientSpecs: []SecondaryClientSpec{
 			{
 				ChainFile:           "blocks_1_td_196704.rlp",
@@ -487,13 +495,15 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 	}
 
 	return TestSpec{
-		Name:           mergeTestSpec.Name,
-		About:          mergeTestSpec.About,
-		Run:            runFunc,
-		TTD:            mergeTestSpec.TTD,
-		TimeoutSeconds: mergeTestSpec.TimeoutSeconds,
-		GenesisFile:    mergeTestSpec.GenesisFile,
-		ChainFile:      mergeTestSpec.MainChainFile,
+		Name:             mergeTestSpec.Name,
+		About:            mergeTestSpec.About,
+		Run:              runFunc,
+		TTD:              mergeTestSpec.TTD,
+		TimeoutSeconds:   mergeTestSpec.TimeoutSeconds,
+		SlotsToSafe:      mergeTestSpec.SlotsToSafe,
+		SlotsToFinalized: mergeTestSpec.SlotsToFinalized,
+		GenesisFile:      mergeTestSpec.GenesisFile,
+		ChainFile:        mergeTestSpec.MainChainFile,
 	}
 }
 

--- a/simulators/ethereum/engine/testenv.go
+++ b/simulators/ethereum/engine/testenv.go
@@ -56,9 +56,9 @@ type TestEnv struct {
 	syncCancel context.CancelFunc
 }
 
-func RunTest(testName string, ttd *big.Int, timeout time.Duration, t *hivesim.T, c *hivesim.Client, fn func(*TestEnv), cParams hivesim.Params, cFiles hivesim.Params) {
+func RunTest(testName string, ttd *big.Int, slotsToSafe *big.Int, slotsToFinalized *big.Int, timeout time.Duration, t *hivesim.T, c *hivesim.Client, fn func(*TestEnv), cParams hivesim.Params, cFiles hivesim.Params) {
 	// Setup the CL Mocker for this test
-	clMocker := NewCLMocker(t, ttd)
+	clMocker := NewCLMocker(t, slotsToSafe, slotsToFinalized)
 	// Defer closing all clients
 	defer func() {
 		clMocker.CloseClients()


### PR DESCRIPTION
This changes allows the CL Mock to simulate the proper behavior of a Consensus Layer client, where the blocks are not immediately finalized (no single-slot-finality yet).

On the transition to PoS, the ForkchoiceUpdated calls from the CL Mock will, by default, now look like this:
```
NewPayload(P1)
ForkchoiceUpdated(head: P1, safe: 0, finalized: 0)
NewPayload(P2)
ForkchoiceUpdated(head: P2, safe: P1, finalized: 0)
NewPayload(P3)
ForkchoiceUpdated(head: P3, safe: P2, finalized: P1)
```

This delay is customizable if we need to extend the finalization period to more slots.

Discord thread link: https://discord.com/channels/595666850260713488/974664364466511972