### PR TITLE
clients/nimbus: add nimbus beacon node and validator client

### DIFF
--- a/clients/nimbus-bn/Dockerfile
+++ b/clients/nimbus-bn/Dockerfile
@@ -1,0 +1,43 @@
+# Docker container spec for building the kiln-dev branch of nimbus.
+
+FROM debian:buster-slim AS build
+
+RUN apt-get update \
+ && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV NPROC=2
+
+RUN git clone --depth 1 --branch kiln-dev-auth https://github.com/status-im/nimbus-eth2.git \
+ && cd nimbus-eth2 \
+ && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" V=1 update
+
+RUN cd nimbus-eth2 && \
+    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" nimbus_beacon_node && \
+    mv build/nimbus_beacon_node /usr/bin/
+
+# --------------------------------- #
+# Starting new image to reduce size #
+# --------------------------------- #
+
+FROM debian:buster-slim AS deploy
+
+RUN apt-get update \
+ && apt-get install -y librocksdb-dev bash curl jq\
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /usr/bin/nimbus_beacon_node /usr/bin/nimbus_beacon_node
+
+RUN usr/bin/nimbus_beacon_node --version > /version.txt
+
+ADD nimbus_bn.sh /nimbus_bn.sh
+RUN chmod +x /nimbus_bn.sh
+
+# TODO: output accurate client version
+RUN usr/bin/nimbus_beacon_node --version > /version.txt
+
+EXPOSE 9000 9000/udp 4000 4000/udp
+
+ENTRYPOINT ["/nimbus_bn.sh"]

--- a/clients/nimbus-bn/Dockerfile
+++ b/clients/nimbus-bn/Dockerfile
@@ -1,4 +1,4 @@
-# Docker container spec for building the kiln-dev branch of nimbus.
+# Docker container spec for building the unstable branch of nimbus.
 
 FROM debian:buster-slim AS build
 
@@ -9,7 +9,7 @@ RUN apt-get update \
 
 ENV NPROC=2
 
-RUN git clone --depth 1 --branch kiln-dev-auth https://github.com/status-im/nimbus-eth2.git \
+RUN git clone --depth 1 --branch unstable https://github.com/status-im/nimbus-eth2.git \
  && cd nimbus-eth2 \
  && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" V=1 update
 

--- a/clients/nimbus-bn/hive.yaml
+++ b/clients/nimbus-bn/hive.yaml
@@ -1,0 +1,4 @@
+roles:
+  - beacon
+build_targets:
+  - mainnet

--- a/clients/nimbus-bn/nimbus_bn.sh
+++ b/clients/nimbus-bn/nimbus_bn.sh
@@ -24,6 +24,7 @@ sed -i 's/TERMINAL_BLOCK_HASH: "\(0x[[:xdigit:]]\+\)"/TERMINAL_BLOCK_HASH: \1/' 
 sed -i 's/GENESIS_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/GENESIS_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
 sed -i 's/ALTAIR_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/ALTAIR_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
 sed -i 's/BELLATRIX_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/BELLATRIX_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
+sed -i 's/CAPELLA_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/CAPELLA_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
 sed -i 's/SHARDING_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/SHARDING_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
 echo Using config.yaml
 cat /data/testnet_setup/config.yaml

--- a/clients/nimbus-bn/nimbus_bn.sh
+++ b/clients/nimbus-bn/nimbus_bn.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+if [ ! -f "/hive/input/genesis.ssz" ]; then
+    if [ -z "$HIVE_ETH2_ETH1_RPC_ADDRS" ]; then
+      echo "genesis.ssz file is missing, and no Eth1 RPC addr was provided for building genesis from scratch."
+      # TODO: alternative to start from weak-subjectivity-state
+      exit 1
+    fi
+fi
+
+mkdir -p /data/testnet_setup
+
+cp /hive/input/genesis.ssz /data/testnet_setup
+cp /hive/input/config.yaml /data/testnet_setup
+
+# znrt encodes the values of these items between double quotes (""), which is against the spec:
+# https://github.com/ethereum/consensus-specs/blob/v1.1.10/configs/mainnet.yaml
+# Nimbus is the only client that complains about this.
+sed -i 's/TERMINAL_TOTAL_DIFFICULTY: "\([[:digit:]]\+\)"/TERMINAL_TOTAL_DIFFICULTY: \1/' /data/testnet_setup/config.yaml
+sed -i 's/TERMINAL_BLOCK_HASH: "\(0x[[:xdigit:]]\+\)"/TERMINAL_BLOCK_HASH: \1/' /data/testnet_setup/config.yaml
+sed -i 's/GENESIS_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/GENESIS_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
+sed -i 's/ALTAIR_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/ALTAIR_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
+sed -i 's/BELLATRIX_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/BELLATRIX_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
+sed -i 's/SHARDING_FORK_VERSION: "\(0x[[:xdigit:]]\+\)"/SHARDING_FORK_VERSION: \1/' /data/testnet_setup/config.yaml
+echo Using config.yaml
+cat /data/testnet_setup/config.yaml
+echo ""
+
+echo "${HIVE_ETH2_CONFIG_DEPOSIT_CONTRACT_ADDRESS:-0x1111111111111111111111111111111111111111}" > /data/testnet_setup/deposit_contract.txt
+echo "${HIVE_ETH2_DEPOSIT_DEPLOY_BLOCK_NUMBER:-0}" > /data/testnet_setup/deploy_block.txt
+
+mkdir -p /data/beacon
+chmod 0700 /data/beacon
+
+LOG=INFO
+case "$HIVE_LOGLEVEL" in
+    0|1) LOG=ERROR ;;
+    2)   LOG=WARN  ;;
+    3)   LOG=INFO  ;;
+    4)   LOG=DEBUG ;;
+    5)   LOG=TRACE ;;
+esac
+
+echo "bootnodes: ${HIVE_ETH2_BOOTNODE_ENRS}"
+
+CONTAINER_IP=`hostname -i | awk '{print $1;}'`
+echo Container IP: "${CONTAINER_IP}"
+bootnodes_option=$([[ "$HIVE_ETH2_BOOTNODE_ENRS" == "" ]] && echo "--subscribe-all-subnets" || echo "--bootstrap-node=$HIVE_ETH2_BOOTNODE_ENRS")
+metrics_option=$([[ "$HIVE_ETH2_METRICS_PORT" == "" ]] && echo "" || echo "--metrics --metrics-address=0.0.0.0 --metrics-port=$HIVE_ETH2_METRICS_PORT")
+
+echo -n "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
+
+echo Starting Nimbus Beacon Node
+
+/usr/bin/nimbus_beacon_node \
+    --non-interactive=true \
+    --log-level="$LOG" \
+    --data-dir=/data/beacon \
+    --network=/data/testnet_setup \
+    --web3-url="$HIVE_ETH2_ETH1_ENGINE_RPC_ADDRS" \
+    --jwt-secret=/jwtsecret \
+    --num-threads=4 \
+    $bootnodes_option $metrics_option \
+    --nat="extip:${CONTAINER_IP}" \
+    --listen-address=0.0.0.0 \
+    --tcp-port="${HIVE_ETH2_P2P_TCP_PORT:-9000}" \
+    --udp-port="${HIVE_ETH2_P2P_UDP_PORT:-9000}" \
+    --rest --rest-address=0.0.0.0 --rest-port="${HIVE_ETH2_BN_API_PORT:-4000}" --rest-allow-origin="*" \
+    --doppelganger-detection=false \
+    --max-peers="${HIVE_ETH2_P2P_TARGET_PEERS:-10}" \
+    --enr-auto-update=false

--- a/clients/nimbus-vc/Dockerfile
+++ b/clients/nimbus-vc/Dockerfile
@@ -1,0 +1,39 @@
+# Docker container spec for building the kiln-dev branch of nimbus.
+
+FROM debian:buster-slim AS build
+
+RUN apt-get update \
+ && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV NPROC=2
+
+RUN git clone --depth 1 --branch kiln-dev-auth https://github.com/status-im/nimbus-eth2.git \
+ && cd nimbus-eth2 \
+ && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" V=1 update
+
+RUN cd nimbus-eth2 && \
+    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" nimbus_validator_client && \
+    mv build/nimbus_validator_client /usr/bin/
+
+# --------------------------------- #
+# Starting new image to reduce size #
+# --------------------------------- #
+
+FROM debian:buster-slim AS deploy
+
+RUN apt-get update \
+ && apt-get install -y librocksdb-dev bash curl jq\
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /usr/bin/nimbus_validator_client /usr/bin/nimbus_validator_client
+
+RUN usr/bin/nimbus_validator_client --version > /version.txt
+
+# Add the startup script.
+ADD nimbus_vc.sh /nimbus_vc.sh
+RUN chmod +x /nimbus_vc.sh
+
+ENTRYPOINT ["/nimbus_vc.sh"]

--- a/clients/nimbus-vc/Dockerfile
+++ b/clients/nimbus-vc/Dockerfile
@@ -1,4 +1,4 @@
-# Docker container spec for building the kiln-dev branch of nimbus.
+# Docker container spec for building the unstable branch of nimbus.
 
 FROM debian:buster-slim AS build
 
@@ -9,7 +9,7 @@ RUN apt-get update \
 
 ENV NPROC=2
 
-RUN git clone --depth 1 --branch kiln-dev-auth https://github.com/status-im/nimbus-eth2.git \
+RUN git clone --depth 1 --branch unstable https://github.com/status-im/nimbus-eth2.git \
  && cd nimbus-eth2 \
  && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" V=1 update
 

--- a/clients/nimbus-vc/hive.yaml
+++ b/clients/nimbus-vc/hive.yaml
@@ -1,0 +1,2 @@
+roles:
+  - validator

--- a/clients/nimbus-vc/nimbus_vc.sh
+++ b/clients/nimbus-vc/nimbus_vc.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+mkdir -p /data/vc
+
+# Nimbus wants all secrets with 0600 permissions
+chmod 0600 /hive/input/secrets/*
+
+LOG=INFO
+case "$HIVE_LOGLEVEL" in
+    0|1) LOG=ERROR ;;
+    2)   LOG=WARN  ;;
+    3)   LOG=INFO  ;;
+    4)   LOG=DEBUG ;;
+    5)   LOG=TRACE ;;
+esac
+
+echo Starting Nimbus Validator Client
+
+/usr/bin/nimbus_validator_client \
+    --non-interactive=true \
+    --log-level="$LOG" \
+    --data-dir=/data/vc \
+    --beacon-node="http://$HIVE_ETH2_BN_API_IP:$HIVE_ETH2_BN_API_PORT" \
+    --validators-dir="/hive/input/keystores" \
+    --secrets-dir="/hive/input/secrets" \


### PR DESCRIPTION
Adds `nimbus-bn` and `nimbus-vc`, which are compiled from source from branch https://github.com/status-im/nimbus-eth2/tree/kiln-dev-auth, with a custom setting `SECONDS_PER_SLOT=3`, to allow quicker test runtimes.