### PR TITLE
simulators/ethereum/engine: Fix nil exception

### DIFF
--- a/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
@@ -336,7 +336,9 @@ func (ec *HiveRPCEngineClient) GetPayload(ctx context.Context, version int, payl
 	if version == 2 {
 		var response api.ExecutableDataV2
 		err = ec.c.CallContext(ctx, &response, rpcString, payloadId)
-		executableData = *response.ExecutionPayload
+		if response.ExecutionPayload != nil {
+			executableData = *response.ExecutionPayload
+		}
 		blockValue = response.BlockValue
 	} else {
 		err = ec.c.CallContext(ctx, &executableData, rpcString, payloadId)


### PR DESCRIPTION
Fixes a small nil on the engine tests, which could happen when clients did not return the expected information.