### PR TITLE
simulators/ethereum/engine: allow invalid status after invalid block

### DIFF
--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -1246,8 +1246,7 @@ func invalidMissingAncestorReOrgGen(invalid_index int, payloadField InvalidPaylo
 							// We have already sent the invalid payload, but the client could've discarded it.
 							// In reality the CL will not get to this point because it will have already received the `INVALID`
 							// response from the previous payload.
-							r.ExpectStatusEither(Accepted, Syncing)
-							r.ExpectLatestValidHash(nil)
+							r.ExpectStatusEither(Accepted, Syncing, Invalid)
 						} else {
 							// This is one of the payloads before the invalid one, therefore is valid.
 							r.ExpectStatus(Valid)


### PR DESCRIPTION
Allow invalid status in case EL is able to determine it is invalid.