### PR TITLE
hive: move simulation runner to internal/libhive

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -5,13 +5,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -68,6 +64,10 @@ func main() {
 	if *simPattern != "" && len(simList) == 0 {
 		fatal("no simulators for pattern", *simPattern)
 	}
+	if *simPattern != "" && *simDevMode {
+		log15.Warn("--sim is ignored when using --dev mode")
+		simList = nil
+	}
 
 	// Create the docker backends.
 	dockerConfig := &libdocker.Config{
@@ -85,7 +85,7 @@ func main() {
 		dockerConfig.ContainerOutput = os.Stderr
 		dockerConfig.BuildOutput = os.Stderr
 	}
-	builder, containerBackend, err := libdocker.Connect(*dockerEndpoint, dockerConfig)
+	builder, cb, err := libdocker.Connect(*dockerEndpoint, dockerConfig)
 	if err != nil {
 		fatal(err)
 	}
@@ -100,246 +100,42 @@ func main() {
 	}()
 
 	// Run.
-	runner := simRunner{
-		inv:       inv,
-		builder:   builder,
-		container: containerBackend,
-		env: libhive.SimEnv{
-			LogDir:             *testResultsRoot,
-			SimLogLevel:        *simLogLevel,
-			SimTestPattern:     *simTestPattern,
-			SimParallelism:     *simParallelism,
-			ClientStartTimeout: *clientTimeout,
-		},
-		SimDurationLimit: *simTimeLimit,
+	env := libhive.SimEnv{
+		LogDir:             *testResultsRoot,
+		SimLogLevel:        *simLogLevel,
+		SimTestPattern:     *simTestPattern,
+		SimParallelism:     *simParallelism,
+		SimDurationLimit:   *simTimeLimit,
+		ClientStartTimeout: *clientTimeout,
 	}
-
-	if err := libdocker.BuildProxy(ctx, builder); err != nil {
-		fatal(err)
-	}
-
+	runner := libhive.NewRunner(inv, builder, cb)
 	clientList := splitAndTrim(*clients, ",")
-	if err := runner.initClients(ctx, clientList); err != nil {
+
+	if err := runner.Build(ctx, clientList, simList); err != nil {
 		fatal(err)
 	}
 
 	if *simDevMode {
-		log15.Info("running in simulator development mode")
-		runner.runSimulatorAPIDevMode(ctx, *simDevModeAPIEndpoint)
-	} else if len(simList) > 0 {
-		if err := runner.initSimulators(ctx, simList); err != nil {
+		runner.RunDevMode(ctx, env, *simDevModeAPIEndpoint)
+		return
+	}
+
+	var failCount int
+	for _, sim := range simList {
+		result, err := runner.Run(ctx, sim, env)
+		if err != nil {
 			fatal(err)
 		}
-		if err := runner.runSimulations(ctx, simList); err != nil {
-			fatal(err)
-		}
-	}
-}
-
-type simRunner struct {
-	inv       libhive.Inventory
-	container libhive.ContainerBackend
-	builder   libhive.Builder
-	env       libhive.SimEnv
-
-	// This holds the image names of all built simulators.
-	simImages map[string]string
-
-	// This is the time limit for a single simulation run.
-	SimDurationLimit time.Duration
-}
-
-// initClients builds client images.
-func (r *simRunner) initClients(ctx context.Context, clientList []string) error {
-	r.env.Definitions = make(map[string]*libhive.ClientDefinition)
-
-	if len(clientList) == 0 {
-		return errors.New("client list is empty, cannot simulate")
+		failCount += result.TestsFailed
+		log15.Info(fmt.Sprintf("simulation %s finished", sim), "suites", result.Suites, "tests", result.Tests, "failed", result.TestsFailed)
 	}
 
-	var anyBuilt bool
-	log15.Info(fmt.Sprintf("building %d clients...", len(clientList)))
-	for _, client := range clientList {
-		if !r.inv.HasClient(client) {
-			return fmt.Errorf("unknown client %q", client)
-		}
-		meta, err := r.builder.ReadClientMetadata(client)
-		if err != nil {
-			return err
-		}
-		image, err := r.builder.BuildClientImage(ctx, client)
-		if err != nil {
-			continue
-		}
-		anyBuilt = true
-		version, err := r.builder.ReadFile(image, "/version.txt")
-		if err != nil {
-			log15.Warn("can't read version info of "+client, "image", image, "err", err)
-		}
-		r.env.Definitions[client] = &libhive.ClientDefinition{
-			Name:    client,
-			Version: strings.TrimSpace(string(version)),
-			Image:   image,
-			Meta:    *meta,
-		}
-	}
-	if !anyBuilt {
-		return errors.New("all clients failed to build")
-	}
-	return nil
-}
-
-// initSimulators builds simulator images.
-func (r *simRunner) initSimulators(ctx context.Context, simList []string) error {
-	r.simImages = make(map[string]string)
-
-	log15.Info(fmt.Sprintf("building %d simulators...", len(simList)))
-	for _, sim := range simList {
-		image, err := r.builder.BuildSimulatorImage(ctx, sim)
-		if err != nil {
-			return err
-		}
-		r.simImages[sim] = image
-	}
-	return nil
-}
-
-func (r *simRunner) runSimulations(ctx context.Context, simList []string) error {
-	log15.Info("creating output directory", "folder", r.env.LogDir)
-	if err := os.MkdirAll(r.env.LogDir, 0755); err != nil {
-		log15.Crit("failed to create logs folder", "err", err)
-		return err
-	}
-
-	for _, sim := range simList {
-		if err := r.run(ctx, sim); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *simRunner) runSimulatorAPIDevMode(ctx context.Context, endpoint string) error {
-	tm := libhive.NewTestManager(r.env, r.container, -1)
-	defer func() {
-		if err := tm.Terminate(); err != nil {
-			log15.Error("could not terminate test manager", "error", err)
-		}
-	}()
-
-	log15.Debug("starting simulator API proxy")
-	proxy, err := r.container.ServeAPI(ctx, tm.API())
-	if err != nil {
-		log15.Error("can't start proxy", "err", err)
-		return err
-	}
-	defer shutdownServer(proxy)
-
-	log15.Debug("starting local API server")
-	listener, err := net.Listen("tcp", endpoint)
-	if err != nil {
-		log15.Error("can't start TCP server", "err", err)
-		return err
-	}
-	httpsrv := &http.Server{Handler: tm.API()}
-	defer httpsrv.Close()
-	go func() { httpsrv.Serve(listener) }()
-
-	fmt.Printf(`---
-Welcome to hive --dev mode. Run with me:
-
-HIVE_SIMULATOR=http://%v
----
-`, listener.Addr())
-
-	// Wait for interrupt.
-	<-ctx.Done()
-	return nil
-}
-
-// run runs one simulation.
-func (r *simRunner) run(ctx context.Context, sim string) error {
-	log15.Info(fmt.Sprintf("running simulation: %s", sim))
-
-	// Start the simulation API.
-	tm := libhive.NewTestManager(r.env, r.container, -1)
-	defer func() {
-		if err := tm.Terminate(); err != nil {
-			log15.Error("could not terminate test manager", "error", err)
-		}
-	}()
-
-	log15.Debug("starting simulator API server")
-	server, err := r.container.ServeAPI(ctx, tm.API())
-	if err != nil {
-		log15.Error("can't start API server", "err", err)
-		return err
-	}
-	defer shutdownServer(server)
-
-	// Create the simulator container.
-	opts := libhive.ContainerOptions{
-		Env: map[string]string{
-			"HIVE_SIMULATOR":    "http://" + server.Addr().String(),
-			"HIVE_PARALLELISM":  strconv.Itoa(r.env.SimParallelism),
-			"HIVE_LOGLEVEL":     strconv.Itoa(r.env.SimLogLevel),
-			"HIVE_TEST_PATTERN": r.env.SimTestPattern,
-		},
-	}
-	containerID, err := r.container.CreateContainer(ctx, r.simImages[sim], opts)
-	if err != nil {
-		return err
-	}
-
-	// Set the log file, and notify TestManager about the container.
-	logbasename := fmt.Sprintf("%d-simulator-%s.log", time.Now().Unix(), containerID)
-	opts.LogFile = filepath.Join(r.env.LogDir, logbasename)
-	tm.SetSimContainerInfo(containerID, logbasename)
-
-	log15.Debug("starting simulator container")
-	sc, err := r.container.StartContainer(ctx, containerID, opts)
-	if err != nil {
-		return err
-	}
-	slogger := log15.New("sim", sim, "container", sc.ID[:8])
-	slogger.Debug("started simulator container")
-	defer func() {
-		slogger.Debug("deleting simulator container")
-		r.container.DeleteContainer(sc.ID)
-	}()
-
-	// Wait for simulator exit.
-	done := make(chan struct{})
-	go func() {
-		sc.Wait()
-		close(done)
-	}()
-
-	// if we have a simulation time limit, apply it.
-	var timeout <-chan time.Time
-	if r.SimDurationLimit != 0 {
-		tt := time.NewTimer(r.SimDurationLimit)
-		defer tt.Stop()
-		timeout = tt.C
-	}
-
-	// Wait for simulation to end.
-	select {
-	case <-done:
-	case <-timeout:
-		slogger.Info("simulation timed out")
-	case <-ctx.Done():
-		slogger.Info("interrupted, shutting down")
-		return errors.New("simulation interrupted")
-	}
-	return nil
-}
-
-// shutdownServer gracefully terminates the HTTP server.
-func shutdownServer(server libhive.APIServer) {
-	log15.Debug("terminating simulator API server")
-	if err := server.Close(); err != nil {
-		log15.Debug("API server shutdown failed", "err", err)
+	switch failCount {
+	case 0:
+	case 1:
+		fatal(errors.New("1 test failed"))
+	default:
+		fatal(fmt.Errorf("%d tests failed", failCount))
 	}
 }
 

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -116,7 +116,7 @@ func TestEnodeReplaceIP(t *testing.T) {
 func TestStartClientStartOptions(t *testing.T) {
 	var lastOptions libhive.ContainerOptions
 	tm, srv := newFakeAPI(&fakes.BackendHooks{
-		StartContainer: func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
+		StartContainer: func(image, containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
 			lastOptions = opt
 			return &libhive.ContainerInfo{}, nil
 		},
@@ -346,7 +346,7 @@ func TestStartClientInitialNetworks(t *testing.T) {
 		ipcounter   byte
 	)
 	tm, srv := newFakeAPI(&fakes.BackendHooks{
-		StartContainer: func(containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
+		StartContainer: func(image, containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
 			return &libhive.ContainerInfo{}, nil
 		},
 		ConnectContainer: func(containerID string, networkID string) error {
@@ -401,14 +401,13 @@ func TestStartClientInitialNetworks(t *testing.T) {
 }
 
 func newFakeAPI(hooks *fakes.BackendHooks) (*libhive.TestManager, *httptest.Server) {
-	env := libhive.SimEnv{
-		Definitions: map[string]*libhive.ClientDefinition{
-			"client-1": {Name: "client-1", Image: "/ignored/in/api", Version: "client-1-version", Meta: libhive.ClientMetadata{Roles: []string{"eth1"}}},
-			"client-2": {Name: "client-2", Image: "/not/exposed/", Version: "client-2-version", Meta: libhive.ClientMetadata{Roles: []string{"beacon"}}},
-		},
+	defs := map[string]*libhive.ClientDefinition{
+		"client-1": {Name: "client-1", Image: "/ignored/in/api", Version: "client-1-version", Meta: libhive.ClientMetadata{Roles: []string{"eth1"}}},
+		"client-2": {Name: "client-2", Image: "/not/exposed/", Version: "client-2-version", Meta: libhive.ClientMetadata{Roles: []string{"beacon"}}},
 	}
+	env := libhive.SimEnv{}
 	backend := fakes.NewContainerBackend(hooks)
-	tm := libhive.NewTestManager(env, backend, -1)
+	tm := libhive.NewTestManager(env, backend, defs)
 	srv := httptest.NewServer(tm.API())
 	return tm, srv
 }

--- a/internal/fakes/builder.go
+++ b/internal/fakes/builder.go
@@ -1,0 +1,63 @@
+package fakes
+
+import (
+	"context"
+	"io/fs"
+
+	"github.com/ethereum/hive/internal/libhive"
+)
+
+// BuilderHooks can be used to override the behavior of the fake builder.
+type BuilderHooks struct {
+	BuildClientImage    func(context.Context, string) (string, error)
+	BuildSimulatorImage func(context.Context, string) (string, error)
+	ReadFile            func(ctx context.Context, image string, file string) ([]byte, error)
+	ReadClientMetadata  func(name string) (*libhive.ClientMetadata, error)
+}
+
+// fakeBuilder implements Backend without docker.
+type fakeBuilder struct {
+	hooks BuilderHooks
+}
+
+// NewBuilder creates a new fake builder.
+func NewBuilder(hooks *BuilderHooks) libhive.Builder {
+	b := &fakeBuilder{}
+	if hooks != nil {
+		b.hooks = *hooks
+	}
+	return b
+}
+
+func (b *fakeBuilder) BuildClientImage(ctx context.Context, client string) (string, error) {
+	if b.hooks.BuildClientImage != nil {
+		return b.hooks.BuildClientImage(ctx, client)
+	}
+	return "fakebuild/client/" + client + ":latest", nil
+}
+
+func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string) (string, error) {
+	if b.hooks.BuildSimulatorImage != nil {
+		return b.hooks.BuildSimulatorImage(ctx, sim)
+	}
+	return "fakebuild/simulator/" + sim + ":latest", nil
+}
+
+func (b *fakeBuilder) BuildImage(ctx context.Context, name string, fsys fs.FS) error {
+	return nil
+}
+
+func (b *fakeBuilder) ReadClientMetadata(name string) (*libhive.ClientMetadata, error) {
+	if b.hooks.ReadClientMetadata != nil {
+		return b.hooks.ReadClientMetadata(name)
+	}
+	m := libhive.ClientMetadata{Roles: []string{"eth1"}}
+	return &m, nil
+}
+
+func (b *fakeBuilder) ReadFile(ctx context.Context, image, file string) ([]byte, error) {
+	if b.hooks.ReadFile != nil {
+		return b.hooks.ReadFile(ctx, image, file)
+	}
+	return []byte{}, nil
+}

--- a/internal/libdocker/proxy.go
+++ b/internal/libdocker/proxy.go
@@ -14,9 +14,9 @@ import (
 
 const hiveproxyTag = "hive/hiveproxy"
 
-// BuildProxy builds the hiveproxy image.
-func BuildProxy(ctx context.Context, builder libhive.Builder) error {
-	return builder.BuildImage(ctx, hiveproxyTag, hiveproxy.Source)
+// Build builds the hiveproxy image.
+func (cb *ContainerBackend) Build(ctx context.Context, b libhive.Builder) error {
+	return b.BuildImage(ctx, hiveproxyTag, hiveproxy.Source)
 }
 
 // ServeAPI starts the API server.

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -59,8 +59,8 @@ type simAPI struct {
 
 // getClientTypes returns all known client types.
 func (api *simAPI) getClientTypes(w http.ResponseWriter, r *http.Request) {
-	clients := make([]*ClientDefinition, 0, len(api.env.Definitions))
-	for _, def := range api.env.Definitions {
+	clients := make([]*ClientDefinition, 0, len(api.tm.clientDefs))
+	for _, def := range api.tm.clientDefs {
 		clients = append(clients, def)
 	}
 	sort.Slice(clients, func(i, j int) bool {
@@ -326,7 +326,7 @@ func (api *simAPI) checkClient(req *simapi.NodeConfig) (*ClientDefinition, error
 	if req.Client == "" {
 		return nil, errors.New("missing client type in start request")
 	}
-	def, ok := api.env.Definitions[req.Client]
+	def, ok := api.tm.clientDefs[req.Client]
 	if !ok {
 		return nil, errors.New("unknown client type in start request")
 	}

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -12,6 +12,10 @@ import (
 
 // ContainerBackend captures the docker interactions of the simulation API.
 type ContainerBackend interface {
+	// Build is a hook allowing ContainerBackend to build internal helper images.
+	// This is called before anything else in the simulation run.
+	Build(context.Context, Builder) error
+
 	// This is for launching the simulation API server.
 	ServeAPI(context.Context, http.Handler) (APIServer, error)
 
@@ -80,7 +84,7 @@ type Builder interface {
 	BuildImage(ctx context.Context, name string, fsys fs.FS) error
 
 	// ReadFile returns the content of a file in the given image.
-	ReadFile(image, path string) ([]byte, error)
+	ReadFile(ctx context.Context, image, path string) ([]byte, error)
 }
 
 // ClientMetadata is metadata to describe the client in more detail, configured with a YAML file in the client dir.

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -1,8 +1,10 @@
-package libhive
+package libhive_test
 
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/ethereum/hive/internal/libhive"
 )
 
 func TestSplitClientName(t *testing.T) {
@@ -15,16 +17,16 @@ func TestSplitClientName(t *testing.T) {
 		{"the_client_b", "the_client", "b"},
 	}
 	for _, test := range tests {
-		c, b := SplitClientName(test.name)
+		c, b := libhive.SplitClientName(test.name)
 		if c != test.wantClient || b != test.wantBranch {
-			t.Errorf("SplitClientName(%q) -> (%q, %q), want (%q, %q)", test.name, c, b, test.wantClient, test.wantBranch)
+			t.Errorf("SpnlitClientName(%q) -> (%q, %q), want (%q, %q)", test.name, c, b, test.wantClient, test.wantBranch)
 		}
 	}
 }
 
 func TestInventory(t *testing.T) {
 	basedir := filepath.FromSlash("../..")
-	inv, err := LoadInventory(basedir)
+	inv, err := libhive.LoadInventory(basedir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -1,0 +1,290 @@
+package libhive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+var (
+	errSimInterrupt = errors.New("simulation interrupted")
+	errSimTimeout   = errors.New("simulation timed out")
+)
+
+// Runner executes a simulation runs.
+type Runner struct {
+	inv       Inventory
+	container ContainerBackend
+	builder   Builder
+
+	// This holds the image names of all built simulators.
+	simImages  map[string]string
+	clientDefs map[string]*ClientDefinition
+}
+
+func NewRunner(inv Inventory, b Builder, cb ContainerBackend) *Runner {
+	return &Runner{
+		inv:       inv,
+		builder:   b,
+		container: cb,
+	}
+}
+
+// Build builds client and simulator images.
+func (r *Runner) Build(ctx context.Context, clientList, simList []string) error {
+	if err := r.container.Build(ctx, r.builder); err != nil {
+		return err
+	}
+	if err := r.buildClients(ctx, clientList); err != nil {
+		return err
+	}
+	return r.buildSimulators(ctx, simList)
+}
+
+// buildClients builds client images.
+func (r *Runner) buildClients(ctx context.Context, clientList []string) error {
+	if len(clientList) == 0 {
+		return errors.New("client list is empty, cannot simulate")
+	}
+
+	r.clientDefs = make(map[string]*ClientDefinition, len(clientList))
+
+	var anyBuilt bool
+	log15.Info(fmt.Sprintf("building %d clients...", len(clientList)))
+	for _, client := range clientList {
+		if !r.inv.HasClient(client) {
+			return fmt.Errorf("unknown client %q", client)
+		}
+		meta, err := r.builder.ReadClientMetadata(client)
+		if err != nil {
+			return err
+		}
+		image, err := r.builder.BuildClientImage(ctx, client)
+		if err != nil {
+			continue
+		}
+		anyBuilt = true
+		version, err := r.builder.ReadFile(ctx, image, "/version.txt")
+		if err != nil {
+			log15.Warn("can't read version info of "+client, "image", image, "err", err)
+		}
+		r.clientDefs[client] = &ClientDefinition{
+			Name:    client,
+			Version: strings.TrimSpace(string(version)),
+			Image:   image,
+			Meta:    *meta,
+		}
+	}
+	if !anyBuilt {
+		return errors.New("all clients failed to build")
+	}
+	return nil
+}
+
+// buildSimulators builds simulator images.
+func (r *Runner) buildSimulators(ctx context.Context, simList []string) error {
+	r.simImages = make(map[string]string)
+
+	log15.Info(fmt.Sprintf("building %d simulators...", len(simList)))
+	for _, sim := range simList {
+		image, err := r.builder.BuildSimulatorImage(ctx, sim)
+		if err != nil {
+			return err
+		}
+		r.simImages[sim] = image
+	}
+	return nil
+}
+
+func (r *Runner) Run(ctx context.Context, sim string, env SimEnv) (SimResult, error) {
+	stat, err := os.Stat(env.LogDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log15.Info("creating output directory", "folder", env.LogDir)
+			if err := os.MkdirAll(env.LogDir, 0755); err != nil {
+				log15.Crit("failed to create logs folder", "err", err)
+				return SimResult{}, err
+			}
+		} else {
+			return SimResult{}, err
+		}
+	}
+	if !stat.IsDir() {
+		return SimResult{}, errors.New("log output directory is a file")
+	}
+
+	return r.run(ctx, sim, env)
+}
+
+// RunDevMode starts simulator development mode. In this mode, the simulator is not
+// launched and the API server runs on the local network instead of listening for requests
+// on the docker network.
+//
+// Note: Sim* options in env are ignored, but Client* options and LogDir still apply.
+func (r *Runner) RunDevMode(ctx context.Context, env SimEnv, endpoint string) error {
+	tm := NewTestManager(env, r.container, r.clientDefs)
+	defer func() {
+		if err := tm.Terminate(); err != nil {
+			log15.Error("could not terminate test manager", "error", err)
+		}
+	}()
+
+	log15.Debug("starting simulator API proxy")
+	proxy, err := r.container.ServeAPI(ctx, tm.API())
+	if err != nil {
+		log15.Error("can't start proxy", "err", err)
+		return err
+	}
+	defer shutdownServer(proxy)
+
+	log15.Debug("starting local API server")
+	listener, err := net.Listen("tcp", endpoint)
+	if err != nil {
+		log15.Error("can't start TCP server", "err", err)
+		return err
+	}
+	httpsrv := &http.Server{Handler: tm.API()}
+	defer httpsrv.Close()
+	go func() { httpsrv.Serve(listener) }()
+
+	fmt.Printf(`---
+Welcome to hive --dev mode. Run with me:
+
+HIVE_SIMULATOR=http://%v
+---
+`, listener.Addr())
+
+	// Wait for interrupt.
+	<-ctx.Done()
+	return nil
+}
+
+// run runs one simulation.
+func (r *Runner) run(ctx context.Context, sim string, env SimEnv) (SimResult, error) {
+	log15.Info(fmt.Sprintf("running simulation: %s", sim))
+
+	clientDefs := make(map[string]*ClientDefinition)
+	if env.ClientList == nil {
+		// Unspecified, make all clients available.
+		for name, def := range r.clientDefs {
+			clientDefs[name] = def
+		}
+	} else {
+		for _, name := range env.ClientList {
+			def, ok := r.clientDefs[name]
+			if !ok {
+				return SimResult{}, fmt.Errorf("unknown client %q in simulation client list", name)
+			}
+			clientDefs[name] = def
+		}
+	}
+
+	// Start the simulation API.
+	tm := NewTestManager(env, r.container, clientDefs)
+	defer func() {
+		if err := tm.Terminate(); err != nil {
+			log15.Error("could not terminate test manager", "error", err)
+		}
+	}()
+
+	log15.Debug("starting simulator API server")
+	server, err := r.container.ServeAPI(ctx, tm.API())
+	if err != nil {
+		log15.Error("can't start API server", "err", err)
+		return SimResult{}, err
+	}
+	defer shutdownServer(server)
+
+	// Create the simulator container.
+	opts := ContainerOptions{
+		Env: map[string]string{
+			"HIVE_SIMULATOR":    "http://" + server.Addr().String(),
+			"HIVE_PARALLELISM":  strconv.Itoa(env.SimParallelism),
+			"HIVE_LOGLEVEL":     strconv.Itoa(env.SimLogLevel),
+			"HIVE_TEST_PATTERN": env.SimTestPattern,
+		},
+	}
+	containerID, err := r.container.CreateContainer(ctx, r.simImages[sim], opts)
+	if err != nil {
+		return SimResult{}, err
+	}
+
+	// Set the log file, and notify TestManager about the container.
+	logbasename := fmt.Sprintf("%d-simulator-%s.log", time.Now().Unix(), containerID)
+	opts.LogFile = filepath.Join(env.LogDir, logbasename)
+	tm.SetSimContainerInfo(containerID, logbasename)
+
+	log15.Debug("starting simulator container")
+	sc, err := r.container.StartContainer(ctx, containerID, opts)
+	if err != nil {
+		return SimResult{}, err
+	}
+	slogger := log15.New("sim", sim, "container", sc.ID[:8])
+	slogger.Debug("started simulator container")
+	defer func() {
+		slogger.Debug("deleting simulator container")
+		r.container.DeleteContainer(sc.ID)
+	}()
+
+	// Wait for simulator exit.
+	done := make(chan struct{})
+	go func() {
+		sc.Wait()
+		close(done)
+	}()
+
+	// if we have a simulation time limit, apply it.
+	var timeout <-chan time.Time
+	if env.SimDurationLimit != 0 {
+		tt := time.NewTimer(env.SimDurationLimit)
+		defer tt.Stop()
+		timeout = tt.C
+	}
+
+	// Wait for simulation to end.
+	select {
+	case <-done:
+	case <-timeout:
+		slogger.Info("simulation timed out")
+		err = errSimTimeout
+	case <-ctx.Done():
+		slogger.Info("interrupted, shutting down")
+		err = errSimInterrupt
+	}
+
+	// Count the results.
+	var result SimResult
+	for _, suite := range tm.Results() {
+		var suiteFailCounted bool
+		result.Suites++
+		for _, test := range suite.TestCases {
+			result.Tests++
+			if !test.SummaryResult.Pass {
+				result.TestsFailed++
+				if !suiteFailCounted {
+					result.SuitesFailed++
+					suiteFailCounted = true
+				}
+			}
+		}
+	}
+
+	return result, err
+}
+
+// shutdownServer gracefully terminates the HTTP server.
+func shutdownServer(server APIServer) {
+	log15.Debug("terminating simulator API server")
+	if err := server.Close(); err != nil {
+		log15.Debug("API server shutdown failed", "err", err)
+	}
+}

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -1,0 +1,73 @@
+package libhive_test
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/hive/hivesim"
+	"github.com/ethereum/hive/internal/fakes"
+	"github.com/ethereum/hive/internal/libhive"
+)
+
+func TestRunner(t *testing.T) {
+	var (
+		allClients = []string{"client-1", "client-2", "client-3"}
+		simClients = allClients[1:]
+	)
+
+	inv := makeTestInventory()
+	b := fakes.NewBuilder(&fakes.BuilderHooks{})
+	cb := fakes.NewContainerBackend(&fakes.BackendHooks{
+		StartContainer: func(image, containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
+			t.Logf("StartContainer(image=%s, id=%s)", image, containerID)
+			if strings.Contains(image, "/simulator/") {
+				simURL := opt.Env["HIVE_SIMULATOR"]
+				t.Log("HIVE_SIMULATOR =", simURL)
+
+				sim := hivesim.NewAt(simURL)
+				defs, err := sim.ClientTypes()
+				if err != nil {
+					t.Fatal("error getting client types:", err)
+				}
+				if names := clientNames(defs); !reflect.DeepEqual(names, simClients) {
+					t.Fatal("wrong client names:", names)
+				}
+			}
+			return new(libhive.ContainerInfo), nil
+		},
+	})
+
+	var (
+		runner  = libhive.NewRunner(inv, b, cb)
+		simList = []string{"sim-1"}
+		simOpt  = libhive.SimEnv{LogDir: t.TempDir(), ClientList: simClients}
+		ctx     = context.Background()
+	)
+	if err := runner.Build(ctx, allClients, simList); err != nil {
+		t.Fatal("Build() failed:", err)
+	}
+	if _, err := runner.Run(context.Background(), "sim-1", simOpt); err != nil {
+		t.Fatal("Run() failed:", err)
+	}
+}
+
+func makeTestInventory() libhive.Inventory {
+	var inv libhive.Inventory
+	inv.AddClient("client-1")
+	inv.AddClient("client-2")
+	inv.AddClient("client-3")
+	inv.AddSimulator("sim-1")
+	return inv
+}
+
+func clientNames(defs []*hivesim.ClientDefinition) []string {
+	names := make([]string, 0, len(defs))
+	for _, def := range defs {
+		names = append(names, def.Name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
This moves all logic related to a simulation run into the library. The
runner has also gained a couple of new features in this change:
Pass/fail stats are now collected across simulators, enabling the hive
tool to exit with a non-zero status when tests have failed.

Another new feature of the library: the client list can now be overridden
separately for every individual simulator run. This will come in handy when
we create a tool to run multiple simulations from a config file.