### PR TITLE
libhive, libdocker: Add client multiple port check

### DIFF
--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -265,15 +265,20 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// by default: check the eth1 port
-	options.CheckLive = 8545
+	options.CheckLive = []uint16{
+		8545,
+	}
 	if portStr := env["HIVE_CHECK_LIVE_PORT"]; portStr != "" {
-		v, err := strconv.ParseUint(portStr, 10, 16)
-		if err != nil {
-			log15.Error("API: could not parse check-live port", "error", err)
-			serveError(w, err, http.StatusBadRequest)
-			return
+		options.CheckLive = make([]uint16, 0)
+		for _, pStr := range strings.Split(portStr, ",") {
+			v, err := strconv.ParseUint(pStr, 10, 16)
+			if err != nil {
+				log15.Error("API: could not parse check-live port", "error", err)
+				serveError(w, err, http.StatusBadRequest)
+				return
+			}
+			options.CheckLive = append(options.CheckLive, uint16(v))
 		}
-		options.CheckLive = uint16(v)
 	}
 
 	// Start it!

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -51,7 +51,7 @@ type ContainerOptions struct {
 	Files map[string]*multipart.FileHeader
 
 	// This requests checking for the given TCP port to be opened by the container.
-	CheckLive uint16
+	CheckLive []uint16
 
 	// Output: if LogFile is set, container stdin and stderr is redirected to the
 	// given log file. If Output is set, stdout is redirected to the writer. These


### PR DESCRIPTION
`HIVE_CHECK_LIVE_PORT` can now be parsed as a comma-separated string of multiple ports to check for liveness of a client.