### PR TITLE
internal/libdocker: buffered capture of client logs

### DIFF
--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -421,9 +421,9 @@ func (b *ContainerBackend) attachLogs(ctx context.Context, logger log15.Logger, 
 		OutputStream: log,
 		ErrorStream:  log,
 		Follow:       true,
-		Timestamps:   true,
 		Stdout:       true,
 		Stderr:       true,
+		// Timestamps:   true,
 	}
 	var wg wgCloseWaiter
 	wg.Add(1)

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -417,7 +417,6 @@ func (b *ContainerBackend) attachLogs(ctx context.Context, logger log15.Logger, 
 	closer.addFile(log)
 
 	logopt := docker.LogsOptions{
-		Context:      ctx,
 		Container:    id,
 		OutputStream: log,
 		ErrorStream:  log,

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -98,6 +98,16 @@ func (b *ContainerBackend) CreateContainer(ctx context.Context, imageName string
 		// but it's probably best to give Docker the info as early as possible.
 		createOpts.Config.AttachStdout = true
 	}
+	if opt.LogFile != "" {
+		createOpts.HostConfig = &docker.HostConfig{
+			LogConfig: docker.LogConfig{
+				Config: map[string]string{
+					"mode":            "non-blocking",
+					"max-buffer-size": "4m",
+				},
+			},
+		}
+	}
 
 	c, err := b.client.CreateContainer(createOpts)
 	if err != nil {


### PR DESCRIPTION
This is an experiment to capture client logs using the equivalent of the `docker logs` command. Using the docker log system instead of attaching to the container should improve the performance of clients when they print lots of output. It also allows timestamping of output.
