### PR TITLE
simulators/eth2/testnet,engine: Fix Nodetype

### DIFF
--- a/simulators/eth2/engine/prepared_testnet.go
+++ b/simulators/eth2/engine/prepared_testnet.go
@@ -65,7 +65,10 @@ func prepareTestnet(t *hivesim.T, env *testEnv, config *Config) *PreparedTestnet
 	if err != nil {
 		t.Fatal(err)
 	}
-	execNodeOpts := hivesim.Params{"HIVE_LOGLEVEL": os.Getenv("HIVE_LOGLEVEL")}
+	execNodeOpts := hivesim.Params{
+		"HIVE_LOGLEVEL": os.Getenv("HIVE_LOGLEVEL"),
+		"HIVE_NODETYPE": "full",
+	}
 	jwtSecret := hivesim.Params{"HIVE_JWTSECRET": "true"}
 	executionOpts := hivesim.Bundle(eth1ConfigOpt, eth1Bundle, execNodeOpts, jwtSecret)
 

--- a/simulators/eth2/testnet/prepared_testnet.go
+++ b/simulators/eth2/testnet/prepared_testnet.go
@@ -56,7 +56,10 @@ func prepareTestnet(t *hivesim.T, env *testEnv, config *config) *PreparedTestnet
 	if err != nil {
 		t.Fatal(err)
 	}
-	execNodeOpts := hivesim.Params{"HIVE_LOGLEVEL": os.Getenv("HIVE_LOGLEVEL")}
+	execNodeOpts := hivesim.Params{
+		"HIVE_LOGLEVEL": os.Getenv("HIVE_LOGLEVEL"),
+		"HIVE_NODETYPE": "full",
+	}
 	executionOpts := hivesim.Bundle(eth1ConfigOpt, eth1Bundle, execNodeOpts)
 
 	// Generate beacon spec


### PR DESCRIPTION
## Changes included
- Fix the execution client node type to be a full node: All tests were failing because Geth was entering snap sync and rejecting `engine_newPayloadV1` calls, even when the payload was created by the same node itself.