### PR TITLE
Add support for custom genesis delay in start

### DIFF
--- a/simulators/eth2/common/testnet/config.go
+++ b/simulators/eth2/common/testnet/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	TerminalTotalDifficulty         *big.Int
 	SafeSlotsToImportOptimistically *big.Int
 	ExtraShares                     *big.Int
+	GenesisDelaySlots               *big.Int
 
 	// Node configurations to launch. Each node as a proportional share of
 	// validators.
@@ -50,6 +51,7 @@ func (a *Config) Join(b *Config) *Config {
 	c.AltairForkEpoch = choose(a.AltairForkEpoch, b.AltairForkEpoch)
 	c.BellatrixForkEpoch = choose(a.BellatrixForkEpoch, b.BellatrixForkEpoch)
 	c.CapellaForkEpoch = choose(a.CapellaForkEpoch, b.CapellaForkEpoch)
+	c.GenesisDelaySlots = choose(a.GenesisDelaySlots, b.GenesisDelaySlots)
 
 	// Testnet config
 	c.ValidatorCount = choose(a.ValidatorCount, b.ValidatorCount)

--- a/simulators/eth2/common/testnet/prepared_testnet.go
+++ b/simulators/eth2/common/testnet/prepared_testnet.go
@@ -81,7 +81,8 @@ func prepareTestnet(
 	env *Environment,
 	config *Config,
 ) *PreparedTestnet {
-	eth1GenesisTime := common.Timestamp(time.Now().Unix())
+	genesisTime := time.Now().Add(time.Second * time.Duration(big.NewInt(0).Mul(config.GenesisDelaySlots, config.SlotTime).Int64()))
+	eth1GenesisTime := common.Timestamp(genesisTime.Unix())
 	eth2GenesisTime := eth1GenesisTime + 30
 
 	// Generate genesis for execution clients
@@ -171,6 +172,11 @@ func prepareTestnet(
 	if config.SlotTime != nil {
 		spec.Config.SECONDS_PER_SLOT = common.Timestamp(
 			config.SlotTime.Uint64(),
+		)
+	}
+	if config.GenesisDelaySlots != nil {
+		spec.Config.GENESIS_DELAY = common.Timestamp(
+			config.GenesisDelaySlots.Uint64(),
 		)
 	}
 	tdd, _ := uint256.FromBig(config.TerminalTotalDifficulty)

--- a/simulators/eth2/withdrawals/specs.go
+++ b/simulators/eth2/withdrawals/specs.go
@@ -49,7 +49,7 @@ var (
 		AltairForkEpoch:         common.Big0,
 		BellatrixForkEpoch:      common.Big0,
 		CapellaForkEpoch:        common.Big1,
-		GenesisDelaySlots:       big.NewInt(10), // To avoid skipped slots in the start
+		GenesisDelaySlots:       big.NewInt(5), // To avoid skipped slots in the start
 		Eth1Consensus:           &el.ExecutionCliqueConsensus{},
 	}
 

--- a/simulators/eth2/withdrawals/specs.go
+++ b/simulators/eth2/withdrawals/specs.go
@@ -49,6 +49,7 @@ var (
 		AltairForkEpoch:         common.Big0,
 		BellatrixForkEpoch:      common.Big0,
 		CapellaForkEpoch:        common.Big1,
+		GenesisDelaySlots:       big.NewInt(10), // To avoid skipped slots in the start
 		Eth1Consensus:           &el.ExecutionCliqueConsensus{},
 	}
 


### PR DESCRIPTION
During the testing of withdrawals it's observed that a few slots skipped during the very start (at least locally on dev machine). Setting up a genesis delay makes the tests more stable don't fail because a few slots skipped earlier. 