### PR TITLE
simulators/eth2/engine: Fix Optimistic Sync Tests + Refactor Allow Client Restarts + No Viable Head Test Case

### DIFF
--- a/simulators/eth2/engine/engineapi.go
+++ b/simulators/eth2/engine/engineapi.go
@@ -50,7 +50,7 @@ type EngineClient struct {
 }
 
 // NewClient creates a engine client that uses the given RPC client.
-func NewEngineClient(t *hivesim.T, n *Eth1Node, ttd *big.Int) *EngineClient {
+func NewEngineClient(t *hivesim.T, n *ExecutionClient, ttd *big.Int) *EngineClient {
 	engineRPCAddress, err := n.EngineRPCAddress()
 	if err != nil {
 		panic(err)

--- a/simulators/eth2/engine/main.go
+++ b/simulators/eth2/engine/main.go
@@ -42,6 +42,7 @@ var transitionTests = []testSpec{
 	{Name: "syncing-with-chain-having-invalid-transition-block", Run: SyncingWithChainHavingInvalidTransitionBlock},
 	{Name: "syncing-with-chain-having-invalid-post-transition-block", Run: SyncingWithChainHavingInvalidPostTransitionBlock},
 	{Name: "re-org-and-sync-with-chain-having-invalid-terminal-block", Run: ReOrgSyncWithChainHavingInvalidTerminalBlock},
+	{Name: "no-viable-head-due-to-optimistic-sync", Run: NoViableHeadDueToOptimisticSync},
 }
 
 func main() {

--- a/simulators/eth2/engine/nodes.go
+++ b/simulators/eth2/engine/nodes.go
@@ -272,6 +272,7 @@ func (b *BeaconClient) PrintAllBeaconBlocks(ctx context.Context) error {
 	} else if !exists {
 		return fmt.Errorf("PrintAllBeaconBlocks: failed to poll head: !exists")
 	}
+	fmt.Printf("PrintAllBeaconBlocks: Printing beacon chain from %s\n", b.HiveClient.Container)
 	fmt.Printf("PrintAllBeaconBlocks: Head, slot %d, root %v\n", headInfo.Header.Message.Slot, headInfo.Root)
 	for i := 1; i <= int(headInfo.Header.Message.Slot); i++ {
 		var bHeader eth2api.BeaconBlockHeaderAndInfo

--- a/simulators/eth2/engine/nodes.go
+++ b/simulators/eth2/engine/nodes.go
@@ -71,7 +71,7 @@ func (en *ExecutionClient) MustGetEnode() string {
 	return addr
 }
 
-func (en *ExecutionClient) Start() error {
+func (en *ExecutionClient) Start(extraOptions ...hivesim.StartOption) error {
 	if en.HiveClient != nil {
 		return fmt.Errorf("Client already started")
 	}
@@ -79,6 +79,9 @@ func (en *ExecutionClient) Start() error {
 	opts, err := en.OptionsGenerator()
 	if err != nil {
 		return fmt.Errorf("Unable to get start options: %v", err)
+	}
+	for _, opt := range extraOptions {
+		opts = append(opts, opt)
 	}
 	en.HiveClient = en.T.StartClient(en.ClientType, opts...)
 
@@ -183,7 +186,7 @@ func NewBeaconClient(t *hivesim.T, beaconDef *hivesim.ClientDefinition, optionsG
 	}
 }
 
-func (bn *BeaconClient) Start() error {
+func (bn *BeaconClient) Start(extraOptions ...hivesim.StartOption) error {
 	if bn.HiveClient != nil {
 		return fmt.Errorf("Client already started")
 	}
@@ -191,6 +194,9 @@ func (bn *BeaconClient) Start() error {
 	opts, err := bn.OptionsGenerator()
 	if err != nil {
 		return fmt.Errorf("Unable to get start options: %v", err)
+	}
+	for _, opt := range extraOptions {
+		opts = append(opts, opt)
 	}
 	bn.HiveClient = bn.T.StartClient(bn.ClientType, opts...)
 	bn.API = &eth2api.Eth2HttpClient{
@@ -489,7 +495,7 @@ func NewValidatorClient(t *hivesim.T, validatorDef *hivesim.ClientDefinition, op
 	}
 }
 
-func (vc *ValidatorClient) Start() error {
+func (vc *ValidatorClient) Start(extraOptions ...hivesim.StartOption) error {
 	if vc.HiveClient != nil {
 		return fmt.Errorf("Client already started")
 	}
@@ -501,6 +507,9 @@ func (vc *ValidatorClient) Start() error {
 	opts, err := vc.OptionsGenerator(vc.Keys)
 	if err != nil {
 		return fmt.Errorf("Unable to get start options: %v", err)
+	}
+	for _, opt := range extraOptions {
+		opts = append(opts, opt)
 	}
 	vc.HiveClient = vc.T.StartClient(vc.ClientType, opts...)
 	return nil
@@ -546,24 +555,24 @@ type NodeClientBundle struct {
 }
 
 // Starts all clients included in the bundle
-func (cb *NodeClientBundle) Start() error {
+func (cb *NodeClientBundle) Start(extraOptions ...hivesim.StartOption) error {
 	cb.T.Logf("Starting validator client bundle %d", cb.Index)
 	if cb.ExecutionClient != nil {
-		if err := cb.ExecutionClient.Start(); err != nil {
+		if err := cb.ExecutionClient.Start(extraOptions...); err != nil {
 			return err
 		}
 	} else {
 		cb.T.Logf("No execution client started")
 	}
 	if cb.BeaconClient != nil {
-		if err := cb.BeaconClient.Start(); err != nil {
+		if err := cb.BeaconClient.Start(extraOptions...); err != nil {
 			return err
 		}
 	} else {
 		cb.T.Logf("No beacon client started")
 	}
 	if cb.ValidatorClient != nil {
-		if err := cb.ValidatorClient.Start(); err != nil {
+		if err := cb.ValidatorClient.Start(extraOptions...); err != nil {
 			return err
 		}
 	} else {

--- a/simulators/eth2/engine/nodes.go
+++ b/simulators/eth2/engine/nodes.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -33,53 +35,188 @@ const (
 // TODO: we assume the clients were configured with default ports.
 // Would be cleaner to run a script in the client to get the address without assumptions
 
-type Eth1Node struct {
-	*hivesim.Client
+type ExecutionClient struct {
+	T                *hivesim.T
+	HiveClient       *hivesim.Client
+	ClientType       string
+	OptionsGenerator func() ([]hivesim.StartOption, error)
+	proxy            **Proxy
+	proxyPort        int
 }
 
-func (en *Eth1Node) UserRPCAddress() (string, error) {
-	return fmt.Sprintf("http://%v:%d", en.IP, PortUserRPC), nil
+func NewExecutionClient(t *hivesim.T, eth1Def *hivesim.ClientDefinition, optionsGenerator func() ([]hivesim.StartOption, error), proxyPort int) *ExecutionClient {
+	return &ExecutionClient{
+		T:                t,
+		ClientType:       eth1Def.Name,
+		OptionsGenerator: optionsGenerator,
+		proxyPort:        proxyPort,
+		proxy:            new(*Proxy),
+	}
 }
 
-func (en *Eth1Node) EngineRPCAddress() (string, error) {
+func (en *ExecutionClient) UserRPCAddress() (string, error) {
+	return fmt.Sprintf("http://%v:%d", en.HiveClient.IP, PortUserRPC), nil
+}
+
+func (en *ExecutionClient) EngineRPCAddress() (string, error) {
 	// TODO what will the default port be?
-	return fmt.Sprintf("http://%v:%d", en.IP, PortEngineRPC), nil
+	return fmt.Sprintf("http://%v:%d", en.HiveClient.IP, PortEngineRPC), nil
 }
 
-func (en *Eth1Node) MustGetEnode() string {
-	addr, err := en.EnodeURL()
+func (en *ExecutionClient) MustGetEnode() string {
+	addr, err := en.HiveClient.EnodeURL()
 	if err != nil {
 		panic(err)
 	}
 	return addr
 }
 
-type BeaconNode struct {
-	*hivesim.Client
-	API         *eth2api.Eth2HttpClient
-	genesisTime common.Timestamp
-	spec        *common.Spec
-	index       int
+func (en *ExecutionClient) Start() error {
+	if en.HiveClient != nil {
+		return fmt.Errorf("Client already started")
+	}
+	en.T.Logf("Starting client %s", en.ClientType)
+	opts, err := en.OptionsGenerator()
+	if err != nil {
+		return fmt.Errorf("Unable to get start options: %v", err)
+	}
+	en.HiveClient = en.T.StartClient(en.ClientType, opts...)
+
+	// Prepare proxy
+	dest, _ := en.EngineRPCAddress()
+
+	secret, err := hex.DecodeString("7365637265747365637265747365637265747365637265747365637265747365")
+	if err != nil {
+		panic(err)
+	}
+	simIP, err := en.T.Sim.ContainerNetworkIP(en.T.SuiteID, "bridge", "simulation")
+	if err != nil {
+		panic(err)
+	}
+
+	*en.proxy = NewProxy(net.ParseIP(simIP), en.proxyPort, dest, secret)
+	return nil
 }
 
-type BeaconNodes []*BeaconNode
+func (en *ExecutionClient) Shutdown() error {
+	_, err := en.HiveClient.Exec("shutdown.sh")
+	if err != nil {
+		return err
+	}
+	en.HiveClient = nil
+	return nil
+}
 
-func NewBeaconNode(cl *hivesim.Client, genesisTime common.Timestamp, spec *common.Spec, index int) *BeaconNode {
-	return &BeaconNode{
-		Client: cl,
-		API: &eth2api.Eth2HttpClient{
-			Addr:  fmt.Sprintf("http://%s:%d", cl.IP, PortBeaconAPI),
-			Cli:   &http.Client{},
-			Codec: eth2api.JSONCodec{},
-		},
-		genesisTime: genesisTime,
-		spec:        spec,
-		index:       index,
+func (en *ExecutionClient) IsRunning() bool {
+	return en.HiveClient != nil
+}
+
+func (en *ExecutionClient) Proxy() *Proxy {
+	if en.proxy != nil && *en.proxy != nil {
+		return *en.proxy
+	}
+	return nil
+}
+
+type ExecutionClients []*ExecutionClient
+
+// Return subset of clients that are currently running
+func (all ExecutionClients) Running() ExecutionClients {
+	res := make(ExecutionClients, 0)
+	for _, ec := range all {
+		if ec.IsRunning() {
+			res = append(res, ec)
+		}
+	}
+	return res
+}
+
+// Returns comma-separated Bootnodes of all running execution nodes
+func (ens ExecutionClients) Enodes() (string, error) {
+	if len(ens) == 0 {
+		return "", nil
+	}
+	enodes := make([]string, 0)
+	for _, en := range ens {
+		if en.IsRunning() {
+			enode, err := en.HiveClient.EnodeURL()
+			if err != nil {
+				return "", err
+			}
+			enodes = append(enodes, enode)
+		}
+	}
+	return strings.Join(enodes, ","), nil
+}
+
+type Proxies []**Proxy
+
+func (all Proxies) Running() []*Proxy {
+	res := make([]*Proxy, 0)
+	for _, p := range all {
+		if p != nil && *p != nil {
+			res = append(res, *p)
+		}
+	}
+	return res
+}
+
+type BeaconClient struct {
+	T                *hivesim.T
+	HiveClient       *hivesim.Client
+	ClientType       string
+	OptionsGenerator func() ([]hivesim.StartOption, error)
+	API              *eth2api.Eth2HttpClient
+	genesisTime      common.Timestamp
+	spec             *common.Spec
+	index            int
+}
+
+func NewBeaconClient(t *hivesim.T, beaconDef *hivesim.ClientDefinition, optionsGenerator func() ([]hivesim.StartOption, error), genesisTime common.Timestamp, spec *common.Spec, index int) *BeaconClient {
+	return &BeaconClient{
+		T:                t,
+		ClientType:       beaconDef.Name,
+		OptionsGenerator: optionsGenerator,
+		genesisTime:      genesisTime,
+		spec:             spec,
+		index:            index,
 	}
 }
 
-func (bn *BeaconNode) ENR() (string, error) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*10)
+func (bn *BeaconClient) Start() error {
+	if bn.HiveClient != nil {
+		return fmt.Errorf("Client already started")
+	}
+	bn.T.Logf("Starting client %s", bn.ClientType)
+	opts, err := bn.OptionsGenerator()
+	if err != nil {
+		return fmt.Errorf("Unable to get start options: %v", err)
+	}
+	bn.HiveClient = bn.T.StartClient(bn.ClientType, opts...)
+	bn.API = &eth2api.Eth2HttpClient{
+		Addr:  fmt.Sprintf("http://%s:%d", bn.HiveClient.IP, PortBeaconAPI),
+		Cli:   &http.Client{},
+		Codec: eth2api.JSONCodec{},
+	}
+	return nil
+}
+
+func (bn *BeaconClient) Shutdown() error {
+	_, err := bn.HiveClient.Exec("shutdown.sh")
+	if err != nil {
+		return err
+	}
+	bn.HiveClient = nil
+	return nil
+}
+
+func (bn *BeaconClient) IsRunning() bool {
+	return bn.HiveClient != nil
+}
+
+func (bn *BeaconClient) ENR() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
 	var out eth2api.NetworkIdentity
 	if err := nodeapi.Identity(ctx, bn.API, &out); err != nil {
 		return "", err
@@ -89,27 +226,64 @@ func (bn *BeaconNode) ENR() (string, error) {
 	return out.ENR, nil
 }
 
-func (bn *BeaconNode) EnodeURL() (string, error) {
+func (bn *BeaconClient) EnodeURL() (string, error) {
 	return "", errors.New("beacon node does not have an discv4 Enode URL, use ENR or multi-address instead")
 }
 
-// Returns comma-separated ENRs of all beacon nodes
-func (beacons BeaconNodes) ENRs() (string, error) {
+type BeaconClients []*BeaconClient
+
+// Return subset of clients that are currently running
+func (all BeaconClients) Running() BeaconClients {
+	res := make(BeaconClients, 0)
+	for _, bc := range all {
+		if bc.IsRunning() {
+			res = append(res, bc)
+		}
+	}
+	return res
+}
+
+// Returns comma-separated ENRs of all running beacon nodes
+func (beacons BeaconClients) ENRs() (string, error) {
 	if len(beacons) == 0 {
 		return "", nil
 	}
 	enrs := make([]string, 0)
 	for _, bn := range beacons {
-		enr, err := bn.ENR()
-		if err != nil {
-			return "", err
+		if bn.IsRunning() {
+			enr, err := bn.ENR()
+			if err != nil {
+				return "", err
+			}
+			enrs = append(enrs, enr)
 		}
-		enrs = append(enrs, enr)
 	}
 	return strings.Join(enrs, ","), nil
 }
 
-func (b *BeaconNode) WaitForExecutionPayload(ctx context.Context, timeoutSlots common.Slot) (ethcommon.Hash, error) {
+func (b *BeaconClient) PrintAllBeaconBlocks(ctx context.Context) error {
+	var headInfo eth2api.BeaconBlockHeaderAndInfo
+	if exists, err := beaconapi.BlockHeader(ctx, b.API, eth2api.BlockHead, &headInfo); err != nil {
+		return fmt.Errorf("PrintAllBeaconBlocks: failed to poll head: %v", err)
+	} else if !exists {
+		return fmt.Errorf("PrintAllBeaconBlocks: failed to poll head: !exists")
+	}
+	fmt.Printf("PrintAllBeaconBlocks: Head, slot %d, root %v\n", headInfo.Header.Message.Slot, headInfo.Root)
+	for i := 1; i <= int(headInfo.Header.Message.Slot); i++ {
+		var bHeader eth2api.BeaconBlockHeaderAndInfo
+		if exists, err := beaconapi.BlockHeader(ctx, b.API, eth2api.BlockIdSlot(i), &bHeader); err != nil {
+			fmt.Printf("PrintAllBeaconBlocks: Slot %d, not found\n", i)
+			continue
+		} else if !exists {
+			fmt.Printf("PrintAllBeaconBlocks: Slot %d, not found\n", i)
+			continue
+		}
+		fmt.Printf("PrintAllBeaconBlocks: Slot %d, root %v\n", i, bHeader.Root)
+	}
+	return nil
+}
+
+func (b *BeaconClient) WaitForExecutionPayload(ctx context.Context, timeoutSlots common.Slot) (ethcommon.Hash, error) {
 	fmt.Printf("Waiting for execution payload on beacon %d\n", b.index)
 	slotDuration := time.Duration(b.spec.SECONDS_PER_SLOT) * time.Second
 	timer := time.NewTicker(slotDuration)
@@ -155,8 +329,65 @@ func (b *BeaconNode) WaitForExecutionPayload(ctx context.Context, timeoutSlots c
 	}
 }
 
+type BlockV2OptimisticResponse struct {
+	Version             string `json:"version"`
+	ExecutionOptimistic bool   `json:"execution_optimistic"`
+}
+
+func (b *BeaconClient) CheckBlockIsOptimistic(ctx context.Context, blockID eth2api.BlockId) (bool, error) {
+	var headOptStatus BlockV2OptimisticResponse
+	if exists, err := eth2api.SimpleRequest(ctx, b.API, eth2api.FmtGET("/eth/v2/beacon/blocks/%s", blockID.BlockId()), &headOptStatus); err != nil {
+		return false, err
+	} else if !exists {
+		// Block still not synced
+		return false, fmt.Errorf("Block not found (!exists)")
+	}
+	return headOptStatus.ExecutionOptimistic, nil
+}
+
+func (b *BeaconClient) WaitForOptimisticState(ctx context.Context, timeoutSlots common.Slot, blockID eth2api.BlockId, optimistic bool) (*eth2api.BeaconBlockHeaderAndInfo, error) {
+	fmt.Printf("Waiting for optimistic sync on beacon %d\n", b.index)
+	slotDuration := time.Duration(b.spec.SECONDS_PER_SLOT) * time.Second
+	timer := time.NewTicker(slotDuration)
+	var timeout <-chan time.Time
+	if timeoutSlots > 0 {
+		timeout = time.After(time.Second * time.Duration(uint64(timeoutSlots)*uint64(b.spec.SECONDS_PER_SLOT)))
+	} else {
+		timeout = make(<-chan time.Time)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context done")
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout")
+		case <-timer.C:
+			var headOptStatus BlockV2OptimisticResponse
+			if exists, err := eth2api.SimpleRequest(ctx, b.API, eth2api.FmtGET("/eth/v2/beacon/blocks/%s", blockID.BlockId()), &headOptStatus); err != nil {
+				// Block still not synced
+				continue
+			} else if !exists {
+				// Block still not synced
+				continue
+			}
+			if headOptStatus.ExecutionOptimistic != optimistic {
+				continue
+			}
+			// Return the block
+			var blockInfo eth2api.BeaconBlockHeaderAndInfo
+			if exists, err := beaconapi.BlockHeader(ctx, b.API, blockID, &blockInfo); err != nil {
+				return nil, fmt.Errorf("WaitForExecutionPayload: failed to poll block: %v", err)
+			} else if !exists {
+				return nil, fmt.Errorf("WaitForExecutionPayload: failed to poll block: !exists")
+			}
+			return &blockInfo, nil
+		}
+	}
+}
+
 //
-func (bn *BeaconNode) GetLatestExecutionBeaconBlock(ctx context.Context) (*bellatrix.SignedBeaconBlock, error) {
+func (bn *BeaconClient) GetLatestExecutionBeaconBlock(ctx context.Context) (*bellatrix.SignedBeaconBlock, error) {
 	var headInfo eth2api.BeaconBlockHeaderAndInfo
 	if exists, err := beaconapi.BlockHeader(ctx, bn.API, eth2api.BlockHead, &headInfo); err != nil {
 		return nil, fmt.Errorf("failed to poll head: %v", err)
@@ -182,7 +413,7 @@ func (bn *BeaconNode) GetLatestExecutionBeaconBlock(ctx context.Context) (*bella
 	return nil, nil
 }
 
-func (bn *BeaconNode) GetFirstExecutionBeaconBlock(ctx context.Context) (*bellatrix.SignedBeaconBlock, error) {
+func (bn *BeaconClient) GetFirstExecutionBeaconBlock(ctx context.Context) (*bellatrix.SignedBeaconBlock, error) {
 	lastSlot := bn.spec.TimeToSlot(common.Timestamp(time.Now().Unix()), bn.genesisTime)
 	for slot := common.Slot(0); slot <= lastSlot; slot++ {
 		var versionedBlock eth2api.VersionedSignedBeaconBlock
@@ -203,7 +434,7 @@ func (bn *BeaconNode) GetFirstExecutionBeaconBlock(ctx context.Context) (*bellat
 	return nil, nil
 }
 
-func (bn *BeaconNode) GetBeaconBlockByExecutionHash(ctx context.Context, hash ethcommon.Hash) (*bellatrix.SignedBeaconBlock, error) {
+func (bn *BeaconClient) GetBeaconBlockByExecutionHash(ctx context.Context, hash ethcommon.Hash) (*bellatrix.SignedBeaconBlock, error) {
 	var headInfo eth2api.BeaconBlockHeaderAndInfo
 	if exists, err := beaconapi.BlockHeader(ctx, bn.API, eth2api.BlockHead, &headInfo); err != nil {
 		return nil, fmt.Errorf("failed to poll head: %v", err)
@@ -231,7 +462,7 @@ func (bn *BeaconNode) GetBeaconBlockByExecutionHash(ctx context.Context, hash et
 	return nil, nil
 }
 
-func (b BeaconNodes) GetBeaconBlockByExecutionHash(ctx context.Context, hash ethcommon.Hash) (*bellatrix.SignedBeaconBlock, error) {
+func (b BeaconClients) GetBeaconBlockByExecutionHash(ctx context.Context, hash ethcommon.Hash) (*bellatrix.SignedBeaconBlock, error) {
 	for _, bn := range b {
 		block, err := bn.GetBeaconBlockByExecutionHash(ctx, hash)
 		if err != nil || block != nil {
@@ -242,15 +473,192 @@ func (b BeaconNodes) GetBeaconBlockByExecutionHash(ctx context.Context, hash eth
 }
 
 type ValidatorClient struct {
-	*hivesim.Client
-	keys []*setup.KeyDetails
+	T                *hivesim.T
+	HiveClient       *hivesim.Client
+	ClientType       string
+	OptionsGenerator func([]*setup.KeyDetails) ([]hivesim.StartOption, error)
+	Keys             []*setup.KeyDetails
+}
+
+func NewValidatorClient(t *hivesim.T, validatorDef *hivesim.ClientDefinition, optionsGenerator func([]*setup.KeyDetails) ([]hivesim.StartOption, error), keys []*setup.KeyDetails) *ValidatorClient {
+	return &ValidatorClient{
+		T:                t,
+		ClientType:       validatorDef.Name,
+		OptionsGenerator: optionsGenerator,
+		Keys:             keys,
+	}
+}
+
+func (vc *ValidatorClient) Start() error {
+	if vc.HiveClient != nil {
+		return fmt.Errorf("Client already started")
+	}
+	if len(vc.Keys) == 0 {
+		vc.T.Logf("Skipping validator because it has 0 validator keys")
+		return nil
+	}
+	vc.T.Logf("Starting client %s", vc.ClientType)
+	opts, err := vc.OptionsGenerator(vc.Keys)
+	if err != nil {
+		return fmt.Errorf("Unable to get start options: %v", err)
+	}
+	vc.HiveClient = vc.T.StartClient(vc.ClientType, opts...)
+	return nil
+}
+
+func (vc *ValidatorClient) IsRunning() bool {
+	return vc.HiveClient != nil
 }
 
 func (v *ValidatorClient) ContainsKey(pk [48]byte) bool {
-	for _, k := range v.keys {
+	for _, k := range v.Keys {
 		if k.ValidatorPubkey == pk {
 			return true
 		}
 	}
 	return false
+}
+
+type ValidatorClients []*ValidatorClient
+
+// Return subset of clients that are currently running
+func (all ValidatorClients) Running() ValidatorClients {
+	res := make(ValidatorClients, 0)
+	for _, vc := range all {
+		if vc.IsRunning() {
+			res = append(res, vc)
+		}
+	}
+	return res
+}
+
+// A validator client bundle consists of:
+// - Execution client
+// - Beacon client
+// - Validator client
+type NodeClientBundle struct {
+	T               *hivesim.T
+	Index           int
+	ExecutionClient *ExecutionClient
+	BeaconClient    *BeaconClient
+	ValidatorClient *ValidatorClient
+	Verification    bool
+}
+
+// Starts all clients included in the bundle
+func (cb *NodeClientBundle) Start() error {
+	cb.T.Logf("Starting validator client bundle %d", cb.Index)
+	if cb.ExecutionClient != nil {
+		if err := cb.ExecutionClient.Start(); err != nil {
+			return err
+		}
+	} else {
+		cb.T.Logf("No execution client started")
+	}
+	if cb.BeaconClient != nil {
+		if err := cb.BeaconClient.Start(); err != nil {
+			return err
+		}
+	} else {
+		cb.T.Logf("No beacon client started")
+	}
+	if cb.ValidatorClient != nil {
+		if err := cb.ValidatorClient.Start(); err != nil {
+			return err
+		}
+	} else {
+		cb.T.Logf("No validator client started")
+	}
+	return nil
+}
+
+type NodeClientBundles []NodeClientBundle
+
+// Return all execution clients, even the ones not currently running
+func (cbs NodeClientBundles) ExecutionClients() ExecutionClients {
+	en := make(ExecutionClients, 0)
+	for _, cb := range cbs {
+		if cb.ExecutionClient != nil {
+			en = append(en, cb.ExecutionClient)
+		}
+	}
+	return en
+}
+
+// Return all proxy pointers, even the ones not currently running
+func (cbs NodeClientBundles) Proxies() Proxies {
+	ps := make(Proxies, 0)
+	for _, cb := range cbs {
+		if cb.ExecutionClient != nil {
+			ps = append(ps, cb.ExecutionClient.proxy)
+		}
+	}
+	return ps
+}
+
+// Return all beacon clients, even the ones not currently running
+func (cbs NodeClientBundles) BeaconClients() BeaconClients {
+	bn := make(BeaconClients, 0)
+	for _, cb := range cbs {
+		if cb.BeaconClient != nil {
+			bn = append(bn, cb.BeaconClient)
+		}
+	}
+	return bn
+}
+
+// Return all validator clients, even the ones not currently running
+func (cbs NodeClientBundles) ValidatorClients() ValidatorClients {
+	vc := make(ValidatorClients, 0)
+	for _, cb := range cbs {
+		if cb.ValidatorClient != nil {
+			vc = append(vc, cb.ValidatorClient)
+		}
+	}
+	return vc
+}
+
+// Return subset of nodes which are marked as verification nodes
+func (all NodeClientBundles) VerificationNodes() NodeClientBundles {
+	// If none is set as verification, then all are verification nodes
+	var any bool
+	for _, cb := range all {
+		if cb.Verification {
+			any = true
+			break
+		}
+	}
+	if !any {
+		return all
+	}
+
+	res := make(NodeClientBundles, 0)
+	for _, cb := range all {
+		if cb.Verification {
+			res = append(res, cb)
+		}
+	}
+	return res
+}
+
+func (cbs NodeClientBundles) RemoveNodeAsVerifier(id int) error {
+	if id >= len(cbs) {
+		return fmt.Errorf("Node %d does not exist", id)
+	}
+	var any bool
+	for _, cb := range cbs {
+		if cb.Verification {
+			any = true
+			break
+		}
+	}
+	if any {
+		cbs[id].Verification = false
+	} else {
+		// If no node is set as verifier, we will set all other nodes as verifiers then
+		for i := range cbs {
+			cbs[i].Verification = (i != id)
+		}
+	}
+	return nil
 }

--- a/simulators/eth2/engine/nodes.go
+++ b/simulators/eth2/engine/nodes.go
@@ -102,8 +102,7 @@ func (en *ExecutionClient) Start(extraOptions ...hivesim.StartOption) error {
 }
 
 func (en *ExecutionClient) Shutdown() error {
-	_, err := en.HiveClient.Exec("shutdown.sh")
-	if err != nil {
+	if err := en.T.Sim.StopClient(en.T.SuiteID, en.T.TestID, en.HiveClient.Container); err != nil {
 		return err
 	}
 	en.HiveClient = nil
@@ -208,8 +207,7 @@ func (bn *BeaconClient) Start(extraOptions ...hivesim.StartOption) error {
 }
 
 func (bn *BeaconClient) Shutdown() error {
-	_, err := bn.HiveClient.Exec("shutdown.sh")
-	if err != nil {
+	if err := bn.T.Sim.StopClient(bn.T.SuiteID, bn.T.TestID, bn.HiveClient.Container); err != nil {
 		return err
 	}
 	bn.HiveClient = nil
@@ -515,6 +513,14 @@ func (vc *ValidatorClient) Start(extraOptions ...hivesim.StartOption) error {
 	return nil
 }
 
+func (vc *ValidatorClient) Shutdown() error {
+	if err := vc.T.Sim.StopClient(vc.T.SuiteID, vc.T.TestID, vc.HiveClient.Container); err != nil {
+		return err
+	}
+	vc.HiveClient = nil
+	return nil
+}
+
 func (vc *ValidatorClient) IsRunning() bool {
 	return vc.HiveClient != nil
 }
@@ -577,6 +583,19 @@ func (cb *NodeClientBundle) Start(extraOptions ...hivesim.StartOption) error {
 		}
 	} else {
 		cb.T.Logf("No validator client started")
+	}
+	return nil
+}
+
+func (cb *NodeClientBundle) Shutdown() error {
+	if err := cb.ExecutionClient.Shutdown(); err != nil {
+		return err
+	}
+	if err := cb.BeaconClient.Shutdown(); err != nil {
+		return err
+	}
+	if err := cb.ValidatorClient.Shutdown(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/simulators/eth2/engine/running_testnet.go
+++ b/simulators/eth2/engine/running_testnet.go
@@ -26,7 +26,8 @@ import (
 var MAX_PARTICIPATION_SCORE = 7
 
 type Testnet struct {
-	t *hivesim.T
+	*hivesim.T
+	NodeClientBundles
 
 	genesisTime           common.Timestamp
 	genesisValidatorsRoot common.Root
@@ -35,98 +36,65 @@ type Testnet struct {
 	spec *common.Spec
 	// Execution chain configuration and genesis info
 	eth1Genesis *setup.Eth1Genesis
-
-	beacons      BeaconNodes
-	validators   []*ValidatorClient
-	eth1         []*Eth1Node
-	proxies      []*Proxy
-	verification []bool
-}
-
-func (t *Testnet) verificationExecution() []*Eth1Node {
-	verificationExecution := make([]*Eth1Node, 0)
-	for i, v := range t.verification {
-		if v {
-			verificationExecution = append(verificationExecution, t.eth1[i])
-		}
-	}
-	if len(verificationExecution) == 0 {
-		return t.eth1
-	}
-	return verificationExecution
-}
-
-func (t *Testnet) verificationBeacons() []*BeaconNode {
-	verificationBeacons := make([]*BeaconNode, 0)
-	for i, v := range t.verification {
-		if v {
-			verificationBeacons = append(verificationBeacons, t.beacons[i])
-		}
-	}
-	if len(verificationBeacons) == 0 {
-		return t.beacons
-	}
-	return verificationBeacons
-}
-
-func (t *Testnet) verificationProxies() []*Proxy {
-	verificationProxies := make([]*Proxy, 0)
-	for i, v := range t.verification {
-		if v {
-			verificationProxies = append(verificationProxies, t.proxies[i])
-		}
-	}
-	if len(verificationProxies) == 0 {
-		return t.proxies
-	}
-	return verificationProxies
-}
-
-func (t *Testnet) removeNodeAsVerifier(id int) error {
-	if id >= len(t.verification) {
-		return fmt.Errorf("Node %d does not exist", id)
-	}
-	var any bool
-	for _, v := range t.verification {
-		if v {
-			any = true
-			break
-		}
-	}
-	if any {
-		t.verification[id] = false
-	} else {
-		// If no node is set as verifier, we will set all other nodes as verifiers then
-		for i := range t.verification {
-			t.verification[i] = (i != id)
-		}
-	}
-	return nil
 }
 
 func startTestnet(t *hivesim.T, env *testEnv, config *Config) *Testnet {
 	prep := prepareTestnet(t, env, config)
 	testnet := prep.createTestnet(t)
-
 	genesisTime := testnet.GenesisTime()
 	countdown := genesisTime.Sub(time.Now())
 	t.Logf("Created new testnet, genesis at %s (%s from now)", genesisTime, countdown)
 
-	// for each key partition, we start a validator client with its own beacon node and eth1 node
-	for i, node := range config.Nodes {
-		prep.startEth1Node(testnet, env.Clients.ClientByNameAndRole(node.ExecutionClient, "eth1"), config.Eth1Consensus, node.ExecutionClientTTD, node.Chain)
-		if node.ConsensusClient != "" {
-			prep.startBeaconNode(testnet, env.Clients.ClientByNameAndRole(fmt.Sprintf("%s-bn", node.ConsensusClient), "beacon"), node.BeaconNodeTTD, []int{i})
-			prep.startValidatorClient(testnet, env.Clients.ClientByNameAndRole(fmt.Sprintf("%s-vc", node.ConsensusClient), "validator"), i, i)
+	testnet.NodeClientBundles = make(NodeClientBundles, len(config.Nodes))
+
+	// For each key partition, we start a client bundle that consists of:
+	// - 1 execution client
+	// - 1 beacon client
+	// - 1 validator client,
+	for nodeIndex, node := range config.Nodes {
+		// Prepare clients for this node
+		var (
+			ec *ExecutionClient
+			bc *BeaconClient
+			vc *ValidatorClient
+
+			executionDef = env.Clients.ClientByNameAndRole(node.ExecutionClient, "eth1")
+			beaconDef    = env.Clients.ClientByNameAndRole(fmt.Sprintf("%s-bn", node.ConsensusClient), "beacon")
+			validatorDef = env.Clients.ClientByNameAndRole(fmt.Sprintf("%s-vc", node.ConsensusClient), "validator")
+		)
+
+		if executionDef == nil || beaconDef == nil || validatorDef == nil {
+			t.Fatalf("FAIL: Unable to get client")
 		}
-		testnet.verification = append(testnet.verification, node.TestVerificationNode)
+
+		// Prepare the client objects with all the information necessary to eventually start
+		ec = prep.prepareExecutionNode(testnet, executionDef, config.Eth1Consensus, node.ExecutionClientTTD, nodeIndex, node.Chain)
+		if node.ConsensusClient != "" {
+			bc = prep.prepareBeaconNode(testnet, beaconDef, node.BeaconNodeTTD, nodeIndex, ec)
+			vc = prep.prepareValidatorClient(testnet, validatorDef, bc, nodeIndex)
+		}
+
+		// Bundle all the clients together
+		testnet.NodeClientBundles[nodeIndex] = NodeClientBundle{
+			T:               t,
+			Index:           nodeIndex,
+			Verification:    node.TestVerificationNode,
+			ExecutionClient: ec,
+			BeaconClient:    bc,
+			ValidatorClient: vc,
+		}
+
+		// Start the node clients if specified so
+		if !node.DisableStartup {
+			testnet.NodeClientBundles[nodeIndex].Start()
+		}
 	}
 
 	return testnet
 }
 
 func (t *Testnet) stopTestnet() {
-	for _, p := range t.proxies {
+	for _, p := range t.Proxies().Running() {
 		p.cancel()
 	}
 }
@@ -140,7 +108,7 @@ func (t *Testnet) SlotsTimeout(slots common.Slot) <-chan time.Time {
 }
 
 func (t *Testnet) ValidatorClientIndex(pk [48]byte) (int, error) {
-	for i, v := range t.validators {
+	for i, v := range t.ValidatorClients() {
 		if v.ContainsKey(pk) {
 			return i, nil
 		}
@@ -154,7 +122,8 @@ func (t *Testnet) WaitForFinality(ctx context.Context, timeoutSlots common.Slot)
 	genesis := t.GenesisTime()
 	slotDuration := time.Duration(t.spec.SECONDS_PER_SLOT) * time.Second
 	timer := time.NewTicker(slotDuration)
-	done := make(chan common.Checkpoint, len(t.verificationBeacons()))
+	runningBeacons := t.VerificationNodes().BeaconClients().Running()
+	done := make(chan common.Checkpoint, len(runningBeacons))
 	var timeout <-chan time.Time
 	if timeoutSlots > 0 {
 		timeout = t.SlotsTimeout(timeoutSlots)
@@ -172,7 +141,7 @@ func (t *Testnet) WaitForFinality(ctx context.Context, timeoutSlots common.Slot)
 		case tim := <-timer.C:
 			// start polling after first slot of genesis
 			if tim.Before(genesis.Add(slotDuration)) {
-				t.t.Logf("Time till genesis: %s", genesis.Sub(tim))
+				t.Logf("Time till genesis: %s", genesis.Sub(tim))
 				continue
 			}
 
@@ -184,11 +153,11 @@ func (t *Testnet) WaitForFinality(ctx context.Context, timeoutSlots common.Slot)
 			}
 			var (
 				wg sync.WaitGroup
-				ch = make(chan res, len(t.verificationBeacons()))
+				ch = make(chan res, len(runningBeacons))
 			)
-			for i, b := range t.verificationBeacons() {
+			for i, b := range runningBeacons {
 				wg.Add(1)
-				go func(ctx context.Context, i int, b *BeaconNode, ch chan res) {
+				go func(ctx context.Context, i int, b *BeaconClient, ch chan res) {
 					defer wg.Done()
 					ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 					defer cancel()
@@ -267,7 +236,7 @@ func (t *Testnet) WaitForFinality(ctx context.Context, timeoutSlots common.Slot)
 			close(ch)
 
 			// print out logs in ascending idx order
-			sorted := make([]string, len(t.verificationBeacons()))
+			sorted := make([]string, len(runningBeacons))
 			for out := range ch {
 				if out.err != nil {
 					return common.Checkpoint{}, out.err
@@ -275,7 +244,148 @@ func (t *Testnet) WaitForFinality(ctx context.Context, timeoutSlots common.Slot)
 				sorted[out.idx] = out.msg
 			}
 			for _, msg := range sorted {
-				t.t.Logf(msg)
+				t.Logf(msg)
+			}
+		}
+	}
+}
+
+// Waits for the current epoch to be finalized, or timeoutSlots have passed, whichever happens first.
+func (t *Testnet) WaitForCurrentEpochFinalization(ctx context.Context, timeoutSlots common.Slot) (common.Checkpoint, error) {
+	genesis := t.GenesisTime()
+	slotDuration := time.Duration(t.spec.SECONDS_PER_SLOT) * time.Second
+	timer := time.NewTicker(slotDuration)
+	runningBeacons := t.VerificationNodes().BeaconClients().Running()
+	done := make(chan common.Checkpoint, len(runningBeacons))
+	var timeout <-chan time.Time
+	if timeoutSlots > 0 {
+		timeout = t.SlotsTimeout(timeoutSlots)
+	} else {
+		timeout = make(<-chan time.Time)
+	}
+
+	// Get the current head root which must be finalized
+	var (
+		epochToBeFinalized common.Epoch
+		headInfo           eth2api.BeaconBlockHeaderAndInfo
+	)
+	if exists, err := beaconapi.BlockHeader(ctx, runningBeacons[0].API, eth2api.BlockHead, &headInfo); err != nil {
+		return common.Checkpoint{}, fmt.Errorf("failed to poll head: %v", err)
+	} else if !exists {
+		return common.Checkpoint{}, fmt.Errorf("no head block")
+	}
+	epochToBeFinalized = t.spec.SlotToEpoch(headInfo.Header.Message.Slot)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return common.Checkpoint{}, fmt.Errorf("context called")
+		case <-timeout:
+			return common.Checkpoint{}, fmt.Errorf("Timeout")
+		case finalized := <-done:
+			return finalized, nil
+		case tim := <-timer.C:
+			// start polling after first slot of genesis
+			if tim.Before(genesis.Add(slotDuration)) {
+				t.Logf("Time till genesis: %s", genesis.Sub(tim))
+				continue
+			}
+
+			// new slot, log and check status of all beacon nodes
+			type res struct {
+				idx int
+				msg string
+				err error
+			}
+			var (
+				wg sync.WaitGroup
+				ch = make(chan res, len(runningBeacons))
+			)
+			for i, b := range runningBeacons {
+				wg.Add(1)
+				go func(ctx context.Context, i int, b *BeaconClient, ch chan res) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+					defer cancel()
+
+					var (
+						slot      common.Slot
+						head      string
+						justified string
+						finalized string
+						execution string
+						health    float64
+					)
+
+					var headInfo eth2api.BeaconBlockHeaderAndInfo
+					if exists, err := beaconapi.BlockHeader(ctx, b.API, eth2api.BlockHead, &headInfo); err != nil {
+						ch <- res{err: fmt.Errorf("beacon %d: failed to poll head: %v", i, err)}
+						return
+					} else if !exists {
+						ch <- res{err: fmt.Errorf("beacon %d: no head block", i)}
+						return
+					}
+
+					var checkpoints eth2api.FinalityCheckpoints
+					if exists, err := beaconapi.FinalityCheckpoints(ctx, b.API, eth2api.StateIdRoot(headInfo.Header.Message.StateRoot), &checkpoints); err != nil || !exists {
+						if exists, err = beaconapi.FinalityCheckpoints(ctx, b.API, eth2api.StateIdSlot(headInfo.Header.Message.Slot), &checkpoints); err != nil {
+							ch <- res{err: fmt.Errorf("beacon %d: failed to poll finality checkpoint: %v", i, err)}
+							return
+						} else if !exists {
+							ch <- res{err: fmt.Errorf("beacon %d: Expected state for head block", i)}
+							return
+						}
+					}
+
+					var versionedBlock eth2api.VersionedSignedBeaconBlock
+					if exists, err := beaconapi.BlockV2(ctx, b.API, eth2api.BlockIdRoot(headInfo.Root), &versionedBlock); err != nil {
+						ch <- res{err: fmt.Errorf("beacon %d: failed to retrieve block: %v", i, err)}
+						return
+					} else if !exists {
+						ch <- res{err: fmt.Errorf("beacon %d: block not found", i)}
+						return
+					}
+					switch versionedBlock.Version {
+					case "phase0":
+						execution = "0x0000..0000"
+					case "altair":
+						execution = "0x0000..0000"
+					case "bellatrix":
+						block := versionedBlock.Data.(*bellatrix.SignedBeaconBlock)
+						execution = shorten(block.Message.Body.ExecutionPayload.BlockHash.String())
+					}
+
+					slot = headInfo.Header.Message.Slot
+					head = shorten(headInfo.Root.String())
+					justified = shorten(checkpoints.CurrentJustified.String())
+					finalized = shorten(checkpoints.Finalized.String())
+					health, err := getHealth(ctx, b.API, t.spec, slot)
+					if err != nil {
+						// warning is printed here instead because some clients
+						// don't support the required REST endpoint.
+						fmt.Printf("WARN: beacon %d: %s\n", i, err)
+					}
+
+					ch <- res{i, fmt.Sprintf("beacon %d: slot=%d, head=%s, health=%.2f, exec_payload=%s, justified=%s, finalized=%s", i, slot, head, health, execution, justified, finalized), nil}
+
+					if checkpoints.Finalized != (common.Checkpoint{}) && checkpoints.Finalized.Epoch >= epochToBeFinalized {
+						done <- checkpoints.Finalized
+					}
+				}(ctx, i, b, ch)
+			}
+			wg.Wait()
+			close(ch)
+
+			// print out logs in ascending idx order
+			sorted := make([]string, len(runningBeacons))
+			for out := range ch {
+				if out.err != nil {
+					return common.Checkpoint{}, out.err
+				}
+				sorted[out.idx] = out.msg
+			}
+			for _, msg := range sorted {
+				t.Logf(msg)
 			}
 		}
 	}
@@ -287,8 +397,9 @@ func (t *Testnet) WaitForExecutionPayload(ctx context.Context, timeoutSlots comm
 	genesis := t.GenesisTime()
 	slotDuration := time.Duration(t.spec.SECONDS_PER_SLOT) * time.Second
 	timer := time.NewTicker(slotDuration)
-	done := make(chan ethcommon.Hash, len(t.verificationBeacons()))
-	userRPCAddress, err := t.eth1[0].UserRPCAddress()
+	runningBeacons := t.VerificationNodes().BeaconClients().Running()
+	done := make(chan ethcommon.Hash, len(runningBeacons))
+	userRPCAddress, err := t.ExecutionClients().Running()[0].UserRPCAddress()
 	if err != nil {
 		panic(err)
 	}
@@ -312,7 +423,7 @@ func (t *Testnet) WaitForExecutionPayload(ctx context.Context, timeoutSlots comm
 		case tim := <-timer.C:
 			// start polling after first slot of genesis
 			if tim.Before(genesis.Add(slotDuration)) {
-				t.t.Logf("Time till genesis: %s", genesis.Sub(tim))
+				t.Logf("Time till genesis: %s", genesis.Sub(tim))
 				continue
 			}
 
@@ -321,11 +432,11 @@ func (t *Testnet) WaitForExecutionPayload(ctx context.Context, timeoutSlots comm
 				var td *TotalDifficultyHeader
 				if err := rpcClient.CallContext(ctx, &td, "eth_getBlockByNumber", "latest", false); err == nil {
 					if td.TotalDifficulty.ToInt().Cmp(t.eth1Genesis.Genesis.Config.TerminalTotalDifficulty) >= 0 {
-						t.t.Logf("ttd (%d) reached at execution block %d", t.eth1Genesis.Genesis.Config.TerminalTotalDifficulty, td.Number)
+						t.Logf("ttd (%d) reached at execution block %d", t.eth1Genesis.Genesis.Config.TerminalTotalDifficulty, td.Number)
 						ttdReached = true
 					}
 				} else {
-					t.t.Logf("Error querying eth1 for TTD: %v", err)
+					t.Logf("Error querying eth1 for TTD: %v", err)
 				}
 			}
 
@@ -338,11 +449,11 @@ func (t *Testnet) WaitForExecutionPayload(ctx context.Context, timeoutSlots comm
 
 			var (
 				wg sync.WaitGroup
-				ch = make(chan res, len(t.verificationBeacons()))
+				ch = make(chan res, len(runningBeacons))
 			)
-			for i, b := range t.verificationBeacons() {
+			for i, b := range runningBeacons {
 				wg.Add(1)
-				go func(ctx context.Context, i int, b *BeaconNode, ch chan res) {
+				go func(ctx context.Context, i int, b *BeaconClient, ch chan res) {
 					defer wg.Done()
 					ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 					defer cancel()
@@ -404,7 +515,7 @@ func (t *Testnet) WaitForExecutionPayload(ctx context.Context, timeoutSlots comm
 			close(ch)
 
 			// print out logs in ascending idx order
-			sorted := make([]string, len(t.verificationBeacons()))
+			sorted := make([]string, len(runningBeacons))
 			for out := range ch {
 				if out.err != nil {
 					return ethcommon.Hash{}, out.err
@@ -412,7 +523,7 @@ func (t *Testnet) WaitForExecutionPayload(ctx context.Context, timeoutSlots comm
 				sorted[out.idx] = out.msg
 			}
 			for _, msg := range sorted {
-				t.t.Logf(msg)
+				t.Logf(msg)
 			}
 
 		}

--- a/simulators/eth2/engine/running_testnet.go
+++ b/simulators/eth2/engine/running_testnet.go
@@ -366,7 +366,7 @@ func (t *Testnet) WaitForCurrentEpochFinalization(ctx context.Context, timeoutSl
 						fmt.Printf("WARN: beacon %d: %s\n", i, err)
 					}
 
-					ch <- res{i, fmt.Sprintf("beacon %d: slot=%d, head=%s, health=%.2f, exec_payload=%s, justified=%s, finalized=%s", i, slot, head, health, execution, justified, finalized), nil}
+					ch <- res{i, fmt.Sprintf("beacon %d: slot=%d, head=%s, health=%.2f, exec_payload=%s, justified=%s, finalized=%s, epoch_to_finalize=%d", i, slot, head, health, execution, justified, finalized, epochToBeFinalized), nil}
 
 					if checkpoints.Finalized != (common.Checkpoint{}) && checkpoints.Finalized.Epoch >= epochToBeFinalized {
 						done <- checkpoints.Finalized

--- a/simulators/eth2/engine/scenarios.go
+++ b/simulators/eth2/engine/scenarios.go
@@ -1766,7 +1766,9 @@ func NoViableHeadDueToOptimisticSync(t *hivesim.T, env *testEnv, n node) {
 		importer      = testnet.BeaconClients()[1]
 		builder1Proxy = testnet.Proxies().Running()[0]
 		importerProxy = testnet.Proxies().Running()[1]
-		builder2Proxy *Proxy // Not yet started
+		// Not yet started
+		builder2      = testnet.BeaconClients()[2]
+		builder2Proxy *Proxy
 	)
 
 	importerNewPayloadResponseMocker := NewEngineResponseMocker(nil)
@@ -1951,6 +1953,8 @@ forloop:
 
 	c, err := testnet.WaitForCurrentEpochFinalization(ctx, testnet.spec.SLOTS_PER_EPOCH*3)
 	if err != nil {
+		importer.PrintAllBeaconBlocks(ctx)
+		builder2.PrintAllBeaconBlocks(ctx)
 		t.Fatalf("FAIL: Error waiting for finality after builder 2 started: %v", err)
 	}
 	t.Logf("INFO: Finality reached after builder 2 started: epoch %v", c.Epoch)


### PR DESCRIPTION
## Changes Included
- Fixes optimistic sync tests by properly waiting until the beacon node becomes optimistic, by querying `execution_optimistic` property from the block in the REST API
- Refactors/cleans up `testnet` code to allow startup/shutdown of a client later during the test
- Introduces test `No viable head due to optimistic sync` from https://github.com/txrx-research/TestingTheMerge/blob/main/tests/engine-api.md

Requires: #604 ~#636~
Supersedes: #631

cc @zilm13 @mkalinin