### PR TITLE
simulators/ethereum/engine: Re-org to Chain with Invalid Transition

### DIFF
--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -118,6 +118,12 @@ Send a NewPayload directive to the client including an incorrect BlockHash, shou
 - ParentHash==BlockHash on NewPayload:  
 Send a NewPayload directive to the client including ParentHash that is equal to the BlockHash (Incorrect hash).
 
+- Invalid Transition Payload:
+Build canonical chain `A: Genesis <- ... <- TB <- P1 <- P2` where TB is a valid terminal block.
+Create an invalid transition payload `INV_P1` with parent `TB`.
+`newPayload(INV_P1)` must return `{status: INVALID/ACCEPTED, latestValidHash: 0x00..00}`.
+`forkchoiceUpdated(head: INV_P1, safe: 0x00..00, finalized: 0x00..00)` must return `{status: INVALID, latestValidHash: 0x00..00}`.
+
 - Invalid Field in NewPayload:  
 Send an invalid payload in NewPayload by modifying fields of a valid ExecutablePayload while maintaining a valid BlockHash.
 After attempting to NewPayload/ForkchoiceUpdated the invalid payload, also attempt to send a valid payload that contains the previously modified invalid payload as parent (should also fail).

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -97,6 +97,12 @@ var engineTests = []TestSpec{
 		Run:  parentHashOnExecPayload,
 	},
 	{
+		Name:      "Invalid Transition Payload",
+		Run:       invalidTransitionPayload,
+		TTD:       393504,
+		ChainFile: "blocks_2_td_393504.rlp",
+	},
+	{
 		Name: "Invalid ParentHash NewPayload",
 		Run:  invalidPayloadTestCaseGen(InvalidParentHash, false, false),
 	},
@@ -854,6 +860,46 @@ func parentHashOnExecPayload(t *TestEnv) {
 		},
 	})
 
+}
+
+// Attempt to re-org to a chain containing an invalid transition payload
+func invalidTransitionPayload(t *TestEnv) {
+	// Wait until TTD is reached by main client
+	t.CLMock.waitForTTD()
+
+	// Produce two blocks before trying to re-org
+	t.nonce = 2 // Initial PoW chain already contains 2 transactions
+	t.CLMock.produceBlocks(2, BlockProcessCallbacks{
+		OnPayloadProducerSelected: func() {
+			t.sendNextTransaction(t.CLMock.NextBlockProducer, prevRandaoContractAddr, big1, nil)
+		},
+	})
+
+	// Introduce the invalid transition payload
+	t.CLMock.produceSingleBlock(BlockProcessCallbacks{
+		// This is being done in the middle of the block building
+		// process simply to be able to re-org back.
+		OnGetPayload: func() {
+			basePayload := t.CLMock.ExecutedPayloadHistory[t.CLMock.FirstPoSBlockNumber.Uint64()]
+			alteredPayload, err := generateInvalidPayload(&basePayload, InvalidStateRoot)
+			if err != nil {
+				t.Fatalf("FAIL (%s): Unable to modify payload: %v", t.TestName, err)
+			}
+			p := t.TestEngine.TestEngineNewPayloadV1(alteredPayload)
+			p.ExpectStatusEither(Invalid, Accepted)
+			p.ExpectLatestValidHash(&(common.Hash{}))
+			r := t.TestEngine.TestEngineForkchoiceUpdatedV1(&ForkchoiceStateV1{
+				HeadBlockHash:      alteredPayload.BlockHash,
+				SafeBlockHash:      common.Hash{},
+				FinalizedBlockHash: common.Hash{},
+			}, nil)
+			r.ExpectPayloadStatus(Invalid)
+			r.ExpectLatestValidHash(&(common.Hash{}))
+
+			s := t.TestEth.TestBlockByNumber(nil)
+			s.ExpectHash(t.CLMock.LatestExecutedPayload.BlockHash)
+		},
+	})
 }
 
 // Generate test cases for each field of NewPayload, where the payload contains a single invalid field and a valid hash.


### PR DESCRIPTION
Implements test case "Re-org to chain with invalid transition block" suggested in https://github.com/txrx-research/TestingTheMerge/pull/4/files#diff-f9223f9dc89130dc64351addac949a8248ec031bcde0561497a06bffd7f74d2cR376

Currently clients Geth, Nethermind and Besu are failing this test because `newPayload(INV_P1)` returns `latestValidHash==TERMINAL_BLOCK`, and the test expects `latestValidHash==0x00..00`.

Erigon is failing when importing PoW chain as in other existing test cases.

cc @mkalinin @MariusVanDerWijden @MarekM25 @garyschulte