### PR TITLE
clients/nimbus, simulators/eth2/testnet: Update SECONDS_PER_SLOT to 6 Seconds

### DIFF
--- a/clients/nimbus-bn/Dockerfile
+++ b/clients/nimbus-bn/Dockerfile
@@ -11,10 +11,10 @@ ENV NPROC=2
 
 RUN git clone --depth 1 --branch unstable https://github.com/status-im/nimbus-eth2.git \
  && cd nimbus-eth2 \
- && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" V=1 update
+ && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=6" V=1 update
 
 RUN cd nimbus-eth2 && \
-    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" nimbus_beacon_node && \
+    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=6" nimbus_beacon_node && \
     mv build/nimbus_beacon_node /usr/bin/
 
 # --------------------------------- #

--- a/clients/nimbus-vc/Dockerfile
+++ b/clients/nimbus-vc/Dockerfile
@@ -11,10 +11,10 @@ ENV NPROC=2
 
 RUN git clone --depth 1 --branch unstable https://github.com/status-im/nimbus-eth2.git \
  && cd nimbus-eth2 \
- && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" V=1 update
+ && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=6" V=1 update
 
 RUN cd nimbus-eth2 && \
-    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=3" nimbus_validator_client && \
+    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:SECONDS_PER_SLOT=6" nimbus_validator_client && \
     mv build/nimbus_validator_client /usr/bin/
 
 # --------------------------------- #

--- a/simulators/eth2/testnet/scenarios.go
+++ b/simulators/eth2/testnet/scenarios.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	VALIDATOR_COUNT           uint64 = 64
-	SLOT_TIME                 uint64 = 3
+	SLOT_TIME                 uint64 = 6
 	TERMINAL_TOTAL_DIFFICULTY        = big.NewInt(100)
 )
 


### PR DESCRIPTION
This PR updates the compile-time value of nimbus to 6 seconds per slot.
The `eth2` test suites are generally more stable with this increased time slot.
Changes were tested by running `eth2/testnet` using the updated value, with Lighthouse and Geth as clients, and the test passed without issues.
Geth `DockerFile` was modified to run the changes only because of a current outstanding issue with `latest` docker.