### PR TITLE
simulators/ethereum/engine: fix wrong TD calculation

### DIFF
--- a/simulators/ethereum/engine/helper/helper.go
+++ b/simulators/ethereum/engine/helper/helper.go
@@ -190,11 +190,10 @@ func LoadGenesisBlock(path string) *types.Block {
 func CalculateTotalDifficulty(genesis core.Genesis, chain types.Blocks, lastBlock uint64) *big.Int {
 	result := new(big.Int).Set(genesis.Difficulty)
 	for _, b := range chain {
+		result.Add(result, b.Difficulty())
 		if lastBlock != 0 && lastBlock == b.NumberU64() {
-			result.Add(result, b.Difficulty())
 			break
 		}
-		result.Add(result, b.Difficulty())
 	}
 	return result
 }

--- a/simulators/ethereum/engine/helper/helper.go
+++ b/simulators/ethereum/engine/helper/helper.go
@@ -191,6 +191,7 @@ func CalculateTotalDifficulty(genesis core.Genesis, chain types.Blocks, lastBloc
 	result := new(big.Int).Set(genesis.Difficulty)
 	for _, b := range chain {
 		if lastBlock != 0 && lastBlock == b.NumberU64() {
+			result.Add(result, b.Difficulty())
 			break
 		}
 		result.Add(result, b.Difficulty())


### PR DESCRIPTION
The last block is not accounted for.

Confirmed test can pass and TTD is set correctly.