### PR TITLE
simulators/ethereum/engine: Add 1559 Transaction Creation to Tests

### DIFF
--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -183,52 +183,104 @@ var engineTests = []TestSpec{
 		Run:  invalidPayloadTestCaseGen(RemoveTransaction, true, false),
 	},
 	{
-		Name: "Invalid Transaction Signature NewPayload",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionSignature, false, false),
+		Name:                "Invalid Transaction Signature NewPayload",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionSignature, false, false),
+		TestTransactionType: LegacyTxOnly,
 	},
 	{
-		Name: "Invalid Transaction Signature NewPayload (Syncing)",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionSignature, true, false),
+		Name:                "Invalid Transaction Signature NewPayload (EIP-1559)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionSignature, false, false),
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 	{
-		Name: "Invalid Transaction Nonce NewPayload",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionNonce, false, false),
+		Name:                "Invalid Transaction Signature NewPayload (Syncing)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionSignature, true, false),
+		TestTransactionType: LegacyTxOnly,
 	},
 	{
-		Name: "Invalid Transaction Nonce NewPayload (Syncing)",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionNonce, true, false),
+		Name:                "Invalid Transaction Nonce NewPayload",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionNonce, false, false),
+		TestTransactionType: LegacyTxOnly,
 	},
 	{
-		Name: "Invalid Transaction GasPrice NewPayload",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionGasPrice, false, false),
+		Name:                "Invalid Transaction Nonce NewPayload (EIP-1559)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionNonce, false, false),
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 	{
-		Name: "Invalid Transaction GasPrice NewPayload (Syncing)",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionGasPrice, true, false),
+		Name:                "Invalid Transaction Nonce NewPayload (Syncing)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionNonce, true, false),
+		TestTransactionType: LegacyTxOnly,
 	},
 	{
-		Name: "Invalid Transaction Gas NewPayload",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionGas, false, false),
+		Name:                "Invalid Transaction GasPrice NewPayload",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGasPrice, false, false),
+		TestTransactionType: LegacyTxOnly,
 	},
 	{
-		Name: "Invalid Transaction Gas NewPayload (Syncing)",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionGas, true, false),
+		Name:                "Invalid Transaction GasPrice NewPayload (EIP-1559)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGasPrice, false, false),
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 	{
-		Name: "Invalid Transaction Value NewPayload",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionValue, false, false),
+		Name:                "Invalid Transaction GasPrice NewPayload (Syncing)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGasPrice, true, false),
+		TestTransactionType: LegacyTxOnly,
 	},
 	{
-		Name: "Invalid Transaction Value NewPayload (Syncing)",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionValue, true, false),
+		Name:                "Invalid Transaction Gas Tip NewPayload (EIP-1559)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGasTipPrice, false, false),
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 	{
-		Name: "Invalid Transaction ChainID NewPayload",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionChainID, false, false),
+		Name:                "Invalid Transaction Gas Tip NewPayload (EIP-1559, Syncing)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGasTipPrice, true, false),
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 	{
-		Name: "Invalid Transaction ChainID NewPayload (Syncing)",
-		Run:  invalidPayloadTestCaseGen(InvalidTransactionChainID, true, false),
+		Name:                "Invalid Transaction Gas NewPayload",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGas, false, false),
+		TestTransactionType: LegacyTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction Gas NewPayload (EIP-1559)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGas, false, false),
+		TestTransactionType: DynamicFeeTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction Gas NewPayload (Syncing)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionGas, true, false),
+		TestTransactionType: LegacyTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction Value NewPayload",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionValue, false, false),
+		TestTransactionType: LegacyTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction Value NewPayload (EIP-1559)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionValue, false, false),
+		TestTransactionType: DynamicFeeTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction Value NewPayload (Syncing)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionValue, true, false),
+		TestTransactionType: LegacyTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction ChainID NewPayload",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionChainID, false, false),
+		TestTransactionType: LegacyTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction ChainID NewPayload (EIP-1559)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionChainID, false, false),
+		TestTransactionType: DynamicFeeTxOnly,
+	},
+	{
+		Name:                "Invalid Transaction ChainID NewPayload (Syncing)",
+		Run:                 invalidPayloadTestCaseGen(InvalidTransactionChainID, true, false),
+		TestTransactionType: LegacyTxOnly,
 	},
 
 	// Invalid Ancestor Re-Org Tests (Reveal via newPayload)
@@ -440,8 +492,14 @@ var engineTests = []TestSpec{
 
 	// Suggested Fee Recipient in Payload creation
 	{
-		Name: "Suggested Fee Recipient Test",
-		Run:  suggestedFeeRecipient,
+		Name:                "Suggested Fee Recipient Test",
+		Run:                 suggestedFeeRecipient,
+		TestTransactionType: LegacyTxOnly,
+	},
+	{
+		Name:                "Suggested Fee Recipient Test (EIP-1559 Transactions)",
+		Run:                 suggestedFeeRecipient,
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 
 	// PrevRandao opcode tests
@@ -449,6 +507,12 @@ var engineTests = []TestSpec{
 		Name: "PrevRandao Opcode Transactions",
 		Run:  prevRandaoOpcodeTx,
 		TTD:  10,
+	},
+	{
+		Name:                "PrevRandao Opcode Transactions (EIP-1559 Transactions)",
+		Run:                 prevRandaoOpcodeTx,
+		TTD:                 10,
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 
 	// Multi-Client Sync tests

--- a/simulators/ethereum/engine/enginetests.go
+++ b/simulators/ethereum/engine/enginetests.go
@@ -454,8 +454,14 @@ var engineTests = []TestSpec{
 		Run:  payloadBuildAfterNewInvalidPayload,
 	},
 	{
-		Name: "Build Payload with Invalid ChainID Transaction",
-		Run:  buildPayloadWithInvalidChainIDTx,
+		Name:                "Build Payload with Invalid ChainID Transaction (Legacy Tx)",
+		Run:                 buildPayloadWithInvalidChainIDTx,
+		TestTransactionType: LegacyTxOnly,
+	},
+	{
+		Name:                "Build Payload with Invalid ChainID Transaction (EIP-1559)",
+		Run:                 buildPayloadWithInvalidChainIDTx,
+		TestTransactionType: DynamicFeeTxOnly,
 	},
 
 	// Re-org using Engine API
@@ -504,9 +510,10 @@ var engineTests = []TestSpec{
 
 	// PrevRandao opcode tests
 	{
-		Name: "PrevRandao Opcode Transactions",
-		Run:  prevRandaoOpcodeTx,
-		TTD:  10,
+		Name:                "PrevRandao Opcode Transactions",
+		Run:                 prevRandaoOpcodeTx,
+		TTD:                 10,
+		TestTransactionType: LegacyTxOnly,
 	},
 	{
 		Name:                "PrevRandao Opcode Transactions (EIP-1559 Transactions)",

--- a/simulators/ethereum/engine/helper.go
+++ b/simulators/ethereum/engine/helper.go
@@ -91,65 +91,127 @@ func SignatureValuesFromRaw(v *big.Int, r *big.Int, s *big.Int) SignatureValues 
 }
 
 type CustomTransactionData struct {
-	Nonce     *uint64
-	GasPrice  *big.Int
-	Gas       *uint64
-	To        *common.Address
-	Value     *big.Int
-	Data      *[]byte
-	ChainID   *big.Int
-	Signature *SignatureValues
+	Nonce               *uint64
+	GasPriceOrGasFeeCap *big.Int
+	GasTipCap           *big.Int
+	Gas                 *uint64
+	To                  *common.Address
+	Value               *big.Int
+	Data                *[]byte
+	ChainID             *big.Int
+	Signature           *SignatureValues
 }
 
 func customizeTransaction(baseTransaction *types.Transaction, pk *ecdsa.PrivateKey, customData *CustomTransactionData) (*types.Transaction, error) {
 	// Create a modified transaction base, from the base transaction and customData mix
-	modifiedTxBase := &types.LegacyTx{}
+	var (
+		modifiedTxData types.TxData
+	)
 
-	if customData.Nonce != nil {
-		modifiedTxBase.Nonce = *customData.Nonce
-	} else {
-		modifiedTxBase.Nonce = baseTransaction.Nonce()
+	switch baseTransaction.Type() {
+	case types.LegacyTxType:
+		modifiedLegacyTxBase := &types.LegacyTx{}
+
+		if customData.Nonce != nil {
+			modifiedLegacyTxBase.Nonce = *customData.Nonce
+		} else {
+			modifiedLegacyTxBase.Nonce = baseTransaction.Nonce()
+		}
+		if customData.GasPriceOrGasFeeCap != nil {
+			modifiedLegacyTxBase.GasPrice = customData.GasPriceOrGasFeeCap
+		} else {
+			modifiedLegacyTxBase.GasPrice = baseTransaction.GasPrice()
+		}
+		if customData.GasTipCap != nil {
+			return nil, fmt.Errorf("GasTipCap is not supported for LegacyTx type")
+		}
+		if customData.Gas != nil {
+			modifiedLegacyTxBase.Gas = *customData.Gas
+		} else {
+			modifiedLegacyTxBase.Gas = baseTransaction.Gas()
+		}
+		if customData.To != nil {
+			modifiedLegacyTxBase.To = customData.To
+		} else {
+			modifiedLegacyTxBase.To = baseTransaction.To()
+		}
+		if customData.Value != nil {
+			modifiedLegacyTxBase.Value = customData.Value
+		} else {
+			modifiedLegacyTxBase.Value = baseTransaction.Value()
+		}
+		if customData.Data != nil {
+			modifiedLegacyTxBase.Data = *customData.Data
+		} else {
+			modifiedLegacyTxBase.Data = baseTransaction.Data()
+		}
+
+		if customData.Signature != nil {
+			modifiedLegacyTxBase.V = customData.Signature.V
+			modifiedLegacyTxBase.R = customData.Signature.R
+			modifiedLegacyTxBase.S = customData.Signature.S
+		}
+
+		modifiedTxData = modifiedLegacyTxBase
+
+	case types.DynamicFeeTxType:
+		modifiedDynamicFeeTxBase := &types.DynamicFeeTx{}
+
+		if customData.Nonce != nil {
+			modifiedDynamicFeeTxBase.Nonce = *customData.Nonce
+		} else {
+			modifiedDynamicFeeTxBase.Nonce = baseTransaction.Nonce()
+		}
+		if customData.GasPriceOrGasFeeCap != nil {
+			modifiedDynamicFeeTxBase.GasFeeCap = customData.GasPriceOrGasFeeCap
+		} else {
+			modifiedDynamicFeeTxBase.GasFeeCap = baseTransaction.GasFeeCap()
+		}
+		if customData.GasTipCap != nil {
+			modifiedDynamicFeeTxBase.GasTipCap = customData.GasTipCap
+		} else {
+			modifiedDynamicFeeTxBase.GasTipCap = baseTransaction.GasTipCap()
+		}
+		if customData.Gas != nil {
+			modifiedDynamicFeeTxBase.Gas = *customData.Gas
+		} else {
+			modifiedDynamicFeeTxBase.Gas = baseTransaction.Gas()
+		}
+		if customData.To != nil {
+			modifiedDynamicFeeTxBase.To = customData.To
+		} else {
+			modifiedDynamicFeeTxBase.To = baseTransaction.To()
+		}
+		if customData.Value != nil {
+			modifiedDynamicFeeTxBase.Value = customData.Value
+		} else {
+			modifiedDynamicFeeTxBase.Value = baseTransaction.Value()
+		}
+		if customData.Data != nil {
+			modifiedDynamicFeeTxBase.Data = *customData.Data
+		} else {
+			modifiedDynamicFeeTxBase.Data = baseTransaction.Data()
+		}
+		if customData.Signature != nil {
+			modifiedDynamicFeeTxBase.V = customData.Signature.V
+			modifiedDynamicFeeTxBase.R = customData.Signature.R
+			modifiedDynamicFeeTxBase.S = customData.Signature.S
+		}
+
+		modifiedTxData = modifiedDynamicFeeTxBase
+
 	}
-	if customData.GasPrice != nil {
-		modifiedTxBase.GasPrice = customData.GasPrice
-	} else {
-		modifiedTxBase.GasPrice = baseTransaction.GasPrice()
-	}
-	if customData.Gas != nil {
-		modifiedTxBase.Gas = *customData.Gas
-	} else {
-		modifiedTxBase.Gas = baseTransaction.Gas()
-	}
-	if customData.To != nil {
-		modifiedTxBase.To = customData.To
-	} else {
-		modifiedTxBase.To = baseTransaction.To()
-	}
-	if customData.Value != nil {
-		modifiedTxBase.Value = customData.Value
-	} else {
-		modifiedTxBase.Value = baseTransaction.Value()
-	}
-	if customData.Data != nil {
-		modifiedTxBase.Data = *customData.Data
-	} else {
-		modifiedTxBase.Data = baseTransaction.Data()
-	}
-	if customData.ChainID == nil {
-		customData.ChainID = chainID
-	}
-	var modifiedTx *types.Transaction
-	if customData.Signature != nil {
-		modifiedTxBase.V = customData.Signature.V
-		modifiedTxBase.R = customData.Signature.R
-		modifiedTxBase.S = customData.Signature.S
-		modifiedTx = types.NewTx(modifiedTxBase)
-	} else {
-		// If a custom signature was not specified, simply sign the transaction again
-		signer := types.NewEIP155Signer(customData.ChainID)
+
+	modifiedTx := types.NewTx(modifiedTxData)
+	if customData.Signature == nil {
+		// If a custom invalid signature was not specified, simply sign the transaction again
+		if customData.ChainID == nil {
+			// Use the default value if an invaild chain ID was not specified
+			customData.ChainID = chainID
+		}
+		signer := types.NewLondonSigner(customData.ChainID)
 		var err error
-		modifiedTx, err = types.SignTx(types.NewTx(modifiedTxBase), signer, pk)
-		if err != nil {
+		if modifiedTx, err = types.SignTx(modifiedTx, signer, pk); err != nil {
 			return nil, err
 		}
 	}
@@ -322,21 +384,22 @@ func (customData *CustomPayloadData) String() string {
 type InvalidPayloadField string
 
 const (
-	InvalidParentHash           InvalidPayloadField = "ParentHash"
-	InvalidStateRoot                                = "StateRoot"
-	InvalidReceiptsRoot                             = "ReceiptsRoot"
-	InvalidNumber                                   = "Number"
-	InvalidGasLimit                                 = "GasLimit"
-	InvalidGasUsed                                  = "GasUsed"
-	InvalidTimestamp                                = "Timestamp"
-	InvalidPrevRandao                               = "PrevRandao"
-	RemoveTransaction                               = "Incomplete Transactions"
-	InvalidTransactionSignature                     = "Transaction Signature"
-	InvalidTransactionNonce                         = "Transaction Nonce"
-	InvalidTransactionGas                           = "Transaction Gas"
-	InvalidTransactionGasPrice                      = "Transaction GasPrice"
-	InvalidTransactionValue                         = "Transaction Value"
-	InvalidTransactionChainID                       = "Transaction ChainID"
+	InvalidParentHash             InvalidPayloadField = "ParentHash"
+	InvalidStateRoot                                  = "StateRoot"
+	InvalidReceiptsRoot                               = "ReceiptsRoot"
+	InvalidNumber                                     = "Number"
+	InvalidGasLimit                                   = "GasLimit"
+	InvalidGasUsed                                    = "GasUsed"
+	InvalidTimestamp                                  = "Timestamp"
+	InvalidPrevRandao                                 = "PrevRandao"
+	RemoveTransaction                                 = "Incomplete Transactions"
+	InvalidTransactionSignature                       = "Transaction Signature"
+	InvalidTransactionNonce                           = "Transaction Nonce"
+	InvalidTransactionGas                             = "Transaction Gas"
+	InvalidTransactionGasPrice                        = "Transaction GasPrice"
+	InvalidTransactionGasTipPrice                     = "Transaction GasTipCapPrice"
+	InvalidTransactionValue                           = "Transaction Value"
+	InvalidTransactionChainID                         = "Transaction ChainID"
 )
 
 // This function generates an invalid payload by taking a base payload and modifying the specified field such that it ends up being invalid.
@@ -400,6 +463,7 @@ func generateInvalidPayload(basePayload *ExecutableDataV1, payloadField InvalidP
 		InvalidTransactionNonce,
 		InvalidTransactionGas,
 		InvalidTransactionGasPrice,
+		InvalidTransactionGasTipPrice,
 		InvalidTransactionValue,
 		InvalidTransactionChainID:
 
@@ -415,38 +479,26 @@ func generateInvalidPayload(basePayload *ExecutableDataV1, payloadField InvalidP
 		case InvalidTransactionSignature:
 			modifiedSignature := SignatureValuesFromRaw(baseTx.RawSignatureValues())
 			modifiedSignature.R = modifiedSignature.R.Sub(modifiedSignature.R, big1)
-			customTxData = CustomTransactionData{
-				Signature: &modifiedSignature,
-			}
+			customTxData.Signature = &modifiedSignature
 		case InvalidTransactionNonce:
 			customNonce := baseTx.Nonce() - 1
-			customTxData = CustomTransactionData{
-				Nonce: &customNonce,
-			}
+			customTxData.Nonce = &customNonce
 		case InvalidTransactionGas:
 			customGas := uint64(0)
-			customTxData = CustomTransactionData{
-				Gas: &customGas,
-			}
+			customTxData.Gas = &customGas
 		case InvalidTransactionGasPrice:
-			customTxData = CustomTransactionData{
-				GasPrice: big0,
-			}
+			customTxData.GasPriceOrGasFeeCap = big0
+		case InvalidTransactionGasTipPrice:
+			invalidGasTip := new(big.Int).Set(gasTipPrice)
+			invalidGasTip.Mul(invalidGasTip, big.NewInt(2))
+			customTxData.GasTipCap = invalidGasTip
 		case InvalidTransactionValue:
 			// Vault account initially has 0x123450000000000000000, so this value should overflow
-			customValue, err := hexutil.DecodeBig("0x123450000000000000001")
-			if err != nil {
-				return nil, err
-			}
-			customTxData = CustomTransactionData{
-				Value: customValue,
-			}
+			customTxData.Value, _ = hexutil.DecodeBig("0x123450000000000000001")
 		case InvalidTransactionChainID:
 			customChainID := new(big.Int).Set(chainID)
 			customChainID.Add(customChainID, big1)
-			customTxData = CustomTransactionData{
-				ChainID: customChainID,
-			}
+			customTxData.ChainID = customChainID
 		}
 
 		modifiedTx, err := customizeTransaction(&baseTx, vaultKey, &customTxData)

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -12,9 +12,10 @@ import (
 
 var (
 	// Test chain parameters
-	chainID   = big.NewInt(7)
-	gasPrice  = big.NewInt(30 * params.GWei)
-	networkID = big.NewInt(7)
+	chainID     = big.NewInt(7)
+	gasPrice    = big.NewInt(30 * params.GWei)
+	gasTipPrice = big.NewInt(1 * params.GWei)
+	networkID   = big.NewInt(7)
 
 	// Time between checks of a client reaching Terminal Total Difficulty
 	tTDCheckPeriod = time.Second * 1
@@ -94,6 +95,9 @@ type TestSpec struct {
 	// When used, clique consensus mechanism is disabled.
 	// Default: None
 	ChainFile string
+
+	// Transaction type to use throughout the test
+	TestTransactionType TestTransactionType
 }
 
 func main() {
@@ -165,7 +169,7 @@ func addTestsToSuite(suite *hivesim.Suite, tests []TestSpec) {
 					timeout = time.Second * time.Duration(currentTest.TimeoutSeconds)
 				}
 				// Run the test case
-				RunTest(currentTest.Name, big.NewInt(ttd), currentTest.SlotsToSafe, currentTest.SlotsToFinalized, timeout, t, c, currentTest.Run, newParams, testFiles)
+				RunTest(currentTest.Name, big.NewInt(ttd), currentTest.SlotsToSafe, currentTest.SlotsToFinalized, timeout, t, c, currentTest.Run, newParams, testFiles, currentTest.TestTransactionType)
 			},
 		})
 	}

--- a/simulators/ethereum/engine/mergetests.go
+++ b/simulators/ethereum/engine/mergetests.go
@@ -442,7 +442,7 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) TestSpec {
 					return
 				}
 				t.nonce = nonce
-				tx := t.makeNextTransaction(prevRandaoContractAddr, big0, nil)
+				tx := t.makeNextTransaction(&prevRandaoContractAddr, 75000, big0, nil)
 				err = t.CLMock.NextBlockProducer.Eth.SendTransaction(t.CLMock.NextBlockProducer.Ctx(), tx)
 				if err != nil {
 					t.Logf("INFO (%s): Unable to send tx (address=%v): %v", t.TestName, vaultAccountAddr, err)


### PR DESCRIPTION
### Changes Included
- Create different types of transactions every time a new transaction is requested by the test case (Legacy or 1559)
- Add tests for specific types of corruption on a 1559 type transaction
- Add tests to verify that payloads that include transactions with incorrect Chain ID are rejected
- Add test to verify that transactions with incorrect Chain ID are not included in the payload creation process