### PR TITLE
simulators/eth2/withdrawals: Withdrawals Tests Fixes

### DIFF
--- a/simulators/eth2/common/clients/beacon.go
+++ b/simulators/eth2/common/clients/beacon.go
@@ -98,6 +98,11 @@ func (bn *BeaconClient) Start(extraOptions ...hivesim.StartOption) error {
 		Cli:   &http.Client{},
 		Codec: eth2api.JSONCodec{},
 	}
+	bn.T.Logf(
+		"Started client %s, container: %s",
+		bn.ClientType,
+		bn.HiveClient.Container,
+	)
 	return nil
 }
 

--- a/simulators/eth2/common/clients/beacon.go
+++ b/simulators/eth2/common/clients/beacon.go
@@ -38,9 +38,7 @@ const (
 	PortValidatorAPI = 5000
 )
 
-var (
-	EMPTY_TREE_ROOT = tree.Root{}
-)
+var EMPTY_TREE_ROOT = tree.Root{}
 
 type BeaconClient struct {
 	T                     *hivesim.T
@@ -582,6 +580,24 @@ func (vbs *VersionedBeaconStateResponse) LatestExecutionPayloadHeaderHash() tree
 		return state.LatestExecutionPayloadHeader.BlockHash
 	}
 	panic("badly formatted beacon state")
+}
+
+func (vbs *VersionedBeaconStateResponse) NextWithdrawalIndex() (common.WithdrawalIndex, error) {
+	var wIndex common.WithdrawalIndex
+	switch state := vbs.Data.(type) {
+	case *capella.BeaconState:
+		wIndex = state.NextWithdrawalIndex
+	}
+	return wIndex, nil
+}
+
+func (vbs *VersionedBeaconStateResponse) NextWithdrawalValidatorIndex() (common.ValidatorIndex, error) {
+	var wIndex common.ValidatorIndex
+	switch state := vbs.Data.(type) {
+	case *capella.BeaconState:
+		wIndex = state.NextWithdrawalValidatorIndex
+	}
+	return wIndex, nil
 }
 
 func (vbs *VersionedBeaconStateResponse) NextWithdrawals(

--- a/simulators/eth2/common/clients/beacon.go
+++ b/simulators/eth2/common/clients/beacon.go
@@ -445,6 +445,20 @@ type VersionedBeaconStateResponse struct {
 	spec *common.Spec
 }
 
+func (vbs *VersionedBeaconStateResponse) Root() tree.Root {
+	switch state := vbs.Data.(type) {
+	case *phase0.BeaconState:
+		return state.HashTreeRoot(vbs.spec, tree.GetHashFn())
+	case *altair.BeaconState:
+		return state.HashTreeRoot(vbs.spec, tree.GetHashFn())
+	case *bellatrix.BeaconState:
+		return state.HashTreeRoot(vbs.spec, tree.GetHashFn())
+	case *capella.BeaconState:
+		return state.HashTreeRoot(vbs.spec, tree.GetHashFn())
+	}
+	panic("badly formatted beacon state")
+}
+
 func (vbs *VersionedBeaconStateResponse) CurrentVersion() common.Version {
 	switch state := vbs.Data.(type) {
 	case *phase0.BeaconState:

--- a/simulators/eth2/common/clients/beacon.go
+++ b/simulators/eth2/common/clients/beacon.go
@@ -226,6 +226,14 @@ func (versionedBlock *VersionedSignedBeaconBlock) ExecutionPayload() (api.Execut
 	return result, nil
 }
 
+func (versionedBlock *VersionedSignedBeaconBlock) Withdrawals() (common.Withdrawals, error) {
+	switch v := versionedBlock.Data.(type) {
+	case *capella.SignedBeaconBlock:
+		return v.Message.Body.ExecutionPayload.Withdrawals, nil
+	}
+	return nil, nil
+}
+
 func (b *VersionedSignedBeaconBlock) StateRoot() tree.Root {
 	switch v := b.Data.(type) {
 	case *phase0.SignedBeaconBlock:

--- a/simulators/eth2/common/clients/execution.go
+++ b/simulators/eth2/common/clients/execution.go
@@ -123,6 +123,11 @@ func (en *ExecutionClient) Start(extraOptions ...hivesim.StartOption) error {
 	opts = append(opts, extraOptions...)
 
 	en.HiveClient = en.T.StartClient(en.ClientType, opts...)
+	en.T.Logf(
+		"Started client %s, container: %s",
+		en.ClientType,
+		en.HiveClient.Container,
+	)
 
 	// Prepare Eth/Engine RPCs
 	engineRPCAddress, err := en.EngineRPCAddress()

--- a/simulators/eth2/common/clients/validator.go
+++ b/simulators/eth2/common/clients/validator.go
@@ -58,6 +58,11 @@ func (vc *ValidatorClient) Start(extraOptions ...hivesim.StartOption) error {
 	}
 
 	vc.HiveClient = vc.T.StartClient(vc.ClientType, opts...)
+	vc.T.Logf(
+		"Started client %s, container: %s",
+		vc.ClientType,
+		vc.HiveClient.Container,
+	)
 	return nil
 }
 

--- a/simulators/eth2/common/config/execution/execution_config.go
+++ b/simulators/eth2/common/config/execution/execution_config.go
@@ -126,6 +126,26 @@ func (c ExecutionPreChain) SecondsPerBlock() uint64 {
 	return 1
 }
 
+// A pre-existing chain is imported by the client, and it is not
+// expected that the client mines or produces any blocks.
+type ExecutionPostMergeGenesis struct{}
+
+func (c ExecutionPostMergeGenesis) Configure(*ExecutionGenesis) error {
+	return nil
+}
+
+func (c ExecutionPostMergeGenesis) HiveParams(node int) hivesim.Params {
+	return hivesim.Params{}
+}
+
+func (c ExecutionPostMergeGenesis) DifficultyPerBlock() *big.Int {
+	return big.NewInt(0)
+}
+
+func (c ExecutionPostMergeGenesis) SecondsPerBlock() uint64 {
+	return 12
+}
+
 type ExecutionCliqueConsensus struct {
 	CliquePeriod uint64
 	PrivateKey   string

--- a/simulators/eth2/withdrawals/helper.go
+++ b/simulators/eth2/withdrawals/helper.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -148,6 +149,32 @@ func (c BeaconCache) GetBlockStateBySlotFromHeadRoot(
 			return nil, err
 		}
 	}
+}
+
+func PrintWithdrawalHistory(c BeaconCache) error {
+	slotMap := make(map[beacon.Slot]tree.Root)
+	slots := make([]beacon.Slot, 0)
+	for r, s := range c {
+		slot := s.StateSlot()
+		slotMap[slot] = r
+		slots = append(slots, slot)
+	}
+
+	sort.Slice(slots, func(i, j int) bool { return slots[j] > slots[i] })
+
+	for _, slot := range slots {
+		root := slotMap[slot]
+		s := c[root]
+		nextWithdrawalIndex, _ := s.NextWithdrawalIndex()
+		nextWithdrawalValidatorIndex, _ := s.NextWithdrawalValidatorIndex()
+		fmt.Printf(
+			"Slot=%d, NextWithdrawalIndex=%d, NextWithdrawalValidatorIndex=%d\n",
+			slot,
+			nextWithdrawalIndex,
+			nextWithdrawalValidatorIndex,
+		)
+	}
+	return nil
 }
 
 // Helper struct to keep track of current status of a validator withdrawal state

--- a/simulators/eth2/withdrawals/helper.go
+++ b/simulators/eth2/withdrawals/helper.go
@@ -173,6 +173,16 @@ func PrintWithdrawalHistory(c BeaconCache) error {
 			nextWithdrawalIndex,
 			nextWithdrawalValidatorIndex,
 		)
+		fmt.Printf("Withdrawals:\n")
+		ws, _ := s.Withdrawals()
+		for i, w := range ws {
+			fmt.Printf(
+				"%d: Validator Index: %s, Amount: %d\n",
+				i,
+				w.ValidatorIndex,
+				w.Amount,
+			)
+		}
 	}
 	return nil
 }

--- a/simulators/eth2/withdrawals/scenarios.go
+++ b/simulators/eth2/withdrawals/scenarios.go
@@ -231,6 +231,7 @@ loop:
 	for {
 		select {
 		case <-slotCtx.Done():
+			PrintWithdrawalHistory(allValidators[0].BlockStateCache)
 			t.Fatalf("FAIL: Timeout waiting on all accounts to withdraw")
 		case <-time.After(time.Duration(testnet.Spec().SECONDS_PER_SLOT) * time.Second):
 			// Print all info
@@ -255,6 +256,8 @@ loop:
 			}
 		}
 	}
+
+	PrintWithdrawalHistory(allValidators[0].BlockStateCache)
 
 	// Lastly check all clients are on the same head
 	testnet.VerifyELHeads(ctx)

--- a/simulators/eth2/withdrawals/scenarios.go
+++ b/simulators/eth2/withdrawals/scenarios.go
@@ -165,9 +165,9 @@ func (ts BaseWithdrawalsTestSpec) Execute(
 	// Get the beacon state and verify the credentials were updated
 	var versionedBeaconState *clients.VersionedBeaconStateResponse
 	for _, bn := range testnet.BeaconClients().Running() {
-		versionedBeaconState, err = bn.BeaconStateV2ByBlock(
+		versionedBeaconState, err = bn.BeaconStateV2(
 			ctx,
-			eth2api.BlockHead,
+			eth2api.StateHead,
 		)
 		if err != nil || versionedBeaconState == nil {
 			t.Logf("WARN: Unable to get latest beacon state: %v", err)

--- a/simulators/eth2/withdrawals/specs.go
+++ b/simulators/eth2/withdrawals/specs.go
@@ -59,7 +59,7 @@ var (
 		AltairForkEpoch:         common.Big0,
 		BellatrixForkEpoch:      common.Big0,
 		CapellaForkEpoch:        common.Big1,
-		Eth1Consensus:           &el.ExecutionCliqueConsensus{},
+		Eth1Consensus:           &el.ExecutionPostMergeGenesis{},
 	}
 
 	MINIMAL_SLOT_TIME_CLIENTS = []string{

--- a/simulators/eth2/withdrawals/specs.go
+++ b/simulators/eth2/withdrawals/specs.go
@@ -204,8 +204,9 @@ func (ts BaseWithdrawalsTestSpec) GetValidatorKeys(
 	}
 
 	for index, key := range keys {
-		// All validators have idiosyncratic balance amounts to identify them
-		key.ExtraInitialBalance = beacon.Gwei(index+1) + ts.ExtraGwei
+		// All validators have idiosyncratic balance amounts to identify them.
+		// Also include a high amount in order to guarantee withdrawals.
+		key.ExtraInitialBalance = beacon.Gwei((index+1)*1000000) + ts.ExtraGwei
 
 		if ts.GenesisExecutionWithdrawalCredentialsShares > 0 &&
 			(index%ts.GenesisExecutionWithdrawalCredentialsShares) == 0 {


### PR DESCRIPTION
## Changes Included
- Fixes obtaining the beacon state from prysm, which only supports `/eth/v2/debug/beacon/states/{state_id}` where `state_id` is a slot number
- Fix Capella genesis tests by including the execution genesis as the previous execution payload header in the genesis beacon state
- Fix tests where withdrawals were not noticeable because of a decreasing balance (below the minimum withdraw balance of `MAX_EFFECTIVE_BALANCE`)