### PR TITLE
simulators/ethereum/engine: fix running tests with multiple syncmodes

### DIFF
--- a/simulators/ethereum/engine/suites/sync/tests.go
+++ b/simulators/ethereum/engine/suites/sync/tests.go
@@ -63,6 +63,8 @@ func AddSyncTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []
 				// Add the new file to be loaded as chain.rlp
 			}
 			for _, variant := range clientSyncVariantGenerator.Configure(big.NewInt(ttd), genesisPath, currentTest.ChainFile) {
+				variant := variant
+				clientDef := clientDef
 				suite.Add(hivesim.TestSpec{
 					Name:        fmt.Sprintf("%s (%s, sync/%s)", currentTest.Name, clientDef.Name, variant.Name),
 					Description: currentTest.About,


### PR DESCRIPTION
Fix only fast sync config is being run.

Its the closure in a loop thingy. https://stackoverflow.com/questions/26692844/captured-closure-for-loop-variable-in-go

Confirmed archive mode is run when expected.