### PR TITLE
simulators/ethereum/consensus: add merge ruleset

### DIFF
--- a/simulators/ethereum/consensus/main.go
+++ b/simulators/ethereum/consensus/main.go
@@ -250,6 +250,18 @@ var ruleset = map[string]envvars{
 		"HIVE_FORK_BERLIN":         0,
 		"HIVE_FORK_LONDON":         0,
 	},
+	"Merge": {
+		"HIVE_FORK_HOMESTEAD": 0,
+		//"HIVE_FORK_DAO_BLOCK":      2000,
+		"HIVE_FORK_TANGERINE":      0,
+		"HIVE_FORK_SPURIOUS":       0,
+		"HIVE_FORK_BYZANTIUM":      0,
+		"HIVE_FORK_CONSTANTINOPLE": 0,
+		"HIVE_FORK_PETERSBURG":     0,
+		"HIVE_FORK_ISTANBUL":       0,
+		"HIVE_FORK_BERLIN":         0,
+		"HIVE_FORK_MERGE":          0,
+	},
 }
 
 func main() {


### PR DESCRIPTION
Fixes the following issues:
```
test validation failed for add_d2g0v0_Merge: network `Merge` not defined in ruleset
test validation failed for add_d0g0v0_Merge: network `Merge` not defined in ruleset
test validation failed for add_d3g0v0_Merge: network `Merge` not defined in ruleset
```
https://hivetests.ethdevops.io/?page=v-pills-results-tab&suite=1666953000-4453fd9653a1f707a4edd2efd25af0e7.json
