### PR TITLE
clients/besu: add JWT secret

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -146,7 +146,8 @@ RPCFLAGS="$RPCFLAGS --rpc-ws-enabled --rpc-ws-api=ETH,NET,WEB3,ADMIN --rpc-ws-ho
 
 # Enable merge support if needed
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
-    RPCFLAGS="$RPCFLAGS --engine-host-allowlist=* --Xmerge-support true --engine-rpc-enabled"
+    echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
+    RPCFLAGS="$RPCFLAGS --engine-host-allowlist=* --Xmerge-support true --engine-rpc-enabled --engine-jwt-enabled --engine-jwt-secret /jwtsecret"
     FLAGS="$FLAGS --sync-mode=FULL"
 fi
 


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

This PR configures Besu to use the hardcoded JWT secret. It's needed to pass all of the JWT tests of the engine simulator