### PR TITLE
simulators/ethereum/engine: Enhance Post-Merge Sync Test

### DIFF
--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -86,6 +86,9 @@ fi
 if [ "$HIVE_NODETYPE" == "light" ]; then
     FLAGS="$FLAGS --syncmode light"
 fi
+if [ "$HIVE_NODETYPE" == "snap" ]; then
+    FLAGS="$FLAGS --syncmode snap"
+fi
 if [ "$HIVE_NODETYPE" == "" ]; then
     FLAGS="$FLAGS --syncmode full"
 fi

--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -1,5 +1,23 @@
 # This JQ script generates the Nethermind config file.
 
+# Removes all empty keys and values in input.
+def remove_empty:
+  . | walk(
+    if type == "object" then
+      with_entries(
+        select(
+          .value != null and
+          .value != "" and
+          .value != [] and
+          .key != null and
+          .key != ""
+        )
+      )
+    else .
+    end
+  )
+;
+
 def keystore_config:
   if env.HIVE_CLIQUE_PRIVATEKEY == null then
     {}
@@ -39,6 +57,16 @@ def json_rpc_config:
   end
 ;
 
+def sync_config:
+  if env.HIVE_SYNC_CONFIG != null then
+    {
+      "Sync": ( env.HIVE_SYNC_CONFIG | fromjson | remove_empty )
+    }
+  else
+    {}
+  end
+;
+
 def base_config:
   {
     "Init": {
@@ -71,4 +99,4 @@ def base_config:
 ;
 
 # This is the main expression that outputs the config.
-base_config * keystore_config * merge_config * json_rpc_config
+base_config * keystore_config * merge_config * json_rpc_config * sync_config

--- a/clients/nethermind/nethermind.sh
+++ b/clients/nethermind/nethermind.sh
@@ -64,6 +64,9 @@ jq . /chainspec/test.json
 mkdir /configs
 jq -n -f /mkconfig.jq > /configs/test.cfg
 
+echo "test.cfg"
+cat /configs/test.cfg
+
 # Set bootnode.
 if [ -n "$HIVE_BOOTNODE" ]; then
     mkdir -p /nethermind/Data

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -1960,7 +1960,7 @@ func sidechainReorg(t *TestEnv) {
 				})
 			r.ExpectNoError()
 
-			time.Sleep(PayloadProductionClientDelay)
+			time.Sleep(t.CLMock.PayloadProductionClientDelay)
 
 			alternativePayload, err := t.Engine.EngineGetPayloadV1(t.Engine.Ctx(), r.Response.PayloadID)
 			if err != nil {

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -24,7 +24,7 @@ var (
 
 	// Time delay between ForkchoiceUpdated and GetPayload to allow the clients
 	// to produce a new Payload
-	PayloadProductionClientDelay = time.Second
+	DefaultPayloadProductionClientDelay = time.Second
 
 	// Confirmation blocks
 	PoWConfirmationBlocks = uint64(15)

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -97,34 +97,43 @@ type TestSpec struct {
 }
 
 func main() {
-	engine := hivesim.Suite{
-		Name: "engine",
-		Description: `
-Test Engine API tests using CL mocker to inject commands into clients after they 
-have reached the Terminal Total Difficulty.`[1:],
-	}
+	var (
+		engine = hivesim.Suite{
+			Name: "engine",
+			Description: `
+	Test Engine API tests using CL mocker to inject commands into clients after they 
+	have reached the Terminal Total Difficulty.`[1:],
+		}
+		transition = hivesim.Suite{
+			Name: "transition",
+			Description: `
+	Test Engine API tests using CL mocker to inject commands into clients and drive 
+	them through the merge.`[1:],
+		}
+		auth = hivesim.Suite{
+			Name: "auth",
+			Description: `
+	Test Engine API authentication features.`[1:],
+		}
+		sync = hivesim.Suite{
+			Name: "sync",
+			Description: `
+	Test Engine API sync, pre/post merge.`[1:],
+		}
+	)
+
+	simulator := hivesim.New()
+
 	addTestsToSuite(&engine, engineTests)
-
-	transition := hivesim.Suite{
-		Name: "transition",
-		Description: `
-Test Engine API tests using CL mocker to inject commands into clients and drive 
-them through the merge.`[1:],
-	}
 	addTestsToSuite(&transition, mergeTests)
-
-	auth := hivesim.Suite{
-		Name: "auth",
-		Description: `
-Test Engine API authentication features.`[1:],
-	}
 	addTestsToSuite(&auth, authTests)
+	addSyncTestsToSuite(simulator, &sync, syncTests)
 
 	// Mark suites for execution
-	simulator := hivesim.New()
 	hivesim.MustRunSuite(simulator, engine)
 	hivesim.MustRunSuite(simulator, transition)
 	hivesim.MustRunSuite(simulator, auth)
+	hivesim.MustRunSuite(simulator, sync)
 }
 
 // Add test cases to a given test suite

--- a/simulators/ethereum/engine/sync.go
+++ b/simulators/ethereum/engine/sync.go
@@ -118,7 +118,7 @@ func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string
 		chain = loadChain("./chains/" + ChainFile)
 	}
 
-	// FastSync
+	// ArchiveSync
 	archiveSyncConfig := NethermindSyncConfig{
 		FastSync:   false,
 		SnapSync:   false,
@@ -134,57 +134,57 @@ func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string
 			},
 		})
 
-	// SnapSync, pivot == TTD
+	// FastSync, pivot == TTD
 	pivot := chain[len(chain)-1]
 	pivotHash := pivot.Hash()
-	snapSyncConfigPivotOnTTD := NethermindSyncConfig{
+	fastSyncConfigPivotOnTTD := NethermindSyncConfig{
 		FastSync:             true,
-		SnapSync:             true,
+		SnapSync:             false,
 		FastBlocks:           true,
 		PivotNumber:          pivot.Number(),
 		PivotHash:            &pivotHash,
 		PivotTotalDifficulty: CalculateTotalDifficulty(genesis, chain, pivot.NumberU64()).String(),
 	}
-	fmt.Printf("DEBUG: snapSyncConfigPivotOnTTD: %s\n", snapSyncConfigPivotOnTTD.String())
+	fmt.Printf("DEBUG: fastSyncConfigPivotOnTTD: %s\n", fastSyncConfigPivotOnTTD.String())
 	result = append(result,
 		SyncTestVariant{
-			Name: "snap sync/pivot.Difficulty>=TTD",
+			Name: "fast sync/pivot.Difficulty>=TTD",
 			MainClientConfig: hivesim.Params{
 				"HIVE_SYNC_CONFIG": NethermindSyncConfig{
 					FastSync:   true,
-					SnapSync:   true,
+					SnapSync:   false,
 					FastBlocks: true,
 				}.String(),
 			},
 			SyncClientConfig: hivesim.Params{
-				"HIVE_SYNC_CONFIG": snapSyncConfigPivotOnTTD.String(),
+				"HIVE_SYNC_CONFIG": fastSyncConfigPivotOnTTD.String(),
 			},
 		})
 
-	// SnapSync, pivot < TTD
+	// FastSync, pivot < TTD
 	pivot = chain[len(chain)-2]
 	pivotHash = pivot.Hash()
-	snapSyncConfigPivotLessThanTTD := NethermindSyncConfig{
+	fastSyncConfigPivotLessThanTTD := NethermindSyncConfig{
 		FastSync:             true,
-		SnapSync:             true,
+		SnapSync:             false,
 		FastBlocks:           true,
 		PivotNumber:          pivot.Number(),
 		PivotHash:            &pivotHash,
 		PivotTotalDifficulty: CalculateTotalDifficulty(genesis, chain, pivot.NumberU64()).String(),
 	}
-	fmt.Printf("DEBUG: snapSyncConfigPivotLessThanTTD: %s\n", snapSyncConfigPivotLessThanTTD.String())
+	fmt.Printf("DEBUG: fastSyncConfigPivotLessThanTTD: %s\n", fastSyncConfigPivotLessThanTTD.String())
 	result = append(result,
 		SyncTestVariant{
-			Name: "snap sync/pivot.Difficulty<TTD",
+			Name: "fast sync/pivot.Difficulty<TTD",
 			MainClientConfig: hivesim.Params{
 				"HIVE_SYNC_CONFIG": NethermindSyncConfig{
 					FastSync:   true,
-					SnapSync:   true,
+					SnapSync:   false,
 					FastBlocks: true,
 				}.String(),
 			},
 			SyncClientConfig: hivesim.Params{
-				"HIVE_SYNC_CONFIG": snapSyncConfigPivotLessThanTTD.String(),
+				"HIVE_SYNC_CONFIG": fastSyncConfigPivotLessThanTTD.String(),
 			},
 		})
 	return result
@@ -194,8 +194,4 @@ func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string
 var ClientToSyncVariantGenerator = map[string]SyncVariantGenerator{
 	"go-ethereum": GethSyncVariantGenerator{},
 	"nethermind":  NethermindSyncVariantGenerator{},
-	"erigon":      DefaultSyncVariantGenerator{},
-	"besu":        DefaultSyncVariantGenerator{},
-	"ethereumjs":  DefaultSyncVariantGenerator{},
-	"nimbus-el":   DefaultSyncVariantGenerator{},
 }

--- a/simulators/ethereum/engine/sync.go
+++ b/simulators/ethereum/engine/sync.go
@@ -44,11 +44,6 @@ type GethSyncVariantGenerator struct{}
 func (GethSyncVariantGenerator) Configure(*big.Int, string, string) []SyncTestVariant {
 	return []SyncTestVariant{
 		{
-			Name:             "default",
-			MainClientConfig: hivesim.Params{},
-			SyncClientConfig: hivesim.Params{},
-		},
-		{
 			Name: "Full",
 			MainClientConfig: hivesim.Params{
 				"HIVE_NODETYPE": "full",
@@ -101,13 +96,7 @@ func (c NethermindSyncConfig) String() string {
 }
 
 func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string, ChainFile string) []SyncTestVariant {
-	result := []SyncTestVariant{
-		{
-			Name:             "default",
-			MainClientConfig: hivesim.Params{},
-			SyncClientConfig: hivesim.Params{},
-		},
-	}
+	result := make([]SyncTestVariant, 0)
 
 	var (
 		genesis = loadGenesis(GenesisFile)
@@ -124,7 +113,6 @@ func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string
 		SnapSync:   false,
 		FastBlocks: false,
 	}
-	fmt.Printf("DEBUG: archiveSyncConfig: %s\n", archiveSyncConfig.String())
 	result = append(result,
 		SyncTestVariant{
 			Name:             "archive sync",
@@ -145,7 +133,6 @@ func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string
 		PivotHash:            &pivotHash,
 		PivotTotalDifficulty: CalculateTotalDifficulty(genesis, chain, pivot.NumberU64()).String(),
 	}
-	fmt.Printf("DEBUG: fastSyncConfigPivotOnTTD: %s\n", fastSyncConfigPivotOnTTD.String())
 	result = append(result,
 		SyncTestVariant{
 			Name: "fast sync/pivot.Difficulty>=TTD",
@@ -172,7 +159,6 @@ func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string
 		PivotHash:            &pivotHash,
 		PivotTotalDifficulty: CalculateTotalDifficulty(genesis, chain, pivot.NumberU64()).String(),
 	}
-	fmt.Printf("DEBUG: fastSyncConfigPivotLessThanTTD: %s\n", fastSyncConfigPivotLessThanTTD.String())
 	result = append(result,
 		SyncTestVariant{
 			Name: "fast sync/pivot.Difficulty<TTD",

--- a/simulators/ethereum/engine/sync.go
+++ b/simulators/ethereum/engine/sync.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/hive/hivesim"
+)
+
+// Specifies a single test variant for the given client:
+// Contains the configuration for the main client and the configuration for
+// the client that must perform the sync.
+type SyncTestVariant struct {
+	Name             string
+	MainClientConfig hivesim.Params
+	SyncClientConfig hivesim.Params
+}
+
+// The sync configurator takes input parameters and outputs all possible sync test variants under which
+// a client must be tested for each sync test.
+type SyncVariantGenerator interface {
+	Configure(TTD *big.Int, GenesisFile string, ChainFile string) []SyncTestVariant
+}
+
+// Generates the default configuration for clients that have no special configuration
+type DefaultSyncVariantGenerator struct{}
+
+func (DefaultSyncVariantGenerator) Configure(*big.Int, string, string) []SyncTestVariant {
+	return []SyncTestVariant{
+		{
+			Name:             "default",
+			MainClientConfig: hivesim.Params{},
+			SyncClientConfig: hivesim.Params{},
+		},
+	}
+}
+
+// Go-ethereum sync test variant generator
+type GethSyncVariantGenerator struct{}
+
+func (GethSyncVariantGenerator) Configure(*big.Int, string, string) []SyncTestVariant {
+	return []SyncTestVariant{
+		{
+			Name:             "default",
+			MainClientConfig: hivesim.Params{},
+			SyncClientConfig: hivesim.Params{},
+		},
+		{
+			Name: "Full",
+			MainClientConfig: hivesim.Params{
+				"HIVE_NODETYPE": "full",
+			},
+			SyncClientConfig: hivesim.Params{
+				"HIVE_NODETYPE": "full",
+			},
+		},
+		{
+			Name: "Archive",
+			MainClientConfig: hivesim.Params{
+				"HIVE_NODETYPE": "archive",
+			},
+			SyncClientConfig: hivesim.Params{
+				"HIVE_NODETYPE": "archive",
+			},
+		},
+		{
+			Name: "Snap",
+			MainClientConfig: hivesim.Params{
+				"HIVE_NODETYPE": "snap",
+			},
+			SyncClientConfig: hivesim.Params{
+				"HIVE_NODETYPE": "snap",
+			},
+		},
+	}
+}
+
+// Nethermind sync test variant generator
+type NethermindSyncVariantGenerator struct{}
+
+// Sync configuration for nethermind, which is marshaled into json string
+// and passed as `HIVE_SYNC_CONFIG`
+type NethermindSyncConfig struct {
+	FastSync             bool         `json:"FastSync"`
+	SnapSync             bool         `json:"SnapSync"`
+	PivotNumber          *big.Int     `json:"PivotNumber"`
+	PivotHash            *common.Hash `json:"PivotHash"`
+	PivotTotalDifficulty string       `json:"PivotTotalDifficulty"`
+	FastBlocks           bool         `json:"FastBlocks"`
+}
+
+func (c NethermindSyncConfig) String() string {
+	b, err := json.Marshal(c)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s", b)
+}
+
+func (NethermindSyncVariantGenerator) Configure(TTD *big.Int, GenesisFile string, ChainFile string) []SyncTestVariant {
+	result := []SyncTestVariant{
+		{
+			Name:             "default",
+			MainClientConfig: hivesim.Params{},
+			SyncClientConfig: hivesim.Params{},
+		},
+	}
+
+	var (
+		genesis = loadGenesis(GenesisFile)
+		chain   types.Blocks
+	)
+
+	if ChainFile != "" {
+		chain = loadChain("./chains/" + ChainFile)
+	}
+
+	// FastSync
+	archiveSyncConfig := NethermindSyncConfig{
+		FastSync:   false,
+		SnapSync:   false,
+		FastBlocks: false,
+	}
+	fmt.Printf("DEBUG: archiveSyncConfig: %s\n", archiveSyncConfig.String())
+	result = append(result,
+		SyncTestVariant{
+			Name:             "archive sync",
+			MainClientConfig: hivesim.Params{},
+			SyncClientConfig: hivesim.Params{
+				"HIVE_SYNC_CONFIG": archiveSyncConfig.String(),
+			},
+		})
+
+	// SnapSync, pivot == TTD
+	pivot := chain[len(chain)-1]
+	pivotHash := pivot.Hash()
+	snapSyncConfigPivotOnTTD := NethermindSyncConfig{
+		FastSync:             true,
+		SnapSync:             true,
+		FastBlocks:           true,
+		PivotNumber:          pivot.Number(),
+		PivotHash:            &pivotHash,
+		PivotTotalDifficulty: CalculateTotalDifficulty(genesis, chain, pivot.NumberU64()).String(),
+	}
+	fmt.Printf("DEBUG: snapSyncConfigPivotOnTTD: %s\n", snapSyncConfigPivotOnTTD.String())
+	result = append(result,
+		SyncTestVariant{
+			Name: "snap sync/pivot.Difficulty>=TTD",
+			MainClientConfig: hivesim.Params{
+				"HIVE_SYNC_CONFIG": NethermindSyncConfig{
+					FastSync:   true,
+					SnapSync:   true,
+					FastBlocks: true,
+				}.String(),
+			},
+			SyncClientConfig: hivesim.Params{
+				"HIVE_SYNC_CONFIG": snapSyncConfigPivotOnTTD.String(),
+			},
+		})
+
+	// SnapSync, pivot < TTD
+	pivot = chain[len(chain)-2]
+	pivotHash = pivot.Hash()
+	snapSyncConfigPivotLessThanTTD := NethermindSyncConfig{
+		FastSync:             true,
+		SnapSync:             true,
+		FastBlocks:           true,
+		PivotNumber:          pivot.Number(),
+		PivotHash:            &pivotHash,
+		PivotTotalDifficulty: CalculateTotalDifficulty(genesis, chain, pivot.NumberU64()).String(),
+	}
+	fmt.Printf("DEBUG: snapSyncConfigPivotLessThanTTD: %s\n", snapSyncConfigPivotLessThanTTD.String())
+	result = append(result,
+		SyncTestVariant{
+			Name: "snap sync/pivot.Difficulty<TTD",
+			MainClientConfig: hivesim.Params{
+				"HIVE_SYNC_CONFIG": NethermindSyncConfig{
+					FastSync:   true,
+					SnapSync:   true,
+					FastBlocks: true,
+				}.String(),
+			},
+			SyncClientConfig: hivesim.Params{
+				"HIVE_SYNC_CONFIG": snapSyncConfigPivotLessThanTTD.String(),
+			},
+		})
+	return result
+}
+
+// Lists the types of sync supported by each client.
+var ClientToSyncVariantGenerator = map[string]SyncVariantGenerator{
+	"go-ethereum": GethSyncVariantGenerator{},
+	"nethermind":  NethermindSyncVariantGenerator{},
+	"erigon":      DefaultSyncVariantGenerator{},
+	"besu":        DefaultSyncVariantGenerator{},
+	"ethereumjs":  DefaultSyncVariantGenerator{},
+	"nimbus-el":   DefaultSyncVariantGenerator{},
+}

--- a/simulators/ethereum/engine/synctests.go
+++ b/simulators/ethereum/engine/synctests.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/hive/hivesim"
+)
+
+var syncTests = []TestSpec{
+	{
+		Name:           "Sync Client Post Merge",
+		Run:            postMergeSync,
+		TimeoutSeconds: 180,
+		ChainFile:      "blocks_1024_td_135112316.rlp",
+		TTD:            135112316,
+	},
+}
+
+// Routine that adds all sync tests to a test suite
+func addSyncTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []TestSpec) {
+	clientDefs, err := sim.ClientTypes()
+	if err != nil {
+		panic(err)
+	}
+	for _, currentTest := range tests {
+		for _, clientDef := range clientDefs {
+			clientSyncVariantGenerator, ok := ClientToSyncVariantGenerator[clientDef.Name]
+			if !ok {
+				continue
+			}
+			currentTest := currentTest
+			genesisPath := "./init/genesis.json"
+			// If the TestSpec specified a custom genesis file, use that instead.
+			if currentTest.GenesisFile != "" {
+				genesisPath = "./init/" + currentTest.GenesisFile
+			}
+			testFiles := hivesim.Params{"/genesis.json": genesisPath}
+			// Calculate and set the TTD for this test
+			ttd := calcRealTTD(genesisPath, currentTest.TTD)
+			newParams := clientEnv.Set("HIVE_TERMINAL_TOTAL_DIFFICULTY", fmt.Sprintf("%d", ttd))
+			if currentTest.ChainFile != "" {
+				// We are using a Proof of Work chain file, remove all clique-related settings
+				// TODO: Nethermind still requires HIVE_MINER for the Engine API
+				// delete(newParams, "HIVE_MINER")
+				delete(newParams, "HIVE_CLIQUE_PRIVATEKEY")
+				delete(newParams, "HIVE_CLIQUE_PERIOD")
+				// Add the new file to be loaded as chain.rlp
+				testFiles = testFiles.Set("/chain.rlp", "./chains/"+currentTest.ChainFile)
+			}
+			for _, variant := range clientSyncVariantGenerator.Configure(big.NewInt(ttd), genesisPath, currentTest.ChainFile) {
+				suite.Add(hivesim.TestSpec{
+					Name:        fmt.Sprintf("%s (%s, sync/%s)", currentTest.Name, clientDef.Name, variant.Name),
+					Description: currentTest.About,
+					Run: func(t *hivesim.T) {
+
+						mainClientParams := newParams.Copy()
+						for k, v := range variant.MainClientConfig {
+							mainClientParams = mainClientParams.Set(k, v)
+						}
+						c := t.StartClient(clientDef.Name, mainClientParams, hivesim.WithStaticFiles(testFiles))
+
+						t.Logf("Start test (%s, %s, sync/%s)", c.Type, currentTest.Name, variant.Name)
+						defer func() {
+							t.Logf("End test (%s, %s, sync/%s)", c.Type, currentTest.Name, variant.Name)
+						}()
+						timeout := DefaultTestCaseTimeout
+						// If a TestSpec specifies a timeout, use that instead
+						if currentTest.TimeoutSeconds != 0 {
+							timeout = time.Second * time.Duration(currentTest.TimeoutSeconds)
+						}
+
+						// Prepare sync client parameters
+						syncClientParams := newParams.Copy()
+						for k, v := range variant.SyncClientConfig {
+							syncClientParams = syncClientParams.Set(k, v)
+						}
+
+						// Run the test case
+						RunTest(currentTest.Name, big.NewInt(ttd), currentTest.SlotsToSafe, currentTest.SlotsToFinalized, timeout, t, c, currentTest.Run, syncClientParams, testFiles)
+					},
+				})
+			}
+		}
+	}
+
+}
+
+// Client Sync tests
+func postMergeSync(t *TestEnv) {
+	// Launch another client after the PoS transition has happened in the main client.
+	// Sync should eventually happen without issues.
+	t.CLMock.waitForTTD()
+
+	// Speed up block production
+	OriginalPayloadProductionClientDelay := PayloadProductionClientDelay
+	defer func() {
+		// In case test fails, revert block production speed
+		PayloadProductionClientDelay = OriginalPayloadProductionClientDelay
+	}()
+	PayloadProductionClientDelay = time.Millisecond * 100
+
+	// Produce some blocks
+	t.CLMock.produceBlocks(500, BlockProcessCallbacks{})
+
+	// Revert block production speed
+	PayloadProductionClientDelay = OriginalPayloadProductionClientDelay
+
+	// Set the Bootnode
+	enode, err := t.Engine.EnodeURL()
+	if err != nil {
+		t.Fatalf("FAIL (%s): Unable to obtain bootnode: %v", t.TestName, err)
+	}
+	newParams := t.ClientParams.Set("HIVE_BOOTNODE", fmt.Sprintf("%s", enode))
+	newParams = newParams.Set("HIVE_MINER", "")
+
+	hc, secondaryEngine, err := t.StartClient(t.Client.Type, newParams, t.MainTTD())
+	if err != nil {
+		t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
+	}
+	secondaryEngineTest := NewTestEngineClient(t, secondaryEngine)
+	t.CLMock.AddEngineClient(t.T, hc, t.MainTTD())
+
+	for {
+		select {
+		case <-t.Timeout:
+			t.Fatalf("FAIL (%s): Test timeout", t.TestName)
+		default:
+		}
+
+		// CL continues building blocks on top of the PoS chain
+		t.CLMock.produceSingleBlock(BlockProcessCallbacks{})
+
+		// When the main client syncs, the test passes
+		latestHeader, err := secondaryEngineTest.Engine.Eth.HeaderByNumber(t.Ctx(), nil)
+		if err != nil {
+			t.Fatalf("FAIL (%s): Unable to obtain latest header: %v", t.TestName, err)
+		}
+		if t.CLMock.LatestHeader != nil && latestHeader.Hash() == t.CLMock.LatestHeader.Hash() {
+			t.Logf("INFO (%v): Client (%v) is now synced to latest PoS block: %v", t.TestName, hc.Container, latestHeader.Hash())
+			break
+		}
+	}
+
+}

--- a/simulators/ethereum/engine/synctests.go
+++ b/simulators/ethereum/engine/synctests.go
@@ -105,7 +105,7 @@ func postMergeSync(t *TestEnv) {
 	t.CLMock.waitForTTD()
 
 	// Speed up block production
-	t.CLMock.PayloadProductionClientDelay = time.Millisecond * 100
+	t.CLMock.PayloadProductionClientDelay = 0
 
 	// Also set the transition payload timestamp to 500 seconds before now
 	// This is done in order to try to not create payloads too old, nor into the future.
@@ -113,6 +113,9 @@ func postMergeSync(t *TestEnv) {
 
 	// Produce some blocks
 	t.CLMock.produceBlocks(500, BlockProcessCallbacks{})
+
+	// Reset block production delay
+	t.CLMock.PayloadProductionClientDelay = time.Second
 
 	// Set the Bootnode
 	enode, err := t.Engine.EnodeURL()
@@ -164,7 +167,7 @@ func incrementalPostMergeSync(t *TestEnv) {
 	)
 
 	// Speed up block production
-	t.CLMock.PayloadProductionClientDelay = time.Millisecond * 100
+	t.CLMock.PayloadProductionClientDelay = 0
 
 	// Also set the transition payload timestamp to 500 seconds before now.
 	// This is done in order to try to not create payloads too old, nor into the future.
@@ -172,6 +175,9 @@ func incrementalPostMergeSync(t *TestEnv) {
 
 	// Produce some blocks
 	t.CLMock.produceBlocks(int(N), BlockProcessCallbacks{})
+
+	// Reset block production delay
+	t.CLMock.PayloadProductionClientDelay = time.Second
 
 	// Set the Bootnode
 	enode, err := t.Engine.EnodeURL()

--- a/simulators/ethereum/engine/synctests.go
+++ b/simulators/ethereum/engine/synctests.go
@@ -16,6 +16,13 @@ var syncTests = []TestSpec{
 		ChainFile:      "blocks_1024_td_135112316.rlp",
 		TTD:            135112316,
 	},
+	{
+		Name:           "Incremental Post Merge Sync",
+		Run:            incrementalPostMergeSync,
+		TimeoutSeconds: 180,
+		ChainFile:      "blocks_1024_td_135112316.rlp",
+		TTD:            135112316,
+	},
 }
 
 // Routine that adds all sync tests to a test suite
@@ -28,7 +35,7 @@ func addSyncTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []
 		for _, clientDef := range clientDefs {
 			clientSyncVariantGenerator, ok := ClientToSyncVariantGenerator[clientDef.Name]
 			if !ok {
-				continue
+				clientSyncVariantGenerator = DefaultSyncVariantGenerator{}
 			}
 			currentTest := currentTest
 			genesisPath := "./init/genesis.json"
@@ -140,6 +147,78 @@ func postMergeSync(t *TestEnv) {
 		if t.CLMock.LatestHeader != nil && latestHeader.Hash() == t.CLMock.LatestHeader.Hash() {
 			t.Logf("INFO (%v): Client (%v) is now synced to latest PoS block: %v", t.TestName, hc.Container, latestHeader.Hash())
 			break
+		}
+	}
+
+}
+
+// Performs a test where sync is done incrementally by sending incremental newPayload/fcU calls
+func incrementalPostMergeSync(t *TestEnv) {
+	// Launch another client after the PoS transition has happened in the main client.
+	// Sync should eventually happen without issues.
+	t.CLMock.waitForTTD()
+
+	var (
+		N uint64 = 500 // Total number of PoS blocks
+		S uint64 = 5   // Number of incremental steps to sync
+	)
+
+	// Speed up block production
+	OriginalPayloadProductionClientDelay := PayloadProductionClientDelay
+	defer func() {
+		// In case test fails, revert block production speed
+		PayloadProductionClientDelay = OriginalPayloadProductionClientDelay
+	}()
+	PayloadProductionClientDelay = time.Millisecond * 100
+
+	// Produce some blocks
+	t.CLMock.produceBlocks(int(N), BlockProcessCallbacks{})
+
+	// Revert block production speed
+	PayloadProductionClientDelay = OriginalPayloadProductionClientDelay
+
+	// Set the Bootnode
+	enode, err := t.Engine.EnodeURL()
+	if err != nil {
+		t.Fatalf("FAIL (%s): Unable to obtain bootnode: %v", t.TestName, err)
+	}
+	newParams := t.ClientParams.Set("HIVE_BOOTNODE", fmt.Sprintf("%s", enode))
+	newParams = newParams.Set("HIVE_MINER", "")
+
+	_, secondaryEngine, err := t.StartClient(t.Client.Type, newParams, t.MainTTD())
+	if err != nil {
+		t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
+	}
+	secondaryEngineTest := NewTestEngineClient(t, secondaryEngine)
+	// t.CLMock.AddEngineClient(t.T, hc, t.MainTTD())
+
+	if N != uint64(len(t.CLMock.ExecutedPayloadHistory)) {
+		t.Fatalf("FAIL (%s): Unexpected number of payloads produced: %d != %d", t.TestName, len(t.CLMock.ExecutedPayloadHistory), N)
+	}
+
+	firstPoSBlockNumber := t.CLMock.FirstPoSBlockNumber.Uint64()
+	for i := uint64(firstPoSBlockNumber + (N / S) - 1); i <= (N + firstPoSBlockNumber); i += N / S {
+		payload, ok := t.CLMock.ExecutedPayloadHistory[i]
+		if !ok {
+			t.Fatalf("FAIL (%s): TEST ISSUE - Payload not found: %d", t.TestName, i)
+		}
+		secondaryEngineTest.TestEngineNewPayloadV1(&payload)
+		secondaryEngineTest.TestEngineForkchoiceUpdatedV1(&ForkchoiceStateV1{
+			HeadBlockHash: payload.BlockHash,
+		}, nil)
+		for {
+			b, err := secondaryEngine.Eth.BlockByNumber(secondaryEngine.Ctx(), nil)
+			if err != nil {
+				t.Fatalf("FAIL (%s): Error trying to get latest block: %v", t.TestName, err)
+			}
+			if b.Hash() == payload.BlockHash {
+				break
+			}
+			select {
+			case <-time.After(time.Second):
+			case <-t.Timeout:
+				t.Fatalf("FAIL (%s): Timeout waiting for client to sync", t.TestName)
+			}
 		}
 	}
 


### PR DESCRIPTION
### Changes included
Enhances Post-Merge sync tests by providing several variations of each sync tests where the variation is client dependent.
- Sync tests for geth are now performed on `archive`, `full` and `snap` modes.
- Sync tests for nethermind are now performed on `archive`, `fast` with varying pivot blocks.
- New test case `Incremental Post Merge Sync` passes a HeadBlockHash that is a block between the actual PoS head and the transition payload S times, waiting for the client to sync each time