### PR TITLE
simulators/ethereum/engine: Randomize Coinbase on Mined Terminal Blocks

### DIFF
--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
@@ -43,8 +44,9 @@ type GethNodeTestConfiguration struct {
 	Name string
 
 	// The node mines proof of work blocks
-	PoWMiner          bool
-	PoWMinerEtherBase common.Address
+	PoWMiner              bool
+	PoWMinerEtherBase     common.Address
+	PoWRandomTransactions bool
 	// Prepare the Ethash instance even if we don't mine (to seal blocks)
 	Ethash           bool
 	DisableGossiping bool
@@ -137,10 +139,6 @@ func (s GethNodeEngineStarter) StartGethNode(T *hivesim.T, testContext context.C
 		if chainFilePath, ok := ClientFiles["/chain.rlp"]; ok {
 			s.Config.ChainFile = chainFilePath
 		}
-	}
-
-	if s.Config.PoWMiner && s.Config.PoWMinerEtherBase == (common.Address{}) {
-		s.Config.PoWMinerEtherBase = common.HexToAddress("0x" + globals.MinerAddrHex)
 	}
 
 	if s.Config.MiningStartDelaySeconds == nil {
@@ -372,6 +370,11 @@ func (n *GethNode) PrepareNextBlock(currentBlock *types.Block) (*state.StateDB, 
 		Coinbase:   n.config.PoWMinerEtherBase,
 	}
 
+	if nextHeader.Coinbase == (common.Address{}) {
+		// Coinbase was not specified, use a random address here to have a different stateRoot each mined block
+		rand.Read(nextHeader.Coinbase[:])
+	}
+
 	// Always randomize extra to try to generate different seal hash
 	rand.Read(nextHeader.Extra)
 
@@ -444,6 +447,9 @@ func (n *GethNode) PoWMiningLoop() {
 			if b == nil {
 				panic(fmt.Errorf("no block got sealed"))
 			}
+			jsH, _ := json.MarshalIndent(b.Header(), "", " ")
+			fmt.Printf("INFO (%s): Mined block:\n%s\n", n.config.Name, jsH)
+
 			// Modify the sealed block if necessary
 			if n.config.BlockModifier != nil {
 				sealVerifier := func(h *types.Header) bool {

--- a/simulators/ethereum/engine/clmock/clmock.go
+++ b/simulators/ethereum/engine/clmock/clmock.go
@@ -510,7 +510,7 @@ func (cl *CLMocker) BroadcastNewPayload(payload *api.ExecutableDataV1) []Execute
 			cl.Errorf("CLMocker: Could not ExecutePayloadV1: %v", err)
 			responses[i].Error = err
 		} else {
-			cl.Logf("CLMocker: Executed payload: %v", execPayloadResp)
+			cl.Logf("CLMocker: Executed payload on %s: %v", ec.ID(), execPayloadResp)
 			responses[i].ExecutePayloadResponse = &execPayloadResp
 		}
 	}


### PR DESCRIPTION
### Changes Included

- Tests that mine PoW blocks during runtime now will get a different coinbase each time to be able to test multiple terminal block with different stateRoots