### PR TITLE
simulators/ethereum/engine: Send `newPayload` again on sync test

### DIFF
--- a/simulators/ethereum/engine/suites/sync/tests.go
+++ b/simulators/ethereum/engine/suites/sync/tests.go
@@ -197,11 +197,11 @@ func incrementalPostMergeSync(t *test.Env) {
 		if !ok {
 			t.Fatalf("FAIL (%s): TEST ISSUE - Payload not found: %d", t.TestName, i)
 		}
-		secondaryEngineTest.TestEngineNewPayloadV1(&payload)
-		secondaryEngineTest.TestEngineForkchoiceUpdatedV1(&api.ForkchoiceStateV1{
-			HeadBlockHash: payload.BlockHash,
-		}, nil)
 		for {
+			secondaryEngineTest.TestEngineNewPayloadV1(&payload)
+			secondaryEngineTest.TestEngineForkchoiceUpdatedV1(&api.ForkchoiceStateV1{
+				HeadBlockHash: payload.BlockHash,
+			}, nil)
 			ctx, cancel := context.WithTimeout(t.TestContext, globals.RPCTimeout)
 			defer cancel()
 			b, err := secondaryEngine.BlockByNumber(ctx, nil)


### PR DESCRIPTION
### Changes Included

- Simple change on sync tests to poll again `newPayload` to the client for some of the clients to properly sync