### PR TITLE
Fix reorgBack: send back FCU only after payload verification

### DIFF
--- a/simulators/ethereum/engine/clmock.go
+++ b/simulators/ethereum/engine/clmock.go
@@ -341,7 +341,7 @@ type BlockProcessCallbacks struct {
 	OnForkchoiceBroadcast     func()
 	OnSafeBlockChange         func()
 	OnFinalizedBlockChange    func()
-	OnVerificationEnd         func()
+	OnBlockProductionEnd      func()
 }
 
 func (cl *CLMocker) produceSingleBlock(callbacks BlockProcessCallbacks) {
@@ -452,8 +452,8 @@ func (cl *CLMocker) produceSingleBlock(callbacks BlockProcessCallbacks) {
 		cl.Fatalf("CLMocker: None of the clients accepted the newly constructed payload")
 	}
 
-	if callbacks.OnVerificationEnd != nil {
-		callbacks.OnVerificationEnd()
+	if callbacks.OnBlockProductionEnd != nil {
+		callbacks.OnBlockProductionEnd()
 	}
 }
 

--- a/simulators/ethereum/engine/clmock.go
+++ b/simulators/ethereum/engine/clmock.go
@@ -341,6 +341,7 @@ type BlockProcessCallbacks struct {
 	OnForkchoiceBroadcast     func()
 	OnSafeBlockChange         func()
 	OnFinalizedBlockChange    func()
+	OnVerificationEnd         func()
 }
 
 func (cl *CLMocker) produceSingleBlock(callbacks BlockProcessCallbacks) {
@@ -451,6 +452,9 @@ func (cl *CLMocker) produceSingleBlock(callbacks BlockProcessCallbacks) {
 		cl.Fatalf("CLMocker: None of the clients accepted the newly constructed payload")
 	}
 
+	if callbacks.OnVerificationEnd != nil {
+		callbacks.OnVerificationEnd()
+	}
 }
 
 // Loop produce PoS blocks by using the Engine API

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -1496,7 +1496,7 @@ func reorgBack(t *TestEnv) {
 
 	// Produce blocks before starting the test (So we don't try to reorg back to the genesis block)
 	t.CLMock.produceBlocks(5, BlockProcessCallbacks{
-		OnVerificationEnd: func() {
+		OnBlockProductionEnd: func() {
 			// Send a fcU with the HeadBlockHash pointing back to the previous block
 			forkchoiceUpdatedBack := ForkchoiceStateV1{
 				HeadBlockHash:      previousHash,

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -1496,7 +1496,7 @@ func reorgBack(t *TestEnv) {
 
 	// Produce blocks before starting the test (So we don't try to reorg back to the genesis block)
 	t.CLMock.produceBlocks(5, BlockProcessCallbacks{
-		OnForkchoiceBroadcast: func() {
+		OnVerificationEnd: func() {
 			// Send a fcU with the HeadBlockHash pointing back to the previous block
 			forkchoiceUpdatedBack := ForkchoiceStateV1{
 				HeadBlockHash:      previousHash,


### PR DESCRIPTION
This improves "Re-Org Back into Canonical Chain" test. The FCU pointing to the previous block sent by `reorgBack` should be sent after the payload verification in `produceSingleBlock`. When the back FCU is sent too early, it might render the newly created block unaccessible by `eth_getBlockByNumber("latest")`, thus leading to "CLMocker: None of the clients accepted the newly constructed payload".