### PR TITLE
simulators/ethereum/engine: Remove PoW config from withdrawals

### DIFF
--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -99,16 +99,24 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 		}
 
 		testFiles := hivesim.Params{}
-		if currentTest.GetChainFile() != "" {
-			// We are using a Proof of Work chain file, remove all clique-related settings
-			// TODO: Nethermind still requires HIVE_MINER for the Engine API
-			// delete(newParams, "HIVE_MINER")
+		if genesis.Difficulty.Cmp(big.NewInt(ttd)) < 0 {
+
+			if currentTest.GetChainFile() != "" {
+				// We are using a Proof of Work chain file, remove all clique-related settings
+				// TODO: Nethermind still requires HIVE_MINER for the Engine API
+				// delete(newParams, "HIVE_MINER")
+				delete(newParams, "HIVE_CLIQUE_PRIVATEKEY")
+				delete(newParams, "HIVE_CLIQUE_PERIOD")
+				// Add the new file to be loaded as chain.rlp
+				testFiles = testFiles.Set("/chain.rlp", "./chains/"+currentTest.GetChainFile())
+			}
+			if currentTest.IsMiningDisabled() {
+				delete(newParams, "HIVE_MINER")
+			}
+		} else {
+			// This is a post-merge test
 			delete(newParams, "HIVE_CLIQUE_PRIVATEKEY")
 			delete(newParams, "HIVE_CLIQUE_PERIOD")
-			// Add the new file to be loaded as chain.rlp
-			testFiles = testFiles.Set("/chain.rlp", "./chains/"+currentTest.GetChainFile())
-		}
-		if currentTest.IsMiningDisabled() {
 			delete(newParams, "HIVE_MINER")
 		}
 

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -624,6 +624,13 @@ func AddUnconditionalBytecode(g *core.Genesis, start *big.Int, end *big.Int) {
 // bytecode for testing purposes.
 func (ws *WithdrawalsBaseSpec) GetGenesis() *core.Genesis {
 	genesis := ws.Spec.GetGenesis()
+
+	// Remove PoW altogether
+	genesis.Difficulty = common.Big0
+	genesis.Config.TerminalTotalDifficulty = common.Big0
+	genesis.Config.Clique = nil
+	genesis.ExtraData = []byte{}
+
 	startAccount := big.NewInt(0x1000)
 	endAccount := big.NewInt(0x1000 + int64(ws.GetWithdrawableAccountCount()) - 1)
 	AddUnconditionalBytecode(genesis, startAccount, endAccount)


### PR DESCRIPTION
Changes on `simulators/ethereum/engine/withdrawals`:
- Removes Clique from config
- Difficulty set to 0 on genesis
- Sets TTD to 0
- Removes ExtraData from the genesis block

Waiting on @jochem-brouwer to see if this fixes some of the issues on EthJS