### PR TITLE
simulators/ethereum/rpc-compat: update chain id to match tests

### DIFF
--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -22,8 +22,8 @@ import (
 var (
 	clientEnv = hivesim.Params{
 		"HIVE_NODETYPE":       "full",
-		"HIVE_NETWORK_ID":     "1",
-		"HIVE_CHAIN_ID":       "1",
+		"HIVE_NETWORK_ID":     "1337",
+		"HIVE_CHAIN_ID":       "1337",
 		"HIVE_FORK_HOMESTEAD": "0",
 		//"HIVE_FORK_DAO_BLOCK":      2000,
 		"HIVE_FORK_TANGERINE":      "0",


### PR DESCRIPTION
The tests now use chain ID `1337` so the hive simulator needs to be updated.