### PR TITLE
clients/erigon: --externalcl flag is not supported anymore

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -135,6 +135,6 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
 fi
 
 # Launch the main client.
-FLAGS="$FLAGS --nat=none --externalcl"
+FLAGS="$FLAGS --nat=none"
 echo "Running erigon with flags $FLAGS"
 $erigon $FLAGS


### PR DESCRIPTION
After https://github.com/ledgerwatch/erigon/pull/7349 the `--externalcl` flag is not supported anymore (the external CL mode is the default now)