### PR TITLE
simulators/eth2/common: Add option to log all engine api calls

### DIFF
--- a/simulators/eth2/common/testnet/environment.go
+++ b/simulators/eth2/common/testnet/environment.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Environment struct {
-	Clients *clients.ClientDefinitionsByRole
-	Keys    []*consensus_config.KeyDetails
-	Secrets *[]blsu.SecretKey
+	Clients        *clients.ClientDefinitionsByRole
+	Keys           []*consensus_config.KeyDetails
+	Secrets        *[]blsu.SecretKey
+	LogEngineCalls bool
 }

--- a/simulators/eth2/common/testnet/prepared_testnet.go
+++ b/simulators/eth2/common/testnet/prepared_testnet.go
@@ -319,6 +319,7 @@ func (p *PreparedTestnet) prepareExecutionNode(
 	executionIndex int,
 	chain []*types.Block,
 	subnet string,
+	logEngineCalls bool,
 ) *clients.ExecutionClient {
 	testnet.Logf(
 		"Preparing execution node: %s (%s)",
@@ -394,9 +395,11 @@ func (p *PreparedTestnet) prepareExecutionNode(
 		testnet.T,
 		eth1Def,
 		optionsGenerator,
+		executionIndex,
 		clients.PortEngineRPC+executionIndex,
 		subnet,
 		ttd,
+		logEngineCalls,
 	)
 }
 

--- a/simulators/eth2/common/testnet/running_testnet.go
+++ b/simulators/eth2/common/testnet/running_testnet.go
@@ -177,6 +177,7 @@ func StartTestnet(
 			nodeIndex,
 			node.Chain,
 			node.ExecutionSubnet,
+			env.LogEngineCalls,
 		)
 
 		if node.ConsensusClient != "" {


### PR DESCRIPTION
Adds an optional proxy callback that can log all Engine API calls that the CL makes to the EL.