### PR TITLE
clients/besu: fix clique mining

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -99,7 +99,7 @@ if [ -d /blocks ]; then
     IMPORTFLAGS="$IMPORTFLAGS $blocks"
 fi
 
-if [ "$HIVE_BOOTNODE" != "" ]; then
+if [ "$HIVE_BOOTNODE" == "" ]; then
     # Configure mining.
     if [ "$HIVE_MINER" != "" ]; then
         FLAGS="$FLAGS --miner-enabled --miner-coinbase=$HIVE_MINER"


### PR DESCRIPTION
Reverse the logic to deploy clique key to bootnode only. 
This commit https://github.com/ethereum/hive/commit/104c1851ce7890a605de2b9123835074d7c14ff3 introduced an additional check to prevent deploying the same private key to a second node. Accidentally ended up stopping the deployment of the key for the first node which prevents besu from mining a block using clique and broke a couple of the RPC suite tests.
Please kindly review that and let me know if there's any additional changes required.
This change  has been tested running hive locally and fixes the RPC suite. Didn't detect any new regression