### PR TITLE
Do not set finalized blockhash on invalid missing ancestor reorg via sync test

### DIFF
--- a/simulators/ethereum/engine/suites/engine/tests.go
+++ b/simulators/ethereum/engine/suites/engine/tests.go
@@ -1479,7 +1479,7 @@ func invalidMissingAncestorReOrgGenSync(invalid_index int, payloadField helper.I
 						status2, err := secondaryClient.ForkchoiceUpdatedV1(ctx, &api.ForkchoiceStateV1{
 							HeadBlockHash:      altChainPayloads[i].BlockHash,
 							SafeBlockHash:      cA.BlockHash,
-							FinalizedBlockHash: cA.BlockHash,
+							FinalizedBlockHash: common.Hash{},
 						}, nil)
 						if err != nil {
 							t.Fatalf("FAIL (%s): TEST ISSUE - Unable to send new payload: %v", t.TestName, err)
@@ -1521,7 +1521,7 @@ func invalidMissingAncestorReOrgGenSync(invalid_index int, payloadField helper.I
 					s := t.TestEngine.TestEngineForkchoiceUpdatedV1(&api.ForkchoiceStateV1{
 						HeadBlockHash:      altChainPayloads[n].BlockHash,
 						SafeBlockHash:      altChainPayloads[n].BlockHash,
-						FinalizedBlockHash: altChainPayloads[n].BlockHash,
+						FinalizedBlockHash: common.Hash{},
 					}, nil)
 					t.Logf("INFO (%s): Response from main client fcu: %v", t.TestName, s.Response.PayloadStatus)
 


### PR DESCRIPTION
- Nethermind removes peers that does not have the finalized blockhash.
- This causes this test to fail because the secondary client does not have the final block which is also set as the finalized blockhash.
- Finalized blockhash are also suppose to be at least 32 block behind head AFAIK.