### PR TITLE
clients/besu: add Shanghai fork and fix issue with duplicated node keys

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -99,14 +99,15 @@ if [ -d /blocks ]; then
     IMPORTFLAGS="$IMPORTFLAGS $blocks"
 fi
 
-
-# Configure mining.
-if [ "$HIVE_MINER" != "" ]; then
-    FLAGS="$FLAGS --miner-enabled --miner-coinbase=$HIVE_MINER"
-    # For clique mining, besu uses the node key as the block signing key.
-    if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
-        echo "Importing clique signing key as node key..."
-        echo "$HIVE_CLIQUE_PRIVATEKEY" > /opt/besu/key
+if [ "$HIVE_BOOTNODE" != "" ]; then
+    # Configure mining.
+    if [ "$HIVE_MINER" != "" ]; then
+        FLAGS="$FLAGS --miner-enabled --miner-coinbase=$HIVE_MINER"
+        # For clique mining, besu uses the node key as the block signing key.
+        if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
+            echo "Importing clique signing key as node key..."
+            echo "$HIVE_CLIQUE_PRIVATEKEY" > /opt/besu/key
+        fi
     fi
 fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then

--- a/clients/besu/mapper.jq
+++ b/clients/besu/mapper.jq
@@ -44,6 +44,7 @@ def to_int:
     "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
     "parisBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
   }|remove_empty
 }


### PR DESCRIPTION
This fixes the tests where hive spins up a second instance of besu and sync from the bootnode. Currently node 1 and 2 have the same enode address which stops them from peering with each other 

Linked to [#4747](https://github.com/hyperledger/besu/issues/4747)