### PR TITLE
Align GraphQL tests with current spec

### DIFF
--- a/simulators/ethereum/graphql/testcases/14_eth_getBlock_byHash.json
+++ b/simulators/ethereum/graphql/testcases/14_eth_getBlock_byHash.json
@@ -11,7 +11,7 @@
         "transactions" : [ {
           "hash" : "0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4"
         } ],
-        "timestamp" : "0x561bc336",
+        "timestamp" : 1444660022,
         "difficulty" : "0x20740",
         "totalDifficulty" : "0x3e6cc0",
         "gasUsed" : 23585,

--- a/simulators/ethereum/graphql/testcases/16_eth_getBlock_byNumber.json
+++ b/simulators/ethereum/graphql/testcases/16_eth_getBlock_byNumber.json
@@ -10,7 +10,7 @@
         "transactions" : [ {
           "hash" : "0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4"
         } ],
-        "timestamp" : "0x561bc336",
+        "timestamp" : 1444660022,
         "difficulty" : "0x20740",
         "totalDifficulty" : "0x3e6cc0",
         "gasUsed" : 23585,

--- a/simulators/ethereum/graphql/testcases/20_eth_getBlockTransactionCount_byNumber.json
+++ b/simulators/ethereum/graphql/testcases/20_eth_getBlockTransactionCount_byNumber.json
@@ -10,7 +10,7 @@
         "transactions" : [ {
           "hash" : "0x9cc6c7e602c56aa30c554bb691377f8703d778cec8845f4b88c0f72516b304f4"
         } ],
-        "timestamp" : "0x561bc336",
+        "timestamp" : 1444660022,
         "difficulty" : "0x20740",
         "totalDifficulty" : "0x3e6cc0",
         "gasUsed" : 23585,

--- a/simulators/ethereum/graphql/testcases/40_eth_syncing.json
+++ b/simulators/ethereum/graphql/testcases/40_eth_syncing.json
@@ -1,6 +1,6 @@
 {
   "request":     
-    "{ syncing {startingBlock currentBlock highestBlock pulledStates knownStates } }",
+    "{ syncing {startingBlock currentBlock highestBlock } }",
 
   "responses": [{
     "data" : {


### PR DESCRIPTION
For graphql use long for timestamp and remove two SyncState fields.

A couple of spec changes occured since these tests were created.

* `timestamp` became a long - https://github.com/ethereum/execution-apis/blob/main/schema.graphqls#L109
* `SyncState` does not have `pulledStates` and `knownStates` as these were implementation details of Fast Sync. https://github.com/ethereum/execution-apis/blob/main/schema.graphqls#L400-L411