### PR TITLE
simulators/ethereum/engine: Fix sending test transactions in batch

### DIFF
--- a/simulators/ethereum/engine/client/engine.go
+++ b/simulators/ethereum/engine/client/engine.go
@@ -21,6 +21,7 @@ type Eth interface {
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	SendTransaction(ctx context.Context, tx *types.Transaction) error
+	SendTransactions(ctx context.Context, txs []*types.Transaction) []error
 	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
@@ -55,6 +56,7 @@ type EngineClient interface {
 
 	// Local Test Account Management
 	GetNextAccountNonce(testCtx context.Context, account common.Address) (uint64, error)
+	UpdateNonce(testCtx context.Context, account common.Address, newNonce uint64) error
 
 	// TTD Methods
 	TerminalTotalDifficulty() *big.Int

--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -803,6 +803,16 @@ func (n *GethNode) SendTransaction(ctx context.Context, tx *types.Transaction) e
 	return n.eth.APIBackend.SendTx(ctx, tx)
 }
 
+func (n *GethNode) SendTransactions(ctx context.Context, txs []*types.Transaction) []error {
+	for _, tx := range txs {
+		err := n.eth.APIBackend.SendTx(ctx, tx)
+		if err != nil {
+			return []error{err}
+		}
+	}
+	return nil
+}
+
 func (n *GethNode) getStateDB(ctx context.Context, blockNumber *big.Int) (*state.StateDB, error) {
 	b, err := n.eth.APIBackend.BlockByNumber(ctx, parseBlockNumber(blockNumber))
 	if err != nil {
@@ -897,6 +907,19 @@ func (n *GethNode) GetNextAccountNonce(testCtx context.Context, account common.A
 		PreviousNonce: nonce,
 	}
 	return nonce, nil
+}
+
+func (n *GethNode) UpdateNonce(testCtx context.Context, account common.Address, newNonce uint64) error {
+	// First get the current head of the client where we will send the tx
+	head, err := n.eth.APIBackend.BlockByNumber(testCtx, LatestBlockNumber)
+	if err != nil {
+		return err
+	}
+	n.accTxInfoMap[account] = &AccountTransactionInfo{
+		PreviousBlock: head.Hash(),
+		PreviousNonce: newNonce,
+	}
+	return nil
 }
 
 func (n *GethNode) PostRunVerifications() error {

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -1553,24 +1553,24 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 		},
 		OnRequestNextPayload: func() {
 			// Send transactions to be included in the payload
-			for i := uint64(0); i < ws.GetTransactionCountPerPayload(); i++ {
-				tx, err := helper.SendNextTransaction(
-					t.TestContext,
-					t.CLMock.NextBlockProducer,
-					&helper.BaseTransactionCreator{
-						Recipient: &globals.PrevRandaoContractAddr,
-						Amount:    common.Big1,
-						Payload:   nil,
-						TxType:    t.TestTransactionType,
-						GasLimit:  75000,
-					},
-				)
-				if err != nil {
-					t.Fatalf("FAIL (%s): Error trying to send transaction: %v", t.TestName, err)
-				}
-				// Error will be ignored here since the tx could have been already relayed
-				secondaryEngine.SendTransaction(t.TestContext, tx)
+			txs, err := helper.SendNextTransactions(
+				t.TestContext,
+				t.CLMock.NextBlockProducer,
+				&helper.BaseTransactionCreator{
+					Recipient: &globals.PrevRandaoContractAddr,
+					Amount:    common.Big1,
+					Payload:   nil,
+					TxType:    t.TestTransactionType,
+					GasLimit:  75000,
+				},
+				ws.GetTransactionCountPerPayload(),
+			)
+			if err != nil {
+				t.Fatalf("FAIL (%s): Error trying to send transactions: %v", t.TestName, err)
 			}
+
+			// Error will be ignored here since the tx could have been already relayed
+			secondaryEngine.SendTransactions(t.TestContext, txs)
 
 			if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainSplitHeight() {
 				// Also request a payload from the sidechain

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -327,6 +327,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 16,
@@ -345,6 +346,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 16,
@@ -363,6 +365,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 16,
@@ -382,6 +385,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 8,
@@ -401,6 +405,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 8,
@@ -420,6 +425,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 8,
@@ -440,6 +446,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 8,
@@ -460,6 +467,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 8,
@@ -481,6 +489,7 @@ var Tests = []test.SpecInterface{
 				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
 			},
 			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 8,


### PR DESCRIPTION
## Changes included
- Test transactions are now sent in batch for the withdrawals re-org tests, which leads to faster execution times
- Re-Org tests now have a higher timeout limit (EthereumJS was failing the tests only due to timeout)