### PR TITLE
clients/lodestar-bn: Fix Log Level

### DIFF
--- a/clients/lodestar-bn/lodestar_bn.sh
+++ b/clients/lodestar-bn/lodestar_bn.sh
@@ -21,6 +21,7 @@ echo "${HIVE_ETH2_CONFIG_DEPOSIT_CONTRACT_ADDRESS:-0x111111111111111111111111111
 mkdir -p /data/beacon
 mkdir -p /data/network
 
+LOG=info
 case "$HIVE_LOGLEVEL" in
     0|1) LOG=error ;;
     2)   LOG=warn  ;;
@@ -28,7 +29,6 @@ case "$HIVE_LOGLEVEL" in
     4)   LOG=debug ;;
     5)   LOG=silly ;;
 esac
-LOG=debug
 
 echo "bootnodes: ${HIVE_ETH2_BOOTNODE_ENRS}"
 

--- a/clients/lodestar-bn/lodestar_bn.sh
+++ b/clients/lodestar-bn/lodestar_bn.sh
@@ -27,7 +27,7 @@ case "$HIVE_LOGLEVEL" in
     2)   LOG=warn  ;;
     3)   LOG=info  ;;
     4)   LOG=debug ;;
-    5)   LOG=silly ;;
+    5)   LOG=trace ;;
 esac
 
 echo "bootnodes: ${HIVE_ETH2_BOOTNODE_ENRS}"


### PR DESCRIPTION
## Changes Included
Lodestar start script contained an erroneously hard-coded log level of `DEBUG`.