### PR TITLE
simulators/ethereum/engine: send `eth_` requests to port 8545

### DIFF
--- a/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	api "github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
-	api "github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -248,10 +248,7 @@ func (ec *HiveRPCEngineClient) StorageAtKeys(ctx context.Context, account common
 		results[key] = valueResult
 	}
 
-	if err := ec.PrepareDefaultAuthCallToken(); err != nil {
-		return nil, err
-	}
-	if err := ec.c.BatchCallContext(ctx, reqs); err != nil {
+	if err := ec.cEth.BatchCallContext(ctx, reqs); err != nil {
 		return nil, err
 	}
 	for i, req := range reqs {
@@ -513,10 +510,7 @@ func (ec *HiveRPCEngineClient) SendTransactions(ctx context.Context, txs []*type
 			Result: &hashes[i],
 		}
 	}
-	if err := ec.PrepareDefaultAuthCallToken(); err != nil {
-		return []error{err}
-	}
-	if err := ec.c.BatchCallContext(ctx, reqs); err != nil {
+	if err := ec.cEth.BatchCallContext(ctx, reqs); err != nil {
 		return []error{err}
 	}
 


### PR DESCRIPTION
Client construct was sending `eth_` requests to engine API port, which not all clients support because it's not required, and this PR changes this to send all requests to the default Eth RPC port (8545).

Also affects `pyspec` simulator.