### PR TITLE
clients/nethermind: Cancun support

### DIFF
--- a/clients/nethermind/Dockerfile
+++ b/clients/nethermind/Dockerfile
@@ -1,5 +1,7 @@
+ARG user=nethermindeth
+ARG repo=hive
 ARG branch=latest
-FROM nethermindeth/hive:$branch
+FROM $user/$repo:$branch
 
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -142,6 +142,9 @@ def clique_engine:
     "eip3860TransitionTimestamp": env.HIVE_SHANGHAI_TIMESTAMP|to_hex,
     "eip4895TransitionTimestamp": env.HIVE_SHANGHAI_TIMESTAMP|to_hex,
 
+    # Cancun
+    "eip4844TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
+
     # Other chain parameters
     "networkID": env.HIVE_NETWORK_ID|to_hex,
     "chainID": env.HIVE_CHAIN_ID|to_hex,


### PR DESCRIPTION
Adds support for `HIVE_CANCUN_TIMESTAMP` environment variable.

Also add more args into the Dockerfile to make it easier to manually change the docker image source.

cc @MarekM25 