### PR TITLE
internal/libhive: fix assignment to entry in nil map bug

### DIFF
--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -228,6 +228,10 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	// Set default client loglevel to sim loglevel.
+	if env == nil {
+		env = make(map[string]string)
+	}
+
 	if env["HIVE_LOGLEVEL"] == "" {
 		env["HIVE_LOGLEVEL"] = strconv.Itoa(api.env.SimLogLevel)
 	}


### PR DESCRIPTION
When the "environment" field is not included in the client launch configuration,  `env := clientConfig.Environment`(line 224) returns nil and a panic  `assignment to entry in nil map` is raised when we do  `env["HIVE_LOGLEVEL"] = strconv.Itoa(api.env.SimLogLevel)` later (line 236).