### PR TITLE
clients/besu fix elif statement for syncing config

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -131,7 +131,7 @@ fi
 # archive, full or merge tests: full sync (per default)
 if [ "$HIVE_NODETYPE" == "light" ]; then
     echo "Ignoring HIVE_NODETYPE == light: besu does not support light client"
-elif [ "$HIVE_NODETYPE" == "" && "$HIVE_TERMINAL_TOTAL_DIFFICULTY" == ""  ]; then
+elif [ "$HIVE_NODETYPE" == "" ] && [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" == "" ]; then
     FLAGS="$FLAGS --sync-mode=FAST --fast-sync-min-peers=1 --Xsynchronizer-fast-sync-pivot-distance=0"
 fi
 


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

Surrounds each condition of the `elif` statement of the syncing config with square brackets. This resolves the following warning that was shown whenever the statement was executed:

```
/opt/besu/bin/besu-hive.sh: line 134: [: missing `]'
```