### PR TITLE
hivesim,libhive: add API to pause/unpause client containers

### DIFF
--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -173,6 +173,26 @@ func (sim *Simulation) StopClient(testSuite SuiteID, test TestID, nodeid string)
 	return err
 }
 
+// PauseClient signals to the host that the node needs to be paused.
+func (sim *Simulation) PauseClient(testSuite SuiteID, test TestID, nodeid string) error {
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/testsuite/%d/test/%d/node/%s/pause", sim.url, testSuite, test, nodeid), nil)
+	if err != nil {
+		return err
+	}
+	_, err = http.DefaultClient.Do(req)
+	return err
+}
+
+// UnpauseClient signals to the host that the node needs to be unpaused.
+func (sim *Simulation) UnpauseClient(testSuite SuiteID, test TestID, nodeid string) error {
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/testsuite/%d/test/%d/node/%s/pause", sim.url, testSuite, test, nodeid), nil)
+	if err != nil {
+		return err
+	}
+	_, err = http.DefaultClient.Do(req)
+	return err
+}
+
 // ClientEnodeURL returns the enode URL of a running client.
 func (sim *Simulation) ClientEnodeURL(testSuite SuiteID, test TestID, node string) (string, error) {
 	return sim.ClientEnodeURLNetwork(testSuite, test, node, "bridge")

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -170,6 +170,16 @@ func (c *Client) Exec(command ...string) (*ExecInfo, error) {
 	return c.test.Sim.ClientExec(c.test.SuiteID, c.test.TestID, c.Container, command)
 }
 
+// Pauses the client container.
+func (c *Client) Pause() error {
+	return c.test.Sim.PauseClient(c.test.SuiteID, c.test.TestID, c.Container)
+}
+
+// Unpauses the client container.
+func (c *Client) Unpause() error {
+	return c.test.Sim.UnpauseClient(c.test.SuiteID, c.test.TestID, c.Container)
+}
+
 // T is a running test. This is a lot like testing.T, but has some additional methods for
 // launching clients.
 //

--- a/internal/fakes/container.go
+++ b/internal/fakes/container.go
@@ -14,10 +14,12 @@ import (
 
 // BackendHooks can be used to override the behavior of the fake backend.
 type BackendHooks struct {
-	CreateContainer func(image string, opt libhive.ContainerOptions) (string, error)
-	StartContainer  func(image, containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error)
-	DeleteContainer func(containerID string) error
-	RunProgram      func(containerID string, cmd []string) (*libhive.ExecInfo, error)
+	CreateContainer  func(image string, opt libhive.ContainerOptions) (string, error)
+	StartContainer   func(image, containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error)
+	DeleteContainer  func(containerID string) error
+	PauseContainer   func(containerID string) error
+	UnpauseContainer func(containerID string) error
+	RunProgram       func(containerID string, cmd []string) (*libhive.ExecInfo, error)
 
 	NetworkNameToID     func(string) (string, error)
 	CreateNetwork       func(string) (string, error)
@@ -143,6 +145,20 @@ func (b *fakeBackend) DeleteContainer(containerID string) error {
 	delete(b.cimg, containerID)
 	b.mutex.Unlock()
 	return err
+}
+
+func (b *fakeBackend) PauseContainer(containerID string) error {
+	if b.hooks.PauseContainer != nil {
+		return b.hooks.PauseContainer(containerID)
+	}
+	return nil
+}
+
+func (b *fakeBackend) UnpauseContainer(containerID string) error {
+	if b.hooks.UnpauseContainer != nil {
+		return b.hooks.UnpauseContainer(containerID)
+	}
+	return nil
 }
 
 func (b *fakeBackend) RunProgram(ctx context.Context, containerID string, cmd []string) (*libhive.ExecInfo, error) {

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -202,6 +202,26 @@ func (b *ContainerBackend) DeleteContainer(containerID string) error {
 	return err
 }
 
+// PauseContainer pauses the given container.
+func (b *ContainerBackend) PauseContainer(containerID string) error {
+	b.logger.Debug("pausing container", "container", containerID[:8])
+	err := b.client.PauseContainer(containerID)
+	if err != nil {
+		b.logger.Error("can't pause container", "container", containerID[:8], "err", err)
+	}
+	return err
+}
+
+// UnpauseContainer unpauses the given container.
+func (b *ContainerBackend) UnpauseContainer(containerID string) error {
+	b.logger.Debug("unpausing container", "container", containerID[:8])
+	err := b.client.UnpauseContainer(containerID)
+	if err != nil {
+		b.logger.Error("can't unpause container", "container", containerID[:8], "err", err)
+	}
+	return err
+}
+
 // CreateNetwork creates a docker network.
 func (b *ContainerBackend) CreateNetwork(name string) (string, error) {
 	network, err := b.client.CreateNetwork(docker.CreateNetworkOptions{

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -23,6 +23,8 @@ type ContainerBackend interface {
 	CreateContainer(ctx context.Context, image string, opt ContainerOptions) (string, error)
 	StartContainer(ctx context.Context, containerID string, opt ContainerOptions) (*ContainerInfo, error)
 	DeleteContainer(containerID string) error
+	PauseContainer(containerID string) error
+	UnpauseContainer(containerID string) error
 
 	// RunProgram runs a command in the given container and returns its outputs and exit code.
 	RunProgram(ctx context.Context, containerID string, cmdline []string) (*ExecInfo, error)

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -499,12 +499,8 @@ func (manager *TestManager) PauseNode(testID TestID, nodeID string) error {
 		return ErrNoSuchNode
 	}
 	// Pause the container.
-	if nodeInfo.wait != nil {
-		if err := manager.backend.PauseContainer(nodeInfo.ID); err != nil {
-			return fmt.Errorf("unable to pause client: %v", err)
-		}
-		nodeInfo.wait()
-		nodeInfo.wait = nil
+	if err := manager.backend.PauseContainer(nodeInfo.ID); err != nil {
+		return fmt.Errorf("unable to pause client: %v", err)
 	}
 	return nil
 }
@@ -523,12 +519,8 @@ func (manager *TestManager) UnpauseNode(testID TestID, nodeID string) error {
 		return ErrNoSuchNode
 	}
 	// Unpause the container.
-	if nodeInfo.wait != nil {
-		if err := manager.backend.UnpauseContainer(nodeInfo.ID); err != nil {
-			return fmt.Errorf("unable to unpause client: %v", err)
-		}
-		nodeInfo.wait()
-		nodeInfo.wait = nil
+	if err := manager.backend.UnpauseContainer(nodeInfo.ID); err != nil {
+		return fmt.Errorf("unable to unpause client: %v", err)
 	}
 	return nil
 }

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -485,6 +485,54 @@ func (manager *TestManager) StopNode(testID TestID, nodeID string) error {
 	return nil
 }
 
+// PauseNode pauses a client container.
+func (manager *TestManager) PauseNode(testID TestID, nodeID string) error {
+	manager.testCaseMutex.Lock()
+	defer manager.testCaseMutex.Unlock()
+
+	testCase, ok := manager.runningTestCases[testID]
+	if !ok {
+		return ErrNoSuchNode
+	}
+	nodeInfo, ok := testCase.ClientInfo[nodeID]
+	if !ok {
+		return ErrNoSuchNode
+	}
+	// Pause the container.
+	if nodeInfo.wait != nil {
+		if err := manager.backend.PauseContainer(nodeInfo.ID); err != nil {
+			return fmt.Errorf("unable to pause client: %v", err)
+		}
+		nodeInfo.wait()
+		nodeInfo.wait = nil
+	}
+	return nil
+}
+
+// UnpauseNode unpauses a client container.
+func (manager *TestManager) UnpauseNode(testID TestID, nodeID string) error {
+	manager.testCaseMutex.Lock()
+	defer manager.testCaseMutex.Unlock()
+
+	testCase, ok := manager.runningTestCases[testID]
+	if !ok {
+		return ErrNoSuchNode
+	}
+	nodeInfo, ok := testCase.ClientInfo[nodeID]
+	if !ok {
+		return ErrNoSuchNode
+	}
+	// Unpause the container.
+	if nodeInfo.wait != nil {
+		if err := manager.backend.UnpauseContainer(nodeInfo.ID); err != nil {
+			return fmt.Errorf("unable to unpause client: %v", err)
+		}
+		nodeInfo.wait()
+		nodeInfo.wait = nil
+	}
+	return nil
+}
+
 // writeSuiteFile writes the simulation result to the log directory.
 func writeSuiteFile(s *TestSuite, logdir string) error {
 	suiteData, err := json.Marshal(s)


### PR DESCRIPTION
Allows hive to pause/unpause clients by using docker api container pausing feature (https://docs.docker.com/engine/api/v1.23/#pause-a-container).

Useful for beacon client tests since these rely on wall clock to construct the chain, and this introduces a nice test condition for when the client is late to produce blocks when it has to.