### PR TITLE
clients/erigon: Upgrade verbosity flag

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -39,7 +39,7 @@ set -e
 erigon=/usr/local/bin/erigon
 
 if [ "$HIVE_LOGLEVEL" != "" ]; then
-    FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"
+    FLAGS="$FLAGS --log.console.verbosity=$HIVE_LOGLEVEL"
 fi
 
 if [ "$HIVE_BOOTNODE" != "" ]; then


### PR DESCRIPTION
The `--verbosity` flag has been recently renamed to `--log.console.verbosity` in Erigon.