### PR TITLE
simulators/ethereum/engine: Cross-client Payload Validation

### DIFF
--- a/simulators/ethereum/engine/client/engine.go
+++ b/simulators/ethereum/engine/client/engine.go
@@ -22,6 +22,7 @@ type Eth interface {
 	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
+	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
 }
 
 type Engine interface {

--- a/simulators/ethereum/engine/client/engine.go
+++ b/simulators/ethereum/engine/client/engine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 type Eth interface {
@@ -38,8 +39,10 @@ type Engine interface {
 type EngineClient interface {
 	// General Methods
 	ID() string
+	ClientType() string
 	Close() error
 	EnodeURL() (string, error)
+	RPC() *rpc.Client
 
 	// Local Test Account Management
 	GetNextAccountNonce(testCtx context.Context, account common.Address) (uint64, error)

--- a/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
@@ -147,6 +147,7 @@ type HiveRPCEngineClient struct {
 	h              *hivesim.Client
 	c              *rpc.Client
 	cEth           *rpc.Client
+	clientType     string
 	ttd            *big.Int
 	JWTSecretBytes []byte
 
@@ -189,6 +190,14 @@ func NewHiveRPCEngineClient(h *hivesim.Client, enginePort int, ethPort int, jwtS
 
 func (ec *HiveRPCEngineClient) ID() string {
 	return ec.h.Container
+}
+
+func (ec *HiveRPCEngineClient) ClientType() string {
+	return ec.clientType
+}
+
+func (ec *HiveRPCEngineClient) RPC() *rpc.Client {
+	return ec.c
 }
 
 func (ec *HiveRPCEngineClient) EnodeURL() (string, error) {

--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -806,6 +806,14 @@ func (n *GethNode) NonceAt(ctx context.Context, account common.Address, blockNum
 	return stateDB.GetNonce(account), nil
 }
 
+func (n *GethNode) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+	stateDB, err := n.getStateDB(ctx, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	return stateDB.GetCode(account), nil
+}
+
 func (n *GethNode) GetBlockTotalDifficulty(ctx context.Context, hash common.Hash) (*big.Int, error) {
 	block := n.eth.BlockChain().GetBlockByHash(hash)
 	if block == nil {

--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -836,6 +836,14 @@ func (n *GethNode) ID() string {
 	return n.node.Config().Name
 }
 
+func (n *GethNode) ClientType() string {
+	return n.node.Config().Name
+}
+
+func (n *GethNode) RPC() *rpc.Client {
+	return nil
+}
+
 func (n *GethNode) GetNextAccountNonce(testCtx context.Context, account common.Address) (uint64, error) {
 	// First get the current head of the client where we will send the tx
 	head, err := n.eth.APIBackend.BlockByNumber(testCtx, LatestBlockNumber)

--- a/simulators/ethereum/engine/clmock/clmock.go
+++ b/simulators/ethereum/engine/clmock/clmock.go
@@ -331,6 +331,9 @@ func (cl *CLMocker) broadcastNextNewPayload() {
 				if resp.ExecutePayloadResponse.LatestValidHash != nil && *resp.ExecutePayloadResponse.LatestValidHash != (common.Hash{}) {
 					cl.Fatalf("CLMocker: NewPayload returned ACCEPTED status with incorrect LatestValidHash==%v", resp.ExecutePayloadResponse.LatestValidHash)
 				}
+			} else if resp.ExecutePayloadResponse.Status == api.INVALID {
+				// At any point during the CLMock workflow there mustn't be any INVALID payload
+				cl.Fatalf("CLMocker: An invalid payload was produced by one of the clients during the payload building process: Payload builder=%s, invalidating client=%s, hash=%s", cl.NextBlockProducer.ID(), resp.Container, cl.LatestPayloadBuilt.BlockHash)
 			} else {
 				cl.Logf("CLMocker: BroadcastNewPayload Response (%v): %v\n", resp.Container, resp.ExecutePayloadResponse)
 			}
@@ -356,7 +359,10 @@ func (cl *CLMocker) broadcastLatestForkchoice() {
 			if resp.ForkchoiceResponse.PayloadID != nil {
 				cl.Fatalf("CLMocker: Expected empty PayloadID: %v\n", resp.Container, resp.ForkchoiceResponse.PayloadID)
 			}
-		} else if resp.ForkchoiceResponse.PayloadStatus.Status != api.VALID {
+		} else if resp.ForkchoiceResponse.PayloadStatus.Status == api.INVALID {
+			// At any point during the CLMock workflow there mustn't be any INVALID payload
+			cl.Fatalf("CLMocker: An invalid payload was produced by one of the clients during the payload building process (ForkchoiceUpdated): Payload builder=%s, invalidating client=%s, hash=%s", cl.NextBlockProducer.ID(), resp.Container, cl.LatestPayloadBuilt.BlockHash)
+		} else {
 			cl.Logf("CLMocker: BroadcastForkchoiceUpdated Response (%v): %v\n", resp.Container, resp.ForkchoiceResponse)
 		}
 	}

--- a/simulators/ethereum/engine/globals/globals.go
+++ b/simulators/ethereum/engine/globals/globals.go
@@ -13,10 +13,11 @@ import (
 var (
 
 	// Test chain parameters
-	ChainID     = big.NewInt(7)
-	GasPrice    = big.NewInt(30 * params.GWei)
-	GasTipPrice = big.NewInt(1 * params.GWei)
-	NetworkID   = big.NewInt(7)
+	ChainID   = big.NewInt(7)
+	GasPrice  = big.NewInt(30 * params.GWei)
+	GasFeeCap = big.NewInt(30 * params.GWei)
+	GasTipCap = big.NewInt(1 * params.GWei)
+	NetworkID = big.NewInt(7)
 
 	// RPC Timeout for every call
 	RPCTimeout = 10 * time.Second

--- a/simulators/ethereum/engine/helper/payload.go
+++ b/simulators/ethereum/engine/helper/payload.go
@@ -250,7 +250,7 @@ func GenerateInvalidPayload(basePayload *api.ExecutableDataV1, payloadField Inva
 		case InvalidTransactionGasPrice:
 			customTxData.GasPriceOrGasFeeCap = common.Big0
 		case InvalidTransactionGasTipPrice:
-			invalidGasTip := new(big.Int).Set(globals.GasTipPrice)
+			invalidGasTip := new(big.Int).Set(globals.GasTipCap)
 			invalidGasTip.Mul(invalidGasTip, big.NewInt(2))
 			customTxData.GasTipCap = invalidGasTip
 		case InvalidTransactionValue:

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -81,15 +81,17 @@ func addTestsToSuite(suite *hivesim.Suite, tests []test.Spec) {
 		if currentTest.DisableMining {
 			delete(newParams, "HIVE_MINER")
 		}
-		suite.Add(hivesim.ClientTestSpec{
+		suite.Add(hivesim.TestSpec{
 			Name:        currentTest.Name,
 			Description: currentTest.About,
-			Parameters:  newParams,
-			Files:       testFiles,
-			Run: func(t *hivesim.T, c *hivesim.Client) {
-				t.Logf("Start test (%s): %s", c.Type, currentTest.Name)
+			Run: func(t *hivesim.T) {
+				testClientTypes, err := t.Sim.ClientTypes()
+				if err != nil {
+					t.Fatalf("No client types")
+				}
+				t.Logf("Start test (%s): %s", testClientTypes[0].Name, currentTest.Name)
 				defer func() {
-					t.Logf("End test (%s): %s", c.Type, currentTest.Name)
+					t.Logf("End test (%s): %s", testClientTypes[0].Name, currentTest.Name)
 				}()
 				timeout := globals.DefaultTestCaseTimeout
 				// If a test.Spec specifies a timeout, use that instead
@@ -97,7 +99,7 @@ func addTestsToSuite(suite *hivesim.Suite, tests []test.Spec) {
 					timeout = time.Second * time.Duration(currentTest.TimeoutSeconds)
 				}
 				// Run the test case
-				test.Run(currentTest.Name, big.NewInt(ttd), currentTest.SlotsToSafe, currentTest.SlotsToFinalized, timeout, t, c, currentTest.Run, newParams, testFiles, currentTest.TestTransactionType, currentTest.SafeSlotsToImportOptimistically)
+				test.Run(currentTest.Name, big.NewInt(ttd), currentTest.SlotsToSafe, currentTest.SlotsToFinalized, timeout, t, currentTest.Run, newParams, testFiles, currentTest.TestTransactionType, currentTest.SafeSlotsToImportOptimistically)
 			},
 		})
 	}


### PR DESCRIPTION
## Changes Included

- Allow launching a second type of client to be able to cross-check that a payload produced is indeed valid
- Create a test where the log bloom is updated on the PoS payloads