### PR TITLE
simulators/ethereum/engine: CL Mock Test Fixes

### DIFF
--- a/simulators/ethereum/engine/clmock.go
+++ b/simulators/ethereum/engine/clmock.go
@@ -127,7 +127,6 @@ func (cl *CLMocker) setTTDBlockClient(ec *EngineClient) {
 	if td == nil {
 		cl.Fatalf("CLMocker: Returned TotalDifficultyHeader is invalid: %v", td)
 	}
-	cl.Logf("CLMocker: Returned TotalDifficultyHeader: %v", td)
 
 	if td.TotalDifficulty.ToInt().Cmp(ec.TerminalTotalDifficulty) < 0 {
 		cl.Fatalf("CLMocker: Attempted to set TTD Block when TTD had not been reached: %v > %v", ec.TerminalTotalDifficulty, td.TotalDifficulty.ToInt())
@@ -173,9 +172,9 @@ func (cl *CLMocker) setTTDBlockClient(ec *EngineClient) {
 // This method waits for TTD in at least one of the clients, then sends the
 // initial forkchoiceUpdated with the info obtained from the client.
 func (cl *CLMocker) waitForTTD() {
-	ec := cl.EngineClients.waitForTTD(cl.Timeout)
-	if ec == nil {
-		cl.Fatalf("CLMocker: Timeout while waiting for TTD")
+	ec, err := cl.EngineClients.waitForTTD(cl.Timeout)
+	if ec == nil || err != nil {
+		cl.Fatalf("CLMocker: Error while waiting for TTD: %v", err)
 	}
 	// One of the clients has reached TTD, send the initial fcU with this client as head
 	cl.setTTDBlockClient(ec)

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -137,6 +137,10 @@ have reached the Terminal Total Difficulty.`[1:],
 			Parameters:  newParams,
 			Files:       testFiles,
 			Run: func(t *hivesim.T, c *hivesim.Client) {
+				t.Logf("Start test: %s", currentTest.Name)
+				defer func() {
+					t.Logf("End test: %s", currentTest.Name)
+				}()
 				timeout := DefaultTestCaseTimeout
 				// If a TestSpec specifies a timeout, use that instead
 				if currentTest.TimeoutSeconds != 0 {

--- a/simulators/ethereum/engine/mergetests.go
+++ b/simulators/ethereum/engine/mergetests.go
@@ -372,8 +372,8 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 	runFunc := func(t *TestEnv) {
 		// The first client waits for TTD, which ideally should be reached immediately using loaded chain
 		if !mergeTestSpec.SkipMainClientTTDWait {
-			if !t.Engine.waitForTTDWithTimeout(t.Timeout) {
-				t.Fatalf("FAIL (%s): Timeout waiting for EngineClient (%s) to reach TTD", t.TestName, t.Engine.Container)
+			if err := t.Engine.waitForTTDWithTimeout(t.Timeout); err != nil {
+				t.Fatalf("FAIL (%s): Error while waiting for EngineClient (%s) to reach TTD: %v", t.TestName, t.Engine.Container, err)
 			}
 
 			if !mergeTestSpec.SkipMainClientFcU {
@@ -411,8 +411,8 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 			t.CLMock.AddEngineClient(t.T, secondaryClient.Client, big.NewInt(secondaryClientSpec.TTD))
 
 			if secondaryClientSpec.BuildPoSChainOnTop {
-				if !secondaryClient.waitForTTDWithTimeout(t.Timeout) {
-					t.Fatalf("FAIL (%s): Timeout waiting for EngineClient (%s) to reach TTD", t.TestName, secondaryClient.Client.Container)
+				if err := secondaryClient.waitForTTDWithTimeout(t.Timeout); err != nil {
+					t.Fatalf("FAIL (%s): Error while waiting for EngineClient (%s) to reach TTD: %v", t.TestName, secondaryClient.Client.Container, err)
 				}
 				t.CLMock.setTTDBlockClient(secondaryClient)
 			}

--- a/simulators/ethereum/engine/node.go
+++ b/simulators/ethereum/engine/node.go
@@ -98,6 +98,10 @@ func restart(bootnode, datadir string, genesis *core.Genesis) (*gethNode, error)
 	}, err
 }
 
+func (n *gethNode) Stop() error {
+	return n.eth.Stop()
+}
+
 type validator struct{}
 
 func (v *validator) ValidateBody(block *types.Block) error {

--- a/simulators/ethereum/engine/testenv.go
+++ b/simulators/ethereum/engine/testenv.go
@@ -143,21 +143,21 @@ func (t *TestEnv) StartClient(clientType string, params hivesim.Params, ttd *big
 func (t *TestEnv) makeNextTransaction(recipient common.Address, amount *big.Int, payload []byte) *types.Transaction {
 
 	gasLimit := uint64(75000)
-
 	tx := types.NewTransaction(t.nonce, recipient, amount, gasLimit, gasPrice, payload)
 	signer := types.NewEIP155Signer(chainID)
 	signedTx, err := types.SignTx(tx, signer, vaultKey)
 	if err != nil {
 		t.Fatal("FAIL (%s): could not sign new tx: %v", t.TestName, err)
 	}
+	t.Logf("INFO (%s): Built next transaction: hash=%s, nonce=%d, recipient=%s", t.TestName, signedTx.Hash(), t.nonce, recipient)
 	t.nonce++
 	return signedTx
 }
 
-func (t *TestEnv) sendNextTransaction(sender *EngineClient, recipient common.Address, amount *big.Int, payload []byte) *types.Transaction {
+func (t *TestEnv) sendNextTransaction(node *EngineClient, recipient common.Address, amount *big.Int, payload []byte) *types.Transaction {
 	tx := t.makeNextTransaction(recipient, amount, payload)
 	for {
-		err := sender.Eth.SendTransaction(sender.Ctx(), tx)
+		err := node.Eth.SendTransaction(node.Ctx(), tx)
 		if err == nil {
 			return tx
 		}


### PR DESCRIPTION
Fixes:
- During hive runs it was detected that some of the transactions from previous tests were being replayed on tests, and it was because the secondary node was not being correctly terminated.
- Checking the TTD no longer panics on error, and therefore subsequent tests are no longer aborted
- ~~HIVE_CHECK_LIVE_PORT is now set to the Engine API port 8551 (#603 )~~ Requires to check multiple live ports to properly fix
- Minor log improvements

Temporarily disabled test cases:
- Invalid Ancestor Chain Re-Org, Invalid Number, Invalid P9', Reveal using sync
- Invalid Ancestor Chain Re-Org, Invalid PrevRandao, Invalid P9', Reveal using sync