### PR TITLE
simulators/ethereum/engine: Combinatorial Withdrawal Sync Tests

### DIFF
--- a/simulators/ethereum/engine/client/engine.go
+++ b/simulators/ethereum/engine/client/engine.go
@@ -69,7 +69,13 @@ type EngineClient interface {
 }
 
 type EngineStarter interface {
-	StartClient(T *hivesim.T, testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...EngineClient) (EngineClient, error)
+	StartClient(T ClientStarter, testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...EngineClient) (EngineClient, error)
+}
+
+type ClientStarter interface {
+	StartClient(clientType string, option ...hivesim.StartOption) *hivesim.Client
+	GetNextClientType() (string, error)
+	Logf(format string, values ...interface{})
 }
 
 var (

--- a/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
@@ -36,23 +36,20 @@ type HiveRPCEngineStarter struct {
 	JWTSecret               []byte
 }
 
-func (s HiveRPCEngineStarter) StartClient(T *hivesim.T, testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...client.EngineClient) (client.EngineClient, error) {
+func (s HiveRPCEngineStarter) StartClient(T client.ClientStarter, testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...client.EngineClient) (client.EngineClient, error) {
 	var (
 		clientType = s.ClientType
 		enginePort = s.EnginePort
 		ethPort    = s.EthPort
 		jwtSecret  = s.JWTSecret
 		ttd        = s.TerminalTotalDifficulty
+		err        error
 	)
 	if clientType == "" {
-		cs, err := T.Sim.ClientTypes()
+		clientType, err = T.GetNextClientType()
 		if err != nil {
-			return nil, fmt.Errorf("client type was not supplied and simulator returned error on trying to get all client types: %v", err)
+			return nil, fmt.Errorf("client type was not supplied and clientTypeSource returned error: %v", err)
 		}
-		if len(cs) == 0 {
-			return nil, fmt.Errorf("client type was not supplied and simulator returned empty client types: %v", cs)
-		}
-		clientType = cs[0].Name
 	}
 	if enginePort == 0 {
 		enginePort = globals.EnginePortHTTP

--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -92,11 +92,11 @@ var (
 	DefaultTerminalBlockSiblingDepth = big.NewInt(1)
 )
 
-func (s GethNodeEngineStarter) StartClient(T *hivesim.T, testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...client.EngineClient) (client.EngineClient, error) {
-	return s.StartGethNode(T, testContext, genesis, ClientParams, ClientFiles, bootClients...)
+func (s GethNodeEngineStarter) StartClient(_ client.ClientStarter, testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...client.EngineClient) (client.EngineClient, error) {
+	return s.StartGethNode(testContext, genesis, ClientParams, ClientFiles, bootClients...)
 }
 
-func (s GethNodeEngineStarter) StartGethNode(T *hivesim.T, testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...client.EngineClient) (*GethNode, error) {
+func (s GethNodeEngineStarter) StartGethNode(testContext context.Context, genesis *core.Genesis, ClientParams hivesim.Params, ClientFiles hivesim.Params, bootClients ...client.EngineClient) (*GethNode, error) {
 	var (
 		ttd = s.TerminalTotalDifficulty
 		err error

--- a/simulators/ethereum/engine/helper/helper.go
+++ b/simulators/ethereum/engine/helper/helper.go
@@ -30,7 +30,36 @@ import (
 	"github.com/ethereum/hive/hivesim"
 )
 
-// From ethereum/rpc:
+type ClientTypeCombinator []*hivesim.ClientDefinition
+
+func (all ClientTypeCombinator) Combinations() [][]*hivesim.ClientDefinition {
+	ret := make([][]*hivesim.ClientDefinition, 0)
+	if len(all) == 1 {
+		ret = append(ret, all)
+		return ret
+	}
+	for i := 0; i < len(all); i++ {
+		for j := 0; j < len(all); j++ {
+			if i == j {
+				continue
+			}
+			comb := []*hivesim.ClientDefinition{
+				all[i],
+				all[j],
+			}
+			ret = append(ret, comb)
+		}
+	}
+	return ret
+}
+
+func ClientTypesNames(c []*hivesim.ClientDefinition) string {
+	var names []string
+	for _, t := range c {
+		names = append(names, t.Name)
+	}
+	return strings.Join(names, "/")
+}
 
 // LoggingRoundTrip writes requests and responses to the test log.
 type LogF interface {

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -51,6 +51,11 @@ func main() {
 			Description: `
 	Test Engine API withdrawals, pre/post Shanghai.`[1:],
 		}
+		withdrawalsSync = hivesim.Suite{
+			Name: "engine-withdrawals-sync",
+			Description: `
+	Test Engine API withdrawals sync, pre/post Shanghai.`[1:],
+		}
 	)
 
 	simulator := hivesim.New()
@@ -61,6 +66,7 @@ func main() {
 	addTestsToSuite(simulator, &excap, specToInterface(suite_ex_cap.Tests), "full")
 	//suite_sync.AddSyncTestsToSuite(simulator, &sync, suite_sync.Tests)
 	addTestsToSuite(simulator, &withdrawals, suite_withdrawals.Tests, "full")
+	addTestsToSuite(simulator, &withdrawalsSync, suite_withdrawals.SyncTests, "full")
 
 	// Mark suites for execution
 	hivesim.MustRunSuite(simulator, engine)
@@ -69,6 +75,7 @@ func main() {
 	hivesim.MustRunSuite(simulator, excap)
 	hivesim.MustRunSuite(simulator, sync)
 	hivesim.MustRunSuite(simulator, withdrawals)
+	hivesim.MustRunSuite(simulator, withdrawalsSync)
 }
 
 func specToInterface(src []test.Spec) []test.SpecInterface {

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -142,8 +142,9 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 				if len(clientTypes) == 0 {
 					panic(fmt.Errorf("client types length zero"))
 				}
+				clientTypesNames := helper.ClientTypesNames(clientTypes)
 				suite.Add(hivesim.TestSpec{
-					Name:        fmt.Sprintf("%s (%s)", currentTest.GetName(), helper.ClientTypesNames(clientTypes)),
+					Name:        fmt.Sprintf("%s (%s)", currentTest.GetName(), clientTypesNames),
 					Description: currentTest.GetAbout(),
 					Run: func(t *hivesim.T) {
 						// Start the client with given options
@@ -153,9 +154,9 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 							genesisStartOption,
 							hivesim.WithStaticFiles(testFiles),
 						)
-						t.Logf("Start test (%s): %s", c.Type, currentTest.GetName())
+						t.Logf("Start test: %s (%s)", currentTest.GetName(), clientTypesNames)
 						defer func() {
-							t.Logf("End test (%s): %s", c.Type, currentTest.GetName())
+							t.Logf("End test: %s (%s)", currentTest.GetName(), clientTypesNames)
 						}()
 						timeout := globals.DefaultTestCaseTimeout
 						// If a test.Spec specifies a timeout, use that instead

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -129,15 +129,19 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 			newParams = newParams.Set("HIVE_POST_MERGE_GENESIS", "true")
 		}
 
-		if clientTypes, err := sim.ClientTypes(); err == nil {
-			for _, clientType := range clientTypes {
+		if allClientTypes, err := sim.ClientTypes(); err == nil {
+			for _, combination := range helper.ClientTypeCombinator(allClientTypes).Combinations() {
+				clientTypes := combination
+				if len(clientTypes) == 0 {
+					panic(fmt.Errorf("client types length zero"))
+				}
 				suite.Add(hivesim.TestSpec{
-					Name:        fmt.Sprintf("%s (%s)", currentTest.GetName(), clientType.Name),
+					Name:        fmt.Sprintf("%s (%s)", currentTest.GetName(), helper.ClientTypesNames(clientTypes)),
 					Description: currentTest.GetAbout(),
 					Run: func(t *hivesim.T) {
 						// Start the client with given options
 						c := t.StartClient(
-							clientType.Name,
+							clientTypes[0].Name,
 							newParams,
 							genesisStartOption,
 							hivesim.WithStaticFiles(testFiles),
@@ -158,6 +162,7 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 							timeout,
 							t,
 							c,
+							clientTypes,
 							genesis,
 							newParams,
 							testFiles,

--- a/simulators/ethereum/engine/suites/engine/tests.go
+++ b/simulators/ethereum/engine/suites/engine/tests.go
@@ -1711,7 +1711,7 @@ func invalidPayloadTestCaseGen(payloadField helper.InvalidPayloadBlockField, syn
 
 		if syncing {
 			// To allow sending the primary engine client into SYNCING state, we need a secondary client to guide the payload creation
-			secondaryClient, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
+			secondaryClient, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
 			if err != nil {
 				t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
 			}
@@ -2101,9 +2101,9 @@ func (spec InvalidMissingAncestorReOrgSpec) GenerateSync() func(*test.Env) {
 		}
 		if spec.ReOrgFromCanonical {
 			// If we are doing a re-org from canonical, we can add both nodes as peers from the start
-			secondaryClient, err = starter.StartGethNode(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
+			secondaryClient, err = starter.StartGethNode(t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
 		} else {
-			secondaryClient, err = starter.StartGethNode(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
+			secondaryClient, err = starter.StartGethNode(t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
 		}
 		if err != nil {
 			t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
@@ -3273,7 +3273,7 @@ func inOrderPayloads(t *test.Env) {
 	r.ExpectBalanceEqual(expectedBalance)
 
 	// Start a second client to send newPayload consecutively without fcU
-	secondaryClient, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
+	secondaryClient, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
 	if err != nil {
 		t.Fatalf("FAIL (%s): Unable to start secondary client: %v", t.TestName, err)
 	}
@@ -3325,7 +3325,7 @@ func validPayloadFcUSyncingClient(t *test.Env) {
 	{
 		// To allow sending the primary engine client into SYNCING state, we need a secondary client to guide the payload creation
 		var err error
-		secondaryClient, err = hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
+		secondaryClient, err = hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
 
 		if err != nil {
 			t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
@@ -3409,7 +3409,7 @@ func missingFcu(t *test.Env) {
 
 	var secondaryEngineTest *test.TestEngineClient
 	{
-		secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
+		secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
 
 		if err != nil {
 			t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
@@ -3450,7 +3450,7 @@ func missingFcu(t *test.Env) {
 // P <- INV_P, newPayload(INV_P), fcU(head: P, payloadAttributes: attrs) + getPayload(…)
 func payloadBuildAfterNewInvalidPayload(t *test.Env) {
 	// Add a second client to build the invalid payload
-	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
+	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles)
 
 	if err != nil {
 		t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)

--- a/simulators/ethereum/engine/suites/sync/tests.go
+++ b/simulators/ethereum/engine/suites/sync/tests.go
@@ -99,7 +99,7 @@ func AddSyncTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []
 						}
 
 						// Run the test case
-						test.Run(currentTest, big.NewInt(ttd), timeout, t, c, &genesis, syncClientParams, testFiles.Copy())
+						test.Run(currentTest, big.NewInt(ttd), timeout, t, c, clientDefs, &genesis, syncClientParams, testFiles.Copy())
 					},
 				})
 			}
@@ -127,7 +127,7 @@ func postMergeSync(t *test.Env) {
 	// Reset block production delay
 	t.CLMock.PayloadProductionClientDelay = time.Second
 
-	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams.Set("HIVE_MINER", ""), t.ClientFiles, t.Engine)
+	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams.Set("HIVE_MINER", ""), t.ClientFiles, t.Engine)
 	if err != nil {
 		t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
 	}
@@ -183,7 +183,7 @@ func incrementalPostMergeSync(t *test.Env) {
 	// Reset block production delay
 	t.CLMock.PayloadProductionClientDelay = time.Second
 
-	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams.Set("HIVE_MINER", ""), t.ClientFiles, t.Engine)
+	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams.Set("HIVE_MINER", ""), t.ClientFiles, t.Engine)
 	if err != nil {
 		t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
 	}

--- a/simulators/ethereum/engine/suites/transition/tests.go
+++ b/simulators/ethereum/engine/suites/transition/tests.go
@@ -946,7 +946,7 @@ func GenerateMergeTestSpec(mergeTestSpec MergeTestSpec) test.Spec {
 
 		for i, secondaryClientSpec := range mergeTestSpec.SecondaryClientSpecs {
 			// Start the secondary client with the alternative chain
-			secondaryClient, err := secondaryClientSpec.ClientStarter.StartClient(t.T, t.CLMock.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
+			secondaryClient, err := secondaryClientSpec.ClientStarter.StartClient(t, t.CLMock.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
 			t.Logf("INFO (%s): Started secondary client: %v", t.TestName, secondaryClient.ID())
 			if err != nil {
 				t.Fatalf("FAIL (%s): Unable to start secondary client: %v", t.TestName, err)

--- a/simulators/ethereum/engine/suites/withdrawals/README.md
+++ b/simulators/ethereum/engine/suites/withdrawals/README.md
@@ -38,6 +38,12 @@ All test cases contain the following verifications:
   - Withdraw to a single account 16 times each block for 2 blocks
   - Spawn a secondary client and send FCUV2(head)
   - Wait for sync and verify withdrawn account's balance
+- Sync after 2 blocks - Shanghai on Block 1 - No Withdrawals - No Transactions:
+  - Spawn a first client
+  - Go through Shanghai fork on Block 1
+  - Do no withdrawals each block for 2 blocks
+  - Spawn a secondary client and send FCUV2(head)
+  - Wait for sync and verify accounts' balances
 - Sync after 2 blocks - Shanghai on Block 1 - Single Withdrawal Account:
   - Spawn a first client
   - Go through Shanghai fork on Block 1
@@ -54,19 +60,19 @@ All test cases contain the following verifications:
   - Go through Shanghai fork on Block 2
   - Withdraw to 16 accounts each block for 2 blocks
   - Spawn a secondary client and send FCUV2(head)
-  - Wait for sync and verify withdrawn account's balance
+  - Wait for sync and verify withdrawn accounts' balances
 - Sync after 2 blocks - Shanghai on Block 2 - Multiple Withdrawal Accounts:
   - Spawn a first client
   - Go through Shanghai fork on Block 2
   - Withdraw to 16 accounts each block for 2 blocks
   - Spawn a secondary client and send FCUV2(head)
-  - Wait for sync and verify withdrawn account's balance
+  - Wait for sync and verify withdrawn accounts' balances
 - Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts:
   - Spawn a first client
   - Go through Shanghai fork on Block 2
   - Withdraw to many accounts 16 times each block for 128 blocks
   - Spawn a secondary client and send FCUV2(head)
-  - Wait for sync and verify withdrawn account's balance
+  - Wait for sync and verify withdrawn accounts' balances
 - [NOT IMPLEMENTED] Error Syncing Null Withdrawals Block after Shanghai:
   - Spawn a first client with configuration `shanghaiTime==2`
   - Send Block 1 with `timestamp==1`

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -1418,7 +1418,7 @@ func (ws *WithdrawalsSyncSpec) Execute(t *test.Env) {
 	ws.WithdrawalsBaseSpec.Execute(t)
 
 	// Spawn a secondary client which will need to sync to the primary client
-	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
+	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
 	if err != nil {
 		t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
 	}
@@ -1508,7 +1508,7 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 	t.CLMock.WaitForTTD()
 
 	// Spawn a secondary client which will produce the sidechain
-	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
+	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
 	if err != nil {
 		t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
 	}
@@ -2052,7 +2052,7 @@ func (ws *GetPayloadBodiesSpec) Execute(t *test.Env) {
 		n2.ExpectStatus(test.Valid)
 	} else if ws.AfterSync {
 		// Spawn a secondary client which will need to sync to the primary client
-		secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
+		secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
 		if err != nil {
 			t.Fatalf("FAIL (%s): Unable to spawn a secondary client: %v", t.TestName, err)
 		}

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -198,125 +198,6 @@ var Tests = []test.SpecInterface{
 		},
 	},
 
-	// Sync Tests
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account - No Transactions",
-				About: `
-			- Spawn a first client
-			- Go through withdrawals fork on Block 1
-			- Withdraw to a single account 16 times each block for 2 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync and verify withdrawn account's balance
-			`,
-				TimeoutSeconds: 6000,
-			},
-			WithdrawalsForkHeight:    1,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 1,
-			TransactionsPerBlock:     common.Big0,
-		},
-		SyncSteps: 1,
-	},
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account",
-				About: `
-			- Spawn a first client
-			- Go through withdrawals fork on Block 1
-			- Withdraw to a single account 16 times each block for 2 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync and verify withdrawn account's balance
-			`,
-			},
-			WithdrawalsForkHeight:    1,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 1,
-		},
-		SyncSteps: 1,
-	},
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Genesis - Single Withdrawal Account",
-				About: `
-			- Spawn a first client, with Withdrawals since genesis
-			- Withdraw to a single account 16 times each block for 2 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync and verify withdrawn account's balance
-			`,
-			},
-			WithdrawalsForkHeight:    0,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 1,
-		},
-		SyncSteps: 1,
-	},
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions",
-				About: `
-			- Spawn a first client
-			- Go through withdrawals fork on Block 2
-			- Withdraw to 16 accounts each block for 2 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
-			`,
-			},
-			WithdrawalsForkHeight:    2,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 16,
-			TransactionsPerBlock:     common.Big0,
-		},
-		SyncSteps: 1,
-	},
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts",
-				About: `
-			- Spawn a first client
-			- Go through withdrawals fork on Block 2
-			- Withdraw to 16 accounts each block for 2 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
-			`,
-			},
-			WithdrawalsForkHeight:    2,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 16,
-		},
-		SyncSteps: 1,
-	},
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts",
-				About: `
-			- Spawn a first client
-			- Go through withdrawals fork on Block 2
-			- Withdraw to many accounts 16 times each block for 128 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
-			`,
-				TimeoutSeconds: 300,
-			},
-			WithdrawalsForkHeight:    2,
-			WithdrawalsBlockCount:    128,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 1024,
-		},
-		SyncSteps: 1,
-	},
-
 	//Re-Org tests
 	&WithdrawalsReorgSpec{
 		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
@@ -769,6 +650,145 @@ var Tests = []test.SpecInterface{
 				End:   17,
 			},
 		},
+	},
+}
+
+var SyncTests = []test.SpecInterface{
+	// Sync Tests
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account - No Transactions",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 1
+			- Withdraw to a single account 16 times each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync and verify withdrawn account's balance
+			`,
+				TimeoutSeconds: 6000,
+			},
+			WithdrawalsForkHeight:    1,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 1,
+			TransactionsPerBlock:     common.Big0,
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 1
+			- Withdraw to a single account 16 times each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync and verify withdrawn account's balance
+			`,
+			},
+			WithdrawalsForkHeight:    1,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 1,
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 2 blocks - Withdrawals on Genesis - Single Withdrawal Account",
+				About: `
+			- Spawn a first client, with Withdrawals since genesis
+			- Withdraw to a single account 16 times each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync and verify withdrawn account's balance
+			`,
+			},
+			WithdrawalsForkHeight:    0,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 1,
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 3 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 2
+			- Withdraw to 16 accounts each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
+			`,
+			},
+			WithdrawalsForkHeight:    2,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 16,
+			TransactionsPerBlock:     common.Big0,
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 3 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 2
+			- Withdraw to 16 accounts each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
+			`,
+			},
+			WithdrawalsForkHeight:    2,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 16,
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 3 blocks - Withdrawals on Block 2 - No Withdrawals",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 2
+			- Withdraw to 16 accounts each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
+			`,
+			},
+			WithdrawalsForkHeight: 2,
+			WithdrawalsBlockCount: 2,
+			WithdrawalsPerBlock:   0,
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 2
+			- Withdraw to many accounts 16 times each block for 128 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
+			`,
+				TimeoutSeconds: 300,
+			},
+			WithdrawalsForkHeight:    2,
+			WithdrawalsBlockCount:    128,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 1024,
+		},
+		SyncSteps: 1,
 	},
 }
 

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -679,6 +679,27 @@ var SyncTests = []test.SpecInterface{
 	&WithdrawalsSyncSpec{
 		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 			Spec: test.Spec{
+				Name: "Sync after 2 blocks - Withdrawals on Block 1 - No Withdrawals - No Transactions",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 1
+			- Do no withdrawals each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync and verify accounts' balances
+			`,
+				TimeoutSeconds: 300,
+			},
+			WithdrawalsForkHeight:    1,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      0,
+			WithdrawableAccountCount: 1,
+			TransactionsPerBlock:     common.Big0,
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
 				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account",
 				About: `
 			- Spawn a first client

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -778,6 +778,26 @@ var SyncTests = []test.SpecInterface{
 	&WithdrawalsSyncSpec{
 		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 			Spec: test.Spec{
+				Name: "Sync after 17 blocks - Withdrawals on Block 2 - Alternating Empty Withdrawals - No Transactions",
+				About: `
+			- Spawn a first client
+			- Go through withdrawals fork on Block 2
+			- Withdraw to 16 accounts each block for 2 blocks
+			- Spawn a secondary client and send FCUV2(head)
+			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
+			`,
+				TimeoutSeconds: 300,
+			},
+			WithdrawalsForkHeight:      2,
+			WithdrawalsBlockCount:      16,
+			TransactionsPerBlock:       big.NewInt(0),
+			WithdrawalsPerBlockOptions: []uint64{16, 0},
+		},
+		SyncSteps: 1,
+	},
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
 				Name: "Sync after 17 blocks - Withdrawals on Block 2 - Alternating Empty Withdrawals",
 				About: `
 			- Spawn a first client
@@ -1498,7 +1518,7 @@ func (ws *WithdrawalsSyncSpec) Execute(t *test.Env) {
 					break loop
 				}
 				if r.Response.PayloadStatus.Status == test.Invalid {
-					t.Fatalf("FAIL (%s): Syncing client rejected valid chain: %s", t.TestName, r.Response)
+					t.Fatalf("FAIL (%s): Syncing client rejected valid chain: %v", t.TestName, r.Response)
 				}
 			}
 		}


### PR DESCRIPTION
Creates suite `engine-withdrawals-sync`, which contains all syncing withdrawals tests from `engine-withdrawals` (thus tests are removed from this suite), and allows running the tests with all possible combinations.
For example, using
```
hive --client go-ethereum,nethermind,erigon --sim ethereum/engine --sim.limit "engine-withdrawals-sync/"
```
Will run the following sync tests:
- Nethermind syncing from Go-ethereum
- Erigon syncing from Go-ethereum
- Go-ethereum syncing from Nethermind
- Erigon syncing from Nethermind
- Go-ethereum syncing from Erigon
- Nethermind syncing from Erigon

Also adds test case where the client has to sync blocks with empty withdrawals list and empty transactions.