### PR TITLE
clients/besu: remove --Xmerge-support and --engine-rpc-enabled options since no more needed

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -147,7 +147,7 @@ RPCFLAGS="$RPCFLAGS --rpc-ws-enabled --rpc-ws-api=ETH,NET,WEB3,ADMIN --rpc-ws-ho
 # Enable merge support if needed
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
-    RPCFLAGS="$RPCFLAGS --engine-host-allowlist=* --Xmerge-support true --engine-rpc-enabled --engine-jwt-enabled --engine-jwt-secret /jwtsecret"
+    RPCFLAGS="$RPCFLAGS --engine-host-allowlist=* --engine-jwt-enabled --engine-jwt-secret /jwtsecret"
     FLAGS="$FLAGS --sync-mode=FULL"
 fi
 


### PR DESCRIPTION
There is no more the need to manually enable merge support, since it is automatically enabled when TTD is present in the genesis file