### PR TITLE
clients/prysm: add Prysm Beacon Node and Validator Client 

### DIFF
--- a/clients/prysm-bn/Dockerfile
+++ b/clients/prysm-bn/Dockerfile
@@ -1,9 +1,12 @@
-ARG branch=latest-alpine
-FROM gcr.io/prysmaticlabs/prysm/beacon-chain:$branch
+ARG branch=latest
+FROM gcr.io/prysmaticlabs/prysm/beacon-chain:$branch as upstream
+
+FROM debian:buster-slim
+COPY --from=upstream /app/cmd/beacon-chain/beacon-chain beacon-chain
 
 ADD prysm_bn.sh /prysm_bn.sh
 RUN chmod +x /prysm_bn.sh
 
-RUN /app/cmd/beacon-chain/beacon-chain --version > /version.txt
+RUN /beacon-chain --version > /version.txt
 
 ENTRYPOINT ["/prysm_bn.sh"]

--- a/clients/prysm-bn/Dockerfile
+++ b/clients/prysm-bn/Dockerfile
@@ -1,0 +1,9 @@
+ARG branch=latest-alpine
+FROM gcr.io/prysmaticlabs/prysm/beacon-chain:$branch
+
+ADD prysm_bn.sh /prysm_bn.sh
+RUN chmod +x /prysm_bn.sh
+
+RUN /app/cmd/beacon-chain/beacon-chain --version > /version.txt
+
+ENTRYPOINT ["/prysm_bn.sh"]

--- a/clients/prysm-bn/Dockerfile
+++ b/clients/prysm-bn/Dockerfile
@@ -1,4 +1,4 @@
-ARG branch=latest
+ARG branch=latest-debug
 FROM gcr.io/prysmaticlabs/prysm/beacon-chain:$branch as upstream
 
 FROM debian:buster-slim

--- a/clients/prysm-bn/hive.yaml
+++ b/clients/prysm-bn/hive.yaml
@@ -1,0 +1,5 @@
+roles:
+  - beacon
+build_targets:
+  - mainnet
+  - minimal

--- a/clients/prysm-bn/minimal.Dockerfile
+++ b/clients/prysm-bn/minimal.Dockerfile
@@ -1,0 +1,13 @@
+ARG branch=latest
+
+# TODO: either special upstream build, or clone + build minimal version here in dockerfile.
+FROM gcr.io/prysmaticlabs/prysm/beacon-chain:$branch
+
+ADD prysm_bn.sh /prysm_bn.sh
+RUN chmod +x /prysm_bn.sh
+
+# TODO: output accurate client version
+RUN echo "latest" > /version.txt
+
+ENTRYPOINT ["/prysm_bn.sh"]
+

--- a/clients/prysm-bn/prysm_bn.sh
+++ b/clients/prysm-bn/prysm_bn.sh
@@ -36,6 +36,10 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     echo "TERMINAL_TOTAL_DIFFICULTY: $HIVE_TERMINAL_TOTAL_DIFFICULTY" >> /hive/input/config.yaml
 fi
 
+if [[ "$HIVE_ETH2_SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY" != "" ]]; then
+    echo "SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY: $HIVE_ETH2_SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY" >> /hive/input/config.yaml
+fi
+
 echo config.yaml:
 cat /hive/input/config.yaml
 

--- a/clients/prysm-bn/prysm_bn.sh
+++ b/clients/prysm-bn/prysm_bn.sh
@@ -31,7 +31,7 @@ metrics_option=$([[ "$HIVE_ETH2_METRICS_PORT" == "" ]] && echo "--disable-monito
 echo -n "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
 
 
-/app/cmd/beacon-chain/beacon-chain \
+/beacon-chain \
     --verbosity="$LOG" \
     --accept-terms-of-use=true \
     --datadir=/data/beacon \

--- a/clients/prysm-bn/prysm_bn.sh
+++ b/clients/prysm-bn/prysm_bn.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+if [ ! -f "/hive/input/genesis.ssz" ]; then
+    if [ -z "$HIVE_ETH2_ETH1_RPC_ADDRS" ]; then
+      echo "genesis.ssz file is missing, and no Eth1 RPC addr was provided for building genesis from scratch."
+      # TODO: alternative to start from weak-subjectivity-state
+      exit 1
+    fi
+fi
+
+mkdir -p /data/beacon
+mkdir -p /data/network
+
+LOG=info
+case "$HIVE_LOGLEVEL" in
+    0)   LOG=fatal ;;
+    1)   LOG=error ;;
+    2)   LOG=warn  ;;
+    3)   LOG=info  ;;
+    4)   LOG=debug ;;
+    5)   LOG=trace ;;
+esac
+
+echo "bootnodes: ${HIVE_ETH2_BOOTNODE_ENRS}"
+
+CONTAINER_IP=`hostname -i | awk '{print $1;}'`
+metrics_option=$([[ "$HIVE_ETH2_METRICS_PORT" == "" ]] && echo "--disable-monitoring=true" || echo "--disable-monitoring=false --monitoring-host=0.0.0.0 --monitoring-port=$HIVE_ETH2_METRICS_PORT")
+echo -n "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
+
+
+/app/cmd/beacon-chain/beacon-chain \
+    --verbosity="$LOG" \
+    --accept-terms-of-use=true \
+    --datadir=/data/beacon \
+    --chain-config-file=/hive/input/config.yaml \
+    --genesis-state=/hive/input/genesis.ssz \
+    --bootstrap-node="${HIVE_ETH2_BOOTNODE_ENRS:-""}" \
+    --p2p-tcp-port="${HIVE_ETH2_P2P_TCP_PORT:-9000}" \
+    --p2p-udp-port="${HIVE_ETH2_P2P_UDP_PORT:-9000}" \
+    --p2p-host-ip="${CONTAINER_IP}" \
+    --p2p-local-ip="${CONTAINER_IP}" \
+    --http-web3provider="$HIVE_ETH2_ETH1_RPC_ADDRS" \
+    --jwt-secret=/jwtsecret \
+    --min-sync-peers=1 \
+    --subscribe-all-subnets=true \
+    $metrics_option \
+    --deposit-contract="${HIVE_ETH2_CONFIG_DEPOSIT_CONTRACT_ADDRESS:-0x1111111111111111111111111111111111111111}" \
+    --contract-deployment-block="${HIVE_ETH2_DEPOSIT_DEPLOY_BLOCK_NUMBER:-0}" \
+    --rpc-host=0.0.0.0 --rpc-port="${HIVE_ETH2_BN_API_PORT:-4000}" \
+    --grpc-gateway-host=0.0.0.0 --grpc-gateway-port="${HIVE_ETH2_BN_GATEWAY_PORT:-3500}" \
+    --suggested-fee-recipient="0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+
+# --interop-genesis-state=/hive/input/genesis.ssz \
+# --max-skip-slots="${HIVE_ETH2_MAX_SKIP_SLOTS:-1000}"
+# --target-peers="${HIVE_ETH2_P2P_TARGET_PEERS:-10}"
+# --disable-enr-auto-update=true 
+# --network-dir=/data/network

--- a/clients/prysm-bn/prysm_bn.sh
+++ b/clients/prysm-bn/prysm_bn.sh
@@ -31,6 +31,11 @@ echo "bootnodes: ${HIVE_ETH2_BOOTNODE_ENRS}"
 sed -i 's/"\([[:digit:]]\+\)"/\1/' /hive/input/config.yaml
 sed -i 's/"\(0x[[:xdigit:]]\+\)"/\1/' /hive/input/config.yaml
 
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    sed -i '/TERMINAL_TOTAL_DIFFICULTY/d' /hive/input/config.yaml
+    echo "TERMINAL_TOTAL_DIFFICULTY: $HIVE_TERMINAL_TOTAL_DIFFICULTY" >> /hive/input/config.yaml
+fi
+
 echo config.yaml:
 cat /hive/input/config.yaml
 

--- a/clients/prysm-vc/Dockerfile
+++ b/clients/prysm-vc/Dockerfile
@@ -1,4 +1,4 @@
-ARG branch=latest
+ARG branch=latest-debug
 FROM gcr.io/prysmaticlabs/prysm/validator:$branch as upstream
 
 FROM debian:buster-slim

--- a/clients/prysm-vc/Dockerfile
+++ b/clients/prysm-vc/Dockerfile
@@ -1,9 +1,12 @@
-ARG branch=latest-alpine
-FROM gcr.io/prysmaticlabs/prysm/validator:$branch
+ARG branch=latest
+FROM gcr.io/prysmaticlabs/prysm/validator:$branch as upstream
+
+FROM debian:buster-slim
+COPY --from=upstream /app/cmd/validator/validator validator
 
 ADD prysm_vc.sh /prysm_vc.sh
 RUN chmod +x /prysm_vc.sh
 
-RUN /app/cmd/validator/validator --version > /version.txt
+RUN /validator --version > /version.txt
 
 ENTRYPOINT ["/prysm_vc.sh"]

--- a/clients/prysm-vc/Dockerfile
+++ b/clients/prysm-vc/Dockerfile
@@ -1,0 +1,9 @@
+ARG branch=latest-alpine
+FROM gcr.io/prysmaticlabs/prysm/validator:$branch
+
+ADD prysm_vc.sh /prysm_vc.sh
+RUN chmod +x /prysm_vc.sh
+
+RUN /app/cmd/validator/validator --version > /version.txt
+
+ENTRYPOINT ["/prysm_vc.sh"]

--- a/clients/prysm-vc/hive.yaml
+++ b/clients/prysm-vc/hive.yaml
@@ -1,0 +1,2 @@
+roles:
+  - validator

--- a/clients/prysm-vc/prysm_vc.sh
+++ b/clients/prysm-vc/prysm_vc.sh
@@ -10,7 +10,7 @@ for keystore_path in /hive/input/keystores/*
 do
   pubkey=$(basename "$keystore_path")
 
-  /app/cmd/validator/validator accounts import \
+  /validator accounts import \
     --prater \
     --wallet-dir="/data/validators" \
     --keys-dir="/hive/input/keystores/$pubkey" \
@@ -30,7 +30,7 @@ case "$HIVE_LOGLEVEL" in
     5)   LOG=trace ;;
 esac
 
-/app/cmd/validator/validator \
+/validator \
     --verbosity="$LOG" \
     --accept-terms-of-use=true \
     --prater \

--- a/clients/prysm-vc/prysm_vc.sh
+++ b/clients/prysm-vc/prysm_vc.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+mkdir -p /data/vc
+mkdir -p /data/validators
+
+for keystore_path in /hive/input/keystores/*
+do
+  pubkey=$(basename "$keystore_path")
+
+  /app/cmd/validator/validator accounts import \
+    --prater \
+    --wallet-dir="/data/validators" \
+    --keys-dir="/hive/input/keystores/$pubkey" \
+    --account-password-file="/hive/input/secrets/$pubkey"
+
+done
+
+ls  /data/validators
+
+LOG=info
+case "$HIVE_LOGLEVEL" in
+    0)   LOG=fatal ;;
+    1)   LOG=error ;;
+    2)   LOG=warn  ;;
+    3)   LOG=info  ;;
+    4)   LOG=debug ;;
+    5)   LOG=trace ;;
+esac
+
+/app/cmd/validator/validator \
+    --verbosity="$LOG" \
+    --accept-terms-of-use=true \
+    --prater \
+    --beacon-rpc-provider="http://$HIVE_ETH2_BN_API_IP:$HIVE_ETH2_BN_API_PORT" \
+    --beacon-rpc-gateway-provider="http://$HIVE_ETH2_BN_API_IP:${HIVE_ETH2_BN_GATEWAY_PORT:-3500}" \
+    --datadir="/data/vc" \
+    --wallet-dir="/data/validators" \
+    --chain-config-file="/hive/input/config.yaml"
+
+    # --init-slashing-protection
+
+

--- a/clients/prysm-vc/prysm_vc.sh
+++ b/clients/prysm-vc/prysm_vc.sh
@@ -5,6 +5,7 @@ set -e
 
 mkdir -p /data/vc
 mkdir -p /data/validators
+echo walletpassword > /wallet.pass
 
 for keystore_path in /hive/input/keystores/*
 do
@@ -12,13 +13,23 @@ do
 
   /validator accounts import \
     --prater \
+    --accept-terms-of-use=true \
     --wallet-dir="/data/validators" \
     --keys-dir="/hive/input/keystores/$pubkey" \
-    --account-password-file="/hive/input/secrets/$pubkey"
+    --account-password-file="/hive/input/secrets/$pubkey" \
+    --wallet-password-file="/wallet.pass"
 
 done
 
 ls  /data/validators
+
+# znrt encodes the values of these items between double quotes (""), which is against the spec:
+# https://github.com/ethereum/consensus-specs/blob/v1.1.10/configs/mainnet.yaml
+sed -i 's/"\([[:digit:]]\+\)"/\1/' /hive/input/config.yaml
+sed -i 's/"\(0x[[:xdigit:]]\+\)"/\1/' /hive/input/config.yaml
+
+echo config.yaml:
+cat /hive/input/config.yaml
 
 LOG=info
 case "$HIVE_LOGLEVEL" in
@@ -30,16 +41,16 @@ case "$HIVE_LOGLEVEL" in
     5)   LOG=trace ;;
 esac
 
+echo Starting Prysm Validator Client
+
 /validator \
     --verbosity="$LOG" \
     --accept-terms-of-use=true \
     --prater \
-    --beacon-rpc-provider="http://$HIVE_ETH2_BN_API_IP:$HIVE_ETH2_BN_API_PORT" \
-    --beacon-rpc-gateway-provider="http://$HIVE_ETH2_BN_API_IP:${HIVE_ETH2_BN_GATEWAY_PORT:-3500}" \
+    --beacon-rpc-provider="$HIVE_ETH2_BN_API_IP:${HIVE_ETH2_BN_GRPC_PORT:-3500}" \
+    --beacon-rpc-gateway-provider="$HIVE_ETH2_BN_API_IP:${HIVE_ETH2_BN_API_PORT:-4000}" \
     --datadir="/data/vc" \
     --wallet-dir="/data/validators" \
+    --wallet-password-file="/wallet.pass" \
     --chain-config-file="/hive/input/config.yaml"
-
-    # --init-slashing-protection
-
-
+# NOTE: gRPC/RPC ports are inverted to allow the simulator to access the REST API


### PR DESCRIPTION
Adds Prysm beacon node and validator client images.

A few considerations:
- Simulator requires that Altair and Bellatrix fork on different epochs (e.g. Altair on epoch 1, and bellatrix on epoch 2) which results in long test case runtimes.
- Requires changes to all FORK_VERSION configurations because Prysm does not admit testnet identifiers to have the same versions as mainnet.
- Prysm's REST API endpoint `/eth/v2/debug/beacon/states/` returns error 404. This endpoint is used by method `getHealth` and therefore it fails, which might require a workaround.

These considerations aside, the client is functional and most of the test cases in https://github.com/ethereum/hive/pull/569 are passing.