### PR TITLE
simulators/ethereum/engine: Update Max Drift Seconds to Spec

### DIFF
--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -39,7 +39,7 @@ var (
 
 	// JWT Authentication Related
 	defaultJwtTokenSecretBytes = []byte("secretsecretsecretsecretsecretse") // secretsecretsecretsecretsecretse
-	maxTimeDriftSeconds        = int64(5)
+	maxTimeDriftSeconds        = int64(60)
 )
 
 var clientEnv = hivesim.Params{


### PR DESCRIPTION
Updates the maximum difference of the `issued-at` drift difference to 60 seconds, according to this [spec PR](https://github.com/ethereum/execution-apis/pull/256).