### PR TITLE
simulators/ethereum/engine: Fix Finality On Invalid Payload Attributes Test

### DIFF
--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -692,8 +692,8 @@ func invalidPayloadAttributesGen(syncing bool) func(*TestEnv) {
 				t.Logf("INFO (%s): Sending EngineForkchoiceUpdatedV1 (Syncing=%s) with invalid payload attributes", t.TestName, syncing)
 				fcu := ForkchoiceStateV1{
 					HeadBlockHash:      blockHash,
-					SafeBlockHash:      blockHash,
-					FinalizedBlockHash: blockHash,
+					SafeBlockHash:      t.CLMock.LatestForkchoice.SafeBlockHash,
+					FinalizedBlockHash: t.CLMock.LatestForkchoice.FinalizedBlockHash,
 				}
 				attr := PayloadAttributesV1{
 					Timestamp:             0,


### PR DESCRIPTION
On the "ForkchoiceUpdated Invalid Payload Attributes" tests, the forkchoice was set to instant finality and then rolled back on the subsequent ForkchoiceUpdated call, which produced unintended behavior on some clients, which is something the test did not intend to verify.
Fix is to send the same hash of the latest forkchoice for `SafeBlockHead` and `FinalizedBlockHead`.