### PR TITLE
simulators/ethereum/engine: Test sending `engine_forkchoiceUpdatedV1`, `engine_newPayloadV1` post-shanghai

### DIFF
--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -1171,7 +1171,7 @@ func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 			if !ws.SkipBaseVerifications {
 				// Try to send a PayloadAttributesV1 with null withdrawals after
 				// Shanghai
-				r := t.TestEngine.TestEngineForkchoiceUpdatedV2(
+				r := t.TestEngine.TestEngineForkchoiceUpdatedV1(
 					&beacon.ForkchoiceStateV1{
 						HeadBlockHash: t.CLMock.LatestHeader.Hash(),
 					},
@@ -1182,7 +1182,21 @@ func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 						Withdrawals:           nil,
 					},
 				)
-				r.ExpectationDescription = "Sent shanghai fcu using PayloadAttributesV1, error is expected"
+				r.ExpectationDescription = "Sent fcuV1 post-Shanghai, error is expected"
+				r.ExpectErrorCode(InvalidParamsError)
+
+				r = t.TestEngine.TestEngineForkchoiceUpdatedV2(
+					&beacon.ForkchoiceStateV1{
+						HeadBlockHash: t.CLMock.LatestHeader.Hash(),
+					},
+					&beacon.PayloadAttributes{
+						Timestamp:             t.CLMock.LatestHeader.Time + ws.GetBlockTimeIncrements(),
+						Random:                common.Hash{},
+						SuggestedFeeRecipient: common.Address{},
+						Withdrawals:           nil,
+					},
+				)
+				r.ExpectationDescription = "Sent shanghai fcuV2 using PayloadAttributesV1, error is expected"
 				r.ExpectErrorCode(InvalidParamsError)
 			}
 

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -1236,7 +1236,11 @@ func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 				if err != nil {
 					t.Fatalf("Unable to append withdrawals: %v", err)
 				}
-				r := t.TestEngine.TestEngineNewPayloadV2(nilWithdrawalsPayload)
+				r := t.TestEngine.TestEngineNewPayloadV1(nilWithdrawalsPayload)
+				r.ExpectationDescription = "Sent post-shanghai payload using NewPayloadV1, error is expected"
+				r.ExpectErrorCode(InvalidParamsError)
+
+				r = t.TestEngine.TestEngineNewPayloadV2(nilWithdrawalsPayload)
 				r.ExpectationDescription = "Sent shanghai payload using ExecutionPayloadV1, error is expected"
 				r.ExpectErrorCode(InvalidParamsError)
 


### PR DESCRIPTION
Adds a test in `simulators/ethereum/engine` to verify that sending `engine_forkchoiceUpdatedV1` or `engine_newPayloadV1` post-Shanghai results in `InvalidParams` error (-32602).

Although this is not explicitly stated in spec, it caused an issue on nimbus as geth started building a transition payload with empty withdrawals because of this.

Setting this as draft because there is nothing explicit in the spec to describe this error, but I think it should be laid out.

@mkalinin @MariusVanDerWijden 