### PR TITLE
clients/go-ethereum: set syncmode=full by default

### DIFF
--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -81,10 +81,13 @@ if [ "$HIVE_NODETYPE" == "archive" ]; then
     FLAGS="$FLAGS --syncmode full --gcmode archive"
 fi
 if [ "$HIVE_NODETYPE" == "full" ]; then
-    FLAGS="$FLAGS --syncmode snap"
+    FLAGS="$FLAGS --syncmode full"
 fi
 if [ "$HIVE_NODETYPE" == "light" ]; then
     FLAGS="$FLAGS --syncmode light"
+fi
+if [ "$HIVE_NODETYPE" == "" ]; then
+    FLAGS="$FLAGS --syncmode full"
 fi
 
 # Configure the chain.


### PR DESCRIPTION
We changed something in geth that makes a lot of tests fail in snap sync mode.
Basically you can not import blocks one by one in snap sync mode, the snap sync has to finish before importing blocks one by one, otherwise we might overwrite data that is already in the database. 
The tests depend on this one-by-one importing though, which is only available to a full synced node in geth. This changes the default sync mode to full. 