### PR TITLE
simulators/eth2/engine: Timeouts test

### DIFF
--- a/simulators/eth2/engine/main.go
+++ b/simulators/eth2/engine/main.go
@@ -28,6 +28,7 @@ var engineTests = []testSpec{
 	{Name: "syncing-with-invalid-chain", Run: SyncingWithInvalidChain},
 	{Name: "basefee-encoding-check", Run: BaseFeeEncodingCheck},
 	{Name: "invalid-quantity-fields", Run: InvalidQuantityPayloadFields},
+	{Name: "timeouts", Run: Timeouts},
 }
 var transitionTests = []testSpec{
 	// Transition (TERMINAL_TOTAL_DIFFICULTY) tests


### PR DESCRIPTION
## Changes Included

- Include test for timeout limits on `engine_newPayloadV1` and `engine_forkchoiceUpdatedV1` calls from the consensus client to the execution client