### PR TITLE
simulators/ethereum/engine: Parallel getPayloadBodies Test

### DIFF
--- a/simulators/ethereum/engine/suites/withdrawals/README.md
+++ b/simulators/ethereum/engine/suites/withdrawals/README.md
@@ -205,6 +205,13 @@ All test cases contain the following verifications:
     - All transactions and withdrawals are in the correct format and order.
     - Requested payload bodies of unknown hashes are returned as null in the returned list
 
+- Payload Bodies By Range/Hash Parallel - Shanghai Fork on Block 17 - 32 Withdrawal Blocks
+  - Launch client `A` and create a canonical chain consisting of 48 blocks, where the first shanghai block is number 17
+  - Make requests to obtain the full withdrawals payload bodies from the canonical chain by hash or range, in parallel, and repeatedly.
+  - Verify that:
+    - All transactions and withdrawals are in the correct format and order.
+    - There are no locking issues in the client due to parallel requests.
+
 ## Block Value Tests
 - Block Value on GetPayloadV2 Post-Shanghai
   - Create a Shanghai chain where the fork transition happens at block 1

--- a/simulators/ethereum/engine/test/expect.go
+++ b/simulators/ethereum/engine/test/expect.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
 	api "github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/hive/simulators/ethereum/engine/client"
@@ -483,7 +483,8 @@ type GetPayloadBodiesResponseExpectObject struct {
 }
 
 func (tec *TestEngineClient) TestEngineGetPayloadBodiesByRangeV1(start uint64, count uint64) *GetPayloadBodiesResponseExpectObject {
-	ctx, cancel := context.WithTimeout(tec.TestContext, globals.RPCTimeout)
+	// Get Payload Bodies can take a long time to respond
+	ctx, cancel := context.WithTimeout(tec.TestContext, globals.RPCTimeout*6)
 	defer cancel()
 	payloadBodies, err := tec.Engine.GetPayloadBodiesByRangeV1(ctx, start, count)
 	ret := &GetPayloadBodiesResponseExpectObject{
@@ -500,7 +501,7 @@ func (tec *TestEngineClient) TestEngineGetPayloadBodiesByRangeV1(start uint64, c
 }
 
 func (tec *TestEngineClient) TestEngineGetPayloadBodiesByHashV1(hashes []common.Hash) *GetPayloadBodiesResponseExpectObject {
-	ctx, cancel := context.WithTimeout(tec.TestContext, globals.RPCTimeout)
+	ctx, cancel := context.WithTimeout(tec.TestContext, globals.RPCTimeout*6)
 	defer cancel()
 	payloadBodies, err := tec.Engine.GetPayloadBodiesByHashV1(ctx, hashes)
 	ret := &GetPayloadBodiesResponseExpectObject{


### PR DESCRIPTION
## Changes Included
- Adds test where the simulator makes numerous requests of GetPayloadBodiesByRange and GetPayloadBodiesByHash in parallel

Related issue: https://github.com/ledgerwatch/erigon/issues/7172

Confirmed Erigon after PR https://github.com/ledgerwatch/erigon/pull/7199 passes this test now.