### PR TITLE
hiveproxy: handle errors during connection setup

### DIFF
--- a/hiveproxy/Dockerfile
+++ b/hiveproxy/Dockerfile
@@ -10,10 +10,10 @@ RUN go mod download
 
 # Now build the proxy executable.
 ADD . /source
-RUN go build -o hive-proxy ./tool
+RUN go build -o /bin/hiveproxy ./tool
 
 # Pull the executable into a fresh image.
 FROM alpine:latest
-COPY --from=builder /source/hive-proxy .
+COPY --from=builder /bin/hiveproxy .
 EXPOSE 8081/tcp
-ENTRYPOINT ./hive-proxy --addr :8081
+ENTRYPOINT ./hiveproxy --addr :8081

--- a/internal/libdocker/proxy.go
+++ b/internal/libdocker/proxy.go
@@ -35,7 +35,15 @@ func (cb *ContainerBackend) ServeAPI(ctx context.Context, h http.Handler) (libhi
 		return nil, err
 	}
 
-	proxy := hiveproxy.RunBackend(outR, inW, h)
+	proxy, err := hiveproxy.RunBackend(outR, inW, h)
+	if err != nil {
+		cb.DeleteContainer(id)
+		return nil, err
+	}
+
+	// Register proxy in ContainerBackend, so it can be used for CheckLive.
+	cb.proxy = proxy
+
 	srv := &proxyContainer{
 		cb:              cb,
 		containerID:     id,


### PR DESCRIPTION
This fixes a panic in internal/libdocker, which could occur
when hive was interrupted while setting up the proxy.