### PR TITLE
clients/lighthouse-bn,teku-bn,prysm-bn,nimbus-bn: Add Shutdown Scripts

### DIFF
--- a/clients/lighthouse-bn/Dockerfile
+++ b/clients/lighthouse-bn/Dockerfile
@@ -7,6 +7,8 @@ RUN chmod +x /lighthouse_bn.sh
 
 ADD lighthouse_version.sh /lighthouse_version.sh
 RUN chmod +x /lighthouse_version.sh
+ADD lighthouse_shutdown.sh /hive-bin/shutdown.sh
+RUN chmod +x /hive-bin/shutdown.sh
 
 RUN /lighthouse_version.sh > /version.txt
 

--- a/clients/lighthouse-bn/lighthouse_shutdown.sh
+++ b/clients/lighthouse-bn/lighthouse_shutdown.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+# Send CTRL+C to start the shutdown process
+kill -SIGINT $(pgrep lighthouse)
+
+# Wait for graceful shutdown
+TIMEOUT_SECONDS=20
+while pgrep lighthouse; do
+    if (( TIMEOUT_SECONDS == 0 )); then
+        break
+    fi
+    sleep 1
+    (( TIMEOUT_SECONDS-- ))
+done
+
+# Forcefully kill if it did not shutdown
+if pgrep lighthouse; then
+    kill -9 $(pgrep lighthouse)
+fi

--- a/clients/nimbus-bn/Dockerfile
+++ b/clients/nimbus-bn/Dockerfile
@@ -34,6 +34,10 @@ RUN usr/bin/nimbus_beacon_node --version > /version.txt
 
 ADD nimbus_bn.sh /nimbus_bn.sh
 RUN chmod +x /nimbus_bn.sh
+ADD nimbus_shutdown.sh /hive-bin/shutdown.sh
+RUN chmod +x /hive-bin/shutdown.sh
+
+RUN apt-get update -y && apt-get install -y procps
 
 # TODO: output accurate client version
 RUN usr/bin/nimbus_beacon_node --version > /version.txt

--- a/clients/nimbus-bn/nimbus_shutdown.sh
+++ b/clients/nimbus-bn/nimbus_shutdown.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+# Send CTRL+C to start the shutdown process
+kill -SIGINT $(pgrep nimbus_beacon_node)
+
+# Wait for graceful shutdown
+TIMEOUT_SECONDS=20
+while pgrep nimbus_beacon_node; do
+    if (( TIMEOUT_SECONDS == 0 )); then
+        break
+    fi
+    sleep 1
+    (( TIMEOUT_SECONDS-- ))
+done
+
+# Forcefully kill if it did not shutdown
+if pgrep nimbus_beacon_node; then
+    kill -9 $(pgrep nimbus_beacon_node)
+fi

--- a/clients/prysm-bn/Dockerfile
+++ b/clients/prysm-bn/Dockerfile
@@ -6,6 +6,10 @@ COPY --from=upstream /app/cmd/beacon-chain/beacon-chain beacon-chain
 
 ADD prysm_bn.sh /prysm_bn.sh
 RUN chmod +x /prysm_bn.sh
+ADD prysm_shutdown.sh /hive-bin/shutdown.sh
+RUN chmod +x /hive-bin/shutdown.sh
+
+RUN apt-get update -y && apt-get install -y procps
 
 RUN /beacon-chain --version > /version.txt
 

--- a/clients/prysm-bn/prysm_bn.sh
+++ b/clients/prysm-bn/prysm_bn.sh
@@ -69,7 +69,7 @@ echo Starting Prysm Beacon Node
     --p2p-udp-port="${HIVE_ETH2_P2P_UDP_PORT:-9000}" \
     --p2p-host-ip="${CONTAINER_IP}" \
     --p2p-local-ip="${CONTAINER_IP}" \
-    --http-web3provider="$HIVE_ETH2_ETH1_RPC_ADDRS" \
+    --execution-endpoint="$HIVE_ETH2_ETH1_RPC_ADDRS" \
     --jwt-secret=/jwtsecret \
     --min-sync-peers=1 \
     --subscribe-all-subnets=true \

--- a/clients/prysm-bn/prysm_shutdown.sh
+++ b/clients/prysm-bn/prysm_shutdown.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+# Send CTRL+C to start the shutdown process
+kill -SIGINT $(pgrep beacon-chain)
+
+# Wait for graceful shutdown
+TIMEOUT_SECONDS=20
+while pgrep beacon-chain; do
+    if (( TIMEOUT_SECONDS == 0 )); then
+        break
+    fi
+    sleep 1
+    (( TIMEOUT_SECONDS-- ))
+done
+
+# Forcefully kill if it did not shutdown
+if pgrep beacon-chain; then
+    kill -9 $(pgrep beacon-chain)
+fi

--- a/clients/teku-bn/Dockerfile
+++ b/clients/teku-bn/Dockerfile
@@ -5,7 +5,9 @@ FROM consensys/teku:$branch
 USER root
 
 ADD teku_bn.sh /opt/teku/bin/teku_bn.sh
-RUN chmod +x /opt/teku/bin//teku_bn.sh
+RUN chmod +x /opt/teku/bin/teku_bn.sh
+ADD teku_shutdown.sh /hive-bin/shutdown.sh
+RUN chmod +x /hive-bin/shutdown.sh
 
 RUN ./bin/teku --version > /version.txt > /version.txt
 

--- a/clients/teku-bn/teku_shutdown.sh
+++ b/clients/teku-bn/teku_shutdown.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Immediately abort the script on any error encountered
+set -e
+
+# Send CTRL+C to start the shutdown process
+kill -SIGINT $(pgrep teku)
+
+# Wait for graceful shutdown
+TIMEOUT_SECONDS=20
+while pgrep teku; do
+    if (( TIMEOUT_SECONDS == 0 )); then
+        break
+    fi
+    sleep 1
+    (( TIMEOUT_SECONDS-- ))
+done
+
+# Forcefully kill if it did not shutdown
+if pgrep teku; then
+    kill -9 $(pgrep teku)
+fi


### PR DESCRIPTION
### Changes Included
- Adds shutdown scripts for each supported beacon client, which send `SIGINT` to the running client in order to shutdown a node mid-test
- Script `shutdown.sh` can be called using `hivesim.Client.Exec` at any point during the test