### PR TITLE
hivesim: make test matching case insensitive

### DIFF
--- a/hivesim/testmatch.go
+++ b/hivesim/testmatch.go
@@ -13,12 +13,12 @@ type testMatcher struct {
 
 func parseTestPattern(p string) (m testMatcher, err error) {
 	parts := splitRegexp(p)
-	m.suite, err = regexp.Compile(parts[0])
+	m.suite, err = regexp.Compile("(?i:" + parts[0] + ")")
 	if err != nil {
 		return m, err
 	}
 	if len(parts) > 1 {
-		m.test, err = regexp.Compile(strings.Join(parts[1:], "/"))
+		m.test, err = regexp.Compile("(?i:" + strings.Join(parts[1:], "/") + ")")
 		if err != nil {
 			return m, err
 		}

--- a/hivesim/testmatch_test.go
+++ b/hivesim/testmatch_test.go
@@ -1,0 +1,25 @@
+package hivesim
+
+import (
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	tm, err := parseTestPattern("sim/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !tm.match("sim", "test") {
+		t.Fatal("expected match")
+	}
+	if !tm.match("Sim", "Test") {
+		t.Fatal("expected match")
+	}
+	if !tm.match("Sim", "TestTest") {
+		t.Fatal("expected match")
+	}
+	if tm.match("Sim", "Tst") {
+		t.Fatal("expected no match")
+	}
+}


### PR DESCRIPTION
For #688, but this doesn't fully implement it. Case-insensitive matching will start working after upgrading the hivesim dependency in simulators.