### PR TITLE
clients/nimbus: clean Dockerfile, accept branch arg

### DIFF
--- a/clients/nimbus-bn/Dockerfile
+++ b/clients/nimbus-bn/Dockerfile
@@ -2,19 +2,21 @@
 
 FROM debian:buster-slim AS build
 
+ARG branch=unstable
+
 RUN apt-get update \
  && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV NPROC=2
+RUN git clone --recurse-submodules --depth 1 --branch "${branch}" \
+    https://github.com/status-im/nimbus-eth2.git
 
-RUN git clone --depth 1 --branch unstable https://github.com/status-im/nimbus-eth2.git \
- && cd nimbus-eth2 \
- && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+WORKDIR /nimbus-eth2
 
-RUN cd nimbus-eth2 && \
-    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_beacon_node && \
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_beacon_node && \
     mv build/nimbus_beacon_node /usr/bin/
 
 # --------------------------------- #

--- a/clients/nimbus-el/Dockerfile
+++ b/clients/nimbus-el/Dockerfile
@@ -2,20 +2,21 @@
 
 FROM debian:buster-slim AS build
 
+ARG branch=master
+
 RUN apt-get update \
  && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV NPROC=2
+RUN git clone --recurse-submodules --depth 1 --branch "${branch}" \
+    https://github.com/status-im/nimbus-eth1.git
 
-RUN git clone --depth 1 --branch master https://github.com/status-im/nimbus-eth1.git \
- && cd nimbus-eth1 \
- && git checkout master \
- && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+WORKDIR /nimbus-eth1
 
-RUN cd nimbus-eth1 && \
-    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus && \
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus && \
     mv build/nimbus /usr/bin/
 
 # --------------------------------- #

--- a/clients/nimbus-vc/Dockerfile
+++ b/clients/nimbus-vc/Dockerfile
@@ -2,19 +2,21 @@
 
 FROM debian:buster-slim AS build
 
+ARG branch=unstable
+
 RUN apt-get update \
  && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV NPROC=2
+RUN git clone --recurse-submodules --depth 1 --branch "${branch}" \
+    https://github.com/status-im/nimbus-eth2.git
 
-RUN git clone --depth 1 --branch unstable https://github.com/status-im/nimbus-eth2.git \
- && cd nimbus-eth2 \
- && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+WORKDIR /nimbus-eth2
 
-RUN cd nimbus-eth2 && \
-    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_validator_client && \
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_validator_client && \
     mv build/nimbus_validator_client /usr/bin/
 
 # --------------------------------- #


### PR DESCRIPTION
Changes:
- Accept a branch argument, so now hive can be called as, e.g.:
```
--clients nimbus-bn_log-withdrawals-discrepancy
```
   and the git branch `log-withdrawals-discrepancy` will be used to compile the client. Default is `unstable`.
- Use `--recurse-submodules` on the `git clone` command so the `make` command doesn't need to fetch the submodules.
- `NPROC` is now dynamic.

@tersec