### PR TITLE
clients/teku: Subscribe to all subnets

### DIFF
--- a/clients/teku-bn/teku_bn.sh
+++ b/clients/teku-bn/teku_bn.sh
@@ -69,4 +69,5 @@ echo Starting Teku Beacon Node
     --p2p-peer-lower-bound="${HIVE_ETH2_P2P_TARGET_PEERS:-10}" \
     --rest-api-enabled=true --rest-api-interface=0.0.0.0 --rest-api-port="${HIVE_ETH2_BN_API_PORT:-4000}" --rest-api-host-allowlist="*" \
     --data-storage-mode=ARCHIVE \
-    --Xstartup-target-peer-count=0    
+    --Xstartup-target-peer-count=0 \
+    --p2p-subscribe-all-subnets-enabled


### PR DESCRIPTION
I think it's a common issue for all CL clients. It's expected by the spec that we have a lot of aggregators and they don't need to subscribe to any extra topics, so when we have just 2 peers, there is a non-zero chance that the other peer is not subscribed to the all attestation subnets, so when first peer is releasing an attestation, another peer sometimes is not able to produce aggregate from it, because it's not subscribed to the topic of this attestation. I have added flag `--p2p-subscribe-all-subnets-enabled` to ensure both peers are listening to the all attestation topics.