### PR TITLE
simulators/eth2/withdrawals: Better withdrawals calculations

### DIFF
--- a/simulators/eth2/withdrawals/helper.go
+++ b/simulators/eth2/withdrawals/helper.go
@@ -228,7 +228,8 @@ func (v *Validator) VerifyWithdrawnBalance(
 				return false, err
 			}
 			if blockState == nil {
-				return false, nil
+				// Probably a skipped slot
+				continue
 			}
 
 			execPayload, err := blockState.ExecutionPayload()

--- a/simulators/eth2/withdrawals/scenarios.go
+++ b/simulators/eth2/withdrawals/scenarios.go
@@ -205,10 +205,12 @@ loop:
 				bc := n.BeaconClient
 				headBlockRoot, err := bc.BlockV2Root(ctx, eth2api.BlockHead)
 				if err != nil {
-					t.Fatalf("FAIL: Error getting head block: %v", err)
+					t.Logf("INFO: error getting head block: %v", err)
+					continue
 				}
 				if allAccountsWithdrawn, err := allValidators.Withdrawable().VerifyWithdrawnBalance(ctx, bc, ec, headBlockRoot); err != nil {
-					t.Fatalf("FAIL: %v", err)
+					t.Logf("INFO: error getting withdrawals balances: %v", err)
+					continue
 				} else if allAccountsWithdrawn {
 					t.Logf("INFO: All accounts have successfully withdrawn")
 					break loop


### PR DESCRIPTION
There was an issue in the withdrawals calculations so that, when the chain missed a slot, it aborted with error, but it's normal to miss a block in a slot.
Now the computing method allows to skip a slot, and the calculations are still correct, the test passes for client combinations that might occasionally miss a slot.