### PR TITLE
simulators/ethereum/engine: Syncing on an Invalid Terminal Block (Invalid Execution)

### DIFF
--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -433,7 +433,7 @@ func (n *GethNode) PoWMiningLoop() {
 
 		// Modify the block before sealing
 		if n.config.BlockModifier != nil {
-			b, err = n.config.BlockModifier.ModifyUnsealedBlock(b)
+			b, err = n.config.BlockModifier.ModifyUnsealedBlock(n.eth.BlockChain(), s, b)
 			if err != nil {
 				panic(err)
 			}

--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -48,7 +48,8 @@ type GethNodeTestConfiguration struct {
 	PoWMinerEtherBase     common.Address
 	PoWRandomTransactions bool
 	// Prepare the Ethash instance even if we don't mine (to seal blocks)
-	Ethash           bool
+	Ethash bool
+	// Disable gossiping of newly mined blocks (peers need to sync to obtain the blocks)
 	DisableGossiping bool
 
 	// Block Modifier

--- a/simulators/ethereum/engine/suites/transition/tests.go
+++ b/simulators/ethereum/engine/suites/transition/tests.go
@@ -819,6 +819,63 @@ var mergeTestSpecs = []MergeTestSpec{
 			},
 		},
 	},
+	{
+		Name:                     "Transition on an Invalid Terminal Execution - Balance Mismatch",
+		TTD:                      290000,
+		TimeoutSeconds:           30,
+		MainChainFile:            "blocks_1_td_196608.rlp",
+		DisableMining:            true,
+		SkipMainClientTTDWait:    true,
+		KeepCheckingUntilTimeout: true,
+		SecondaryClientSpecs: []SecondaryClientSpec{
+			{
+				ClientStarter: node.GethNodeEngineStarter{
+					Config: node.GethNodeTestConfiguration{
+						Name:     "PoW Producer",
+						PoWMiner: true,
+						MaxPeers: big.NewInt(1),
+						BlockModifier: helper.PoWBlockModifier{
+							BalanceIncrease: true,
+						},
+					},
+					TerminalTotalDifficulty: big.NewInt(290000),
+					ChainFile:               "blocks_1_td_196608.rlp",
+				},
+				BuildPoSChainOnTop:  true,
+				MainClientShallSync: false,
+			},
+		},
+	},
+	{
+		Name:                        "Syncing on an Invalid Terminal Execution - Balance Mismatch",
+		TTD:                         290000,
+		TimeoutSeconds:              30,
+		MainChainFile:               "blocks_1_td_196608.rlp",
+		DisableMining:               true,
+		SkipMainClientTTDWait:       true,
+		TransitionPayloadStatusSync: test.Invalid,
+		SecondaryClientSpecs: []SecondaryClientSpec{
+			{
+				ClientStarter: node.GethNodeEngineStarter{
+					Config: node.GethNodeTestConfiguration{
+						Name:     "PoW Producer",
+						PoWMiner: true,
+						MaxPeers: big.NewInt(1),
+						BlockModifier: helper.PoWBlockModifier{
+							BalanceIncrease: true,
+						},
+						// Mined blocks are not gossiped, peers have to sync
+						DisableGossiping: true,
+					},
+					TerminalTotalDifficulty: big.NewInt(290000),
+					ChainFile:               "blocks_1_td_196608.rlp",
+				},
+				BuildPoSBlocksForSync: 1,
+				BuildPoSChainOnTop:    true,
+				MainClientShallSync:   false,
+			},
+		},
+	},
 }
 
 var Tests = func() []test.Spec {

--- a/simulators/ethereum/engine/suites/transition/tests.go
+++ b/simulators/ethereum/engine/suites/transition/tests.go
@@ -649,6 +649,36 @@ var mergeTestSpecs = []MergeTestSpec{
 		},
 	},
 	{
+		Name:                        "Syncing on an Invalid Terminal Execution - Difficulty",
+		TTD:                         696608,
+		TimeoutSeconds:              30,
+		MainChainFile:               "blocks_1_td_196608.rlp",
+		DisableMining:               true,
+		SkipMainClientTTDWait:       true,
+		TransitionPayloadStatusSync: test.Invalid,
+		SecondaryClientSpecs: []SecondaryClientSpec{
+			{
+				ClientStarter: node.GethNodeEngineStarter{
+					Config: node.GethNodeTestConfiguration{
+						Name:     "PoW Producer",
+						PoWMiner: true,
+						MaxPeers: big.NewInt(1),
+						BlockModifier: helper.PoWBlockModifier{
+							Difficulty: big.NewInt(500000),
+						},
+						// Mined blocks are not gossiped, peers have to sync
+						DisableGossiping: true,
+					},
+					TerminalTotalDifficulty: big.NewInt(696608),
+					ChainFile:               "blocks_1_td_196608.rlp",
+				},
+				BuildPoSBlocksForSync: 1,
+				BuildPoSChainOnTop:    true,
+				MainClientShallSync:   false,
+			},
+		},
+	},
+	{
 		Name:                     "Transition on an Invalid Terminal Execution - Distant Future",
 		TTD:                      290000,
 		TimeoutSeconds:           30,
@@ -703,6 +733,36 @@ var mergeTestSpecs = []MergeTestSpec{
 		},
 	},
 	{
+		Name:                        "Syncing on an Invalid Terminal Execution - Sealed MixHash",
+		TTD:                         290000,
+		TimeoutSeconds:              30,
+		MainChainFile:               "blocks_1_td_196608.rlp",
+		DisableMining:               true,
+		SkipMainClientTTDWait:       true,
+		TransitionPayloadStatusSync: test.Invalid,
+		SecondaryClientSpecs: []SecondaryClientSpec{
+			{
+				ClientStarter: node.GethNodeEngineStarter{
+					Config: node.GethNodeTestConfiguration{
+						Name:     "PoW Producer",
+						PoWMiner: true,
+						MaxPeers: big.NewInt(1),
+						BlockModifier: helper.PoWBlockModifier{
+							InvalidSealedMixHash: true,
+						},
+						// Mined blocks are not gossiped, peers have to sync
+						DisableGossiping: true,
+					},
+					TerminalTotalDifficulty: big.NewInt(290000),
+					ChainFile:               "blocks_1_td_196608.rlp",
+				},
+				BuildPoSBlocksForSync: 1,
+				BuildPoSChainOnTop:    true,
+				MainClientShallSync:   false,
+			},
+		},
+	},
+	{
 		Name:                     "Transition on an Invalid Terminal Execution - Sealed Nonce",
 		TTD:                      290000,
 		TimeoutSeconds:           30,
@@ -726,6 +786,36 @@ var mergeTestSpecs = []MergeTestSpec{
 				},
 				BuildPoSChainOnTop:  true,
 				MainClientShallSync: false,
+			},
+		},
+	},
+	{
+		Name:                        "Syncing on an Invalid Terminal Execution - Sealed Nonce",
+		TTD:                         290000,
+		TimeoutSeconds:              30,
+		MainChainFile:               "blocks_1_td_196608.rlp",
+		DisableMining:               true,
+		SkipMainClientTTDWait:       true,
+		TransitionPayloadStatusSync: test.Invalid,
+		SecondaryClientSpecs: []SecondaryClientSpec{
+			{
+				ClientStarter: node.GethNodeEngineStarter{
+					Config: node.GethNodeTestConfiguration{
+						Name:     "PoW Producer",
+						PoWMiner: true,
+						MaxPeers: big.NewInt(1),
+						BlockModifier: helper.PoWBlockModifier{
+							InvalidSealedNonce: true,
+						},
+						// Mined blocks are not gossiped, peers have to sync
+						DisableGossiping: true,
+					},
+					TerminalTotalDifficulty: big.NewInt(290000),
+					ChainFile:               "blocks_1_td_196608.rlp",
+				},
+				BuildPoSBlocksForSync: 1,
+				BuildPoSChainOnTop:    true,
+				MainClientShallSync:   false,
 			},
 		},
 	},


### PR DESCRIPTION
## Changes Included
- Introduce tests `Syncing on an Invalid Terminal Execution`, described here: https://github.com/txrx-research/TestingTheMerge/blob/main/tests/transition.md (`Syncing with the chain where terminal block is invalid with respect to EE`), where the client is delivered a `newPayload(P1)` and `forkchoiceUpdated(P1)`, and `P1` is built on top of an unknown terminal block that reaches the Terminal Total Difficulty but it's an invalid block due to one of these characteristics
  - `difficulty` number in the block header is incorrect according to the ethash consensus mechanism
  - Sealed `mixHash` in the block header is incorrect according to the ethash consensus mechanism
  - Sealed `nonce` in the block header is incorrect according to the ethash consensus mechanism

Please suggest further modes of invalidation for the terminal block.

cc @mkalinin