### PR TITLE
clients/nethermind: Use Terminal Block Hash/Number

### DIFF
--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -32,7 +32,9 @@ def merge_config:
       "Merge": {
         "Enabled": true,
         "TerminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY,
-      }
+        "TerminalBlockHash": env.HIVE_TERMINAL_BLOCK_HASH,
+        "TerminalBlockNumber": env.HIVE_TERMINAL_BLOCK_NUMBER,
+      } | remove_empty
     }
   else
     {}


### PR DESCRIPTION
Adds TERMINAL_BLOCK_HASH and TERMINAL_BLOCK_NUMBER, which fixes interactions with prysm.