### PR TITLE
clients/erigon: Add externalcl flag

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -135,6 +135,6 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
 fi
 
 # Launch the main client.
-FLAGS="$FLAGS --nat=none"
+FLAGS="$FLAGS --nat=none --externalcl"
 echo "Running erigon with flags $FLAGS"
 $erigon $FLAGS


### PR DESCRIPTION
After https://github.com/ledgerwatch/erigon/pull/5813 Erigon uses embedded light-client CL by default. That mode is not compatible with Hive tests and erigon should be switched back to using external CL.