### PR TITLE
libhive,libdocker: Allow more args to docker image building

### DIFF
--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -1,21 +1,9 @@
-## By default, the geth is pulled from Docker Hub.
+## By default, geth is pulled from Docker Hub.
 
+ARG user=ethereum
+ARG repo=client-go
 ARG branch=latest
-FROM ethereum/client-go:$branch as builder
-
-## ----
-## Uncomment the steps below (and comment out the steps above!) to build go-ethereum
-## from local sources in the ./go-ethereum directory.
-
-# FROM golang:1-alpine as builder
-# ARG branch=master
-# ADD go-ethereum /go-ethereum
-# WORKDIR /go-ethereum
-# RUN apk add --update bash curl jq git make
-# RUN make geth
-# RUN mv ./build/bin/geth /usr/local/bin/geth
-
-## ----
+FROM $user/$repo:$branch as builder
 
 FROM alpine:latest
 RUN apk add --update bash curl jq

--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -1,0 +1,52 @@
+## Pulls geth from a git repository and builds it from source.
+
+FROM alpine:latest as builder
+ARG user=ethereum
+ARG repo=go-ethereum
+ARG branch=master
+
+RUN \
+  apk add --update bash curl jq go git make gcc musl-dev         \
+        ca-certificates linux-headers                         && \
+  git clone --depth 1 --branch $branch                           \
+      https://github.com/$user/$repo                          && \
+  (cd go-ethereum && make geth)                               && \
+  (cd go-ethereum                                             && \
+  echo "{}"                                                      \
+  | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
+  | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
+  | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
+  > /version.json)                                            && \
+  cp go-ethereum/build/bin/geth /usr/local/bin/geth           && \
+  apk del go git make gcc musl-dev linux-headers              && \
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+
+FROM alpine:latest
+RUN apk add --update bash curl jq
+COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
+
+# Generate the version.txt file.
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script.
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Add a default genesis file.
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
+
+# Generate the ethash verification caches
+RUN \
+ /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
+ /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum/Dockerfile.local
+++ b/clients/go-ethereum/Dockerfile.local
@@ -1,0 +1,39 @@
+## Build geth from source from a local directory called go-ethereum.
+
+FROM golang:1-alpine as builder
+ARG branch=master
+ADD go-ethereum /go-ethereum
+WORKDIR /go-ethereum
+RUN apk add --update bash curl jq git make
+RUN make geth
+RUN mv ./build/bin/geth /usr/local/bin/geth
+
+FROM alpine:latest
+RUN apk add --update bash curl jq
+COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
+
+# Generate the version.txt file.
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script.
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Add a default genesis file.
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
+
+# Generate the ethash verification caches
+RUN \
+ /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
+ /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum/Dockerfile.local
+++ b/clients/go-ethereum/Dockerfile.local
@@ -1,7 +1,6 @@
 ## Build geth from source from a local directory called go-ethereum.
 
 FROM golang:1-alpine as builder
-ARG branch=master
 ADD go-ethereum /go-ethereum
 WORKDIR /go-ethereum
 RUN apk add --update bash curl jq git make

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -36,6 +36,38 @@ Examples:
 	besu_u:hyperledger_b:master -> client: besu, user: hyperledger, branch: master
 	go-ethereum_f:git -> client: go-ethereum, dockerfile: Dockerfile.git
 
+Client configuration can also be specified as a YAML or JSON file.
+
+    ./hive --sim my-simulation --client clients.yaml
+
+```yaml
+- name: go-ethereum
+  dockerfile: git
+- name: nethermind
+  user: nethermindeth
+  repo: hive
+  branch: latest
+```
+
+    ./hive --sim my-simulation --client clients.json
+
+```json
+[
+	{
+		"name": "go-ethereum",
+		"dockerfile": "git"
+	},
+	{
+		"name": "nethermind",
+		"user": "nethermindeth",
+		"repo": "hive",
+		"branch": "latest",
+	}
+]
+```
+
+The client name is required, but all other fields are optional.
+
 See the [go-ethereum client definition][geth-docker] for an example of a client
 Dockerfile.
 
@@ -51,7 +83,7 @@ list:
 
 The role list is available to simulators and can be used to differentiate between clients
 based on features. Declaring a client role also signals that the client supports certain
-role-specific environment variables and files. If `hive.yml` is missing or doesn't declare
+role-specific environment variables and files. If `hive.yaml` is missing or doesn't declare
 roles, the `eth1` role is assumed.
 
 ### /version.txt

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -20,6 +20,22 @@ name like:
 
     ./hive --sim my-simulation --client go-ethereum_v1.9.23,go_ethereum_v1.9.22
 
+Other arguments to the docker image building process of the client can be specified by
+using a single letter and colon prefix.
+
+Supported prefixes are:
+
+	f: - docker file name (used to build the client image)
+	u: - user name (owner of git repository)
+	r: - repository name
+	b: - branch or tag name
+
+Examples:
+
+	besu_nightly -> client: besu, branch: nightly
+	besu_u:hyperledger_b:master -> client: besu, user: hyperledger, branch: master
+	go-ethereum_f:git -> client: go-ethereum, dockerfile: Dockerfile.git
+
 See the [go-ethereum client definition][geth-docker] for an example of a client
 Dockerfile.
 

--- a/internal/fakes/builder.go
+++ b/internal/fakes/builder.go
@@ -9,10 +9,10 @@ import (
 
 // BuilderHooks can be used to override the behavior of the fake builder.
 type BuilderHooks struct {
-	BuildClientImage    func(context.Context, string) (string, error)
+	BuildClientImage    func(context.Context, libhive.ClientBuildInfo) (string, error)
 	BuildSimulatorImage func(context.Context, string) (string, error)
 	ReadFile            func(ctx context.Context, image string, file string) ([]byte, error)
-	ReadClientMetadata  func(name string) (*libhive.ClientMetadata, error)
+	ReadClientMetadata  func(client libhive.ClientBuildInfo) (*libhive.ClientMetadata, error)
 }
 
 // fakeBuilder implements Backend without docker.
@@ -29,11 +29,11 @@ func NewBuilder(hooks *BuilderHooks) libhive.Builder {
 	return b
 }
 
-func (b *fakeBuilder) BuildClientImage(ctx context.Context, client string) (string, error) {
+func (b *fakeBuilder) BuildClientImage(ctx context.Context, client libhive.ClientBuildInfo) (string, error) {
 	if b.hooks.BuildClientImage != nil {
 		return b.hooks.BuildClientImage(ctx, client)
 	}
-	return "fakebuild/client/" + client + ":latest", nil
+	return "fakebuild/client/" + client.Name + ":latest", nil
 }
 
 func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string) (string, error) {
@@ -47,9 +47,9 @@ func (b *fakeBuilder) BuildImage(ctx context.Context, name string, fsys fs.FS) e
 	return nil
 }
 
-func (b *fakeBuilder) ReadClientMetadata(name string) (*libhive.ClientMetadata, error) {
+func (b *fakeBuilder) ReadClientMetadata(client libhive.ClientBuildInfo) (*libhive.ClientMetadata, error) {
 	if b.hooks.ReadClientMetadata != nil {
-		return b.hooks.ReadClientMetadata(name)
+		return b.hooks.ReadClientMetadata(client)
 	}
 	m := libhive.ClientMetadata{Roles: []string{"eth1"}}
 	return &m, nil

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -80,8 +80,8 @@ type ContainerInfo struct {
 
 // Builder can build docker images of clients and simulators.
 type Builder interface {
-	ReadClientMetadata(name string) (*ClientMetadata, error)
-	BuildClientImage(ctx context.Context, name string) (string, error)
+	ReadClientMetadata(client ClientBuildInfo) (*ClientMetadata, error)
+	BuildClientImage(ctx context.Context, client ClientBuildInfo) (string, error)
 	BuildSimulatorImage(ctx context.Context, name string) (string, error)
 	BuildImage(ctx context.Context, name string, fsys fs.FS) error
 

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -9,17 +9,25 @@ import (
 
 func TestSplitClientName(t *testing.T) {
 	tests := []struct {
-		name                   string
-		wantClient, wantBranch string
+		name                                                       string
+		wantClient, wantDockerFile, wantUser, wantRepo, wantBranch string
 	}{
-		{"client", "client", ""},
-		{"client_b", "client", "b"},
-		{"the_client_b", "the_client", "b"},
+		{"client", "client", "", "", "", ""},
+		{"client_b", "client", "", "", "", "b"},
+		{"the_client_b", "the_client", "", "", "", "b"},
+		{"the_client_u:user", "the_client", "", "user", "", ""},
+		{"the_client_u:user_b", "the_client", "", "user", "", "b"},
+		{"the_client_u:user_b:branch", "the_client", "", "user", "", "branch"},
+		{"the_client_b:branch_u:user", "the_client", "", "user", "", "branch"},
+		{"the_client_r:repo_b:branch_u:user", "the_client", "", "user", "repo", "branch"},
+		{"client_r:repo_b:branch_u:user", "client", "", "user", "repo", "branch"},
+		{"client_b:branch_u:user_r:repo", "client", "", "user", "repo", "branch"},
+		{"client_b:branch_f:git_r:repo", "client", "git", "", "repo", "branch"},
 	}
 	for _, test := range tests {
-		c, b := libhive.SplitClientName(test.name)
-		if c != test.wantClient || b != test.wantBranch {
-			t.Errorf("SpnlitClientName(%q) -> (%q, %q), want (%q, %q)", test.name, c, b, test.wantClient, test.wantBranch)
+		cInfo := libhive.SplitClientName(test.name)
+		if cInfo.Name != test.wantClient || cInfo.TagBranch != test.wantBranch || cInfo.User != test.wantUser || cInfo.Repo != test.wantRepo {
+			t.Errorf("SpnlitClientName(%q) -> (%q, %q, %q, %q), want (%q, %q, %q, %q)", test.name, cInfo.Name, cInfo.TagBranch, cInfo.User, cInfo.Repo, test.wantClient, test.wantBranch, test.wantUser, test.wantRepo)
 		}
 	}
 }

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -2,6 +2,8 @@ package libhive_test
 
 import (
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/hive/internal/libhive"
@@ -25,7 +27,7 @@ func TestSplitClientName(t *testing.T) {
 		{"client_b:branch_f:git_r:repo", "client", "git", "", "repo", "branch"},
 	}
 	for _, test := range tests {
-		cInfo := libhive.SplitClientName(test.name)
+		cInfo := libhive.ParseClientBuildInfoString(test.name)
 		if cInfo.Name != test.wantClient || cInfo.TagBranch != test.wantBranch || cInfo.User != test.wantUser || cInfo.Repo != test.wantRepo {
 			t.Errorf("SpnlitClientName(%q) -> (%q, %q, %q, %q), want (%q, %q, %q, %q)", test.name, cInfo.Name, cInfo.TagBranch, cInfo.User, cInfo.Repo, test.wantClient, test.wantBranch, test.wantUser, test.wantRepo)
 		}
@@ -40,15 +42,69 @@ func TestInventory(t *testing.T) {
 	}
 
 	t.Run("HasClient", func(t *testing.T) {
-		if !inv.HasClient("go-ethereum") {
+		clientInfo, err := libhive.ClientsBuildInfoFromString("go-ethereum_f:git,go-ethereum_latest,supereth3000")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(clientInfo) != 3 {
+			t.Fatal("wrong number of clients")
+		}
+		if !inv.HasClient(clientInfo[0]) {
 			t.Error("can't find go-ethereum client")
 		}
-		if !inv.HasClient("go-ethereum_latest") {
+		if !inv.HasClient(clientInfo[1]) {
 			t.Error("can't find go-ethereum_latest client")
 		}
-		if inv.HasClient("supereth3000") {
+		if inv.HasClient(clientInfo[2]) {
 			t.Error("returned true for unknown client")
 		}
+	})
+
+	t.Run("ClientBuildInfoFromYaml", func(t *testing.T) {
+		r := strings.NewReader(`
+- name: go-ethereum
+  dockerfile: git
+- name: go-ethereum
+  branch: latest
+  dockerfile: local
+- name: supereth3000
+`,
+		)
+		clientInfo, err := libhive.ClientsBuildInfoFromFile(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reflect.DeepEqual(clientInfo[0], libhive.ClientsBuildInfo{
+			{Name: "go-ethereum", DockerFile: "git"},
+			{Name: "go-ethereum", TagBranch: "latest", DockerFile: "local"},
+			{Name: "supereth3000"}})
+	})
+	t.Run("ClientBuildInfoFromJson", func(t *testing.T) {
+		r := strings.NewReader(`
+[
+	{
+		"name": "go-ethereum",
+		"dockerfile": "git"
+	},
+	{
+		"name": "go-ethereum",
+		"branch": "latest",
+		"dockerfile": "local"
+	},
+	{
+		"name": "supereth3000"
+	}
+]
+`,
+		)
+		clientInfo, err := libhive.ClientsBuildInfoFromFile(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reflect.DeepEqual(clientInfo[0], libhive.ClientsBuildInfo{
+			{Name: "go-ethereum", DockerFile: "git"},
+			{Name: "go-ethereum", TagBranch: "latest", DockerFile: "local"},
+			{Name: "supereth3000"}})
 	})
 	t.Run("HasSimulator", func(t *testing.T) {
 		if !inv.HasSimulator("smoke/genesis") {

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -42,7 +42,7 @@ func NewRunner(inv Inventory, b Builder, cb ContainerBackend) *Runner {
 }
 
 // Build builds client and simulator images.
-func (r *Runner) Build(ctx context.Context, clientList, simList []string) error {
+func (r *Runner) Build(ctx context.Context, clientList []ClientBuildInfo, simList []string) error {
 	if err := r.container.Build(ctx, r.builder); err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (r *Runner) Build(ctx context.Context, clientList, simList []string) error 
 }
 
 // buildClients builds client images.
-func (r *Runner) buildClients(ctx context.Context, clientList []string) error {
+func (r *Runner) buildClients(ctx context.Context, clientList []ClientBuildInfo) error {
 	if len(clientList) == 0 {
 		return errors.New("client list is empty, cannot simulate")
 	}
@@ -77,10 +77,10 @@ func (r *Runner) buildClients(ctx context.Context, clientList []string) error {
 		anyBuilt = true
 		version, err := r.builder.ReadFile(ctx, image, "/version.txt")
 		if err != nil {
-			log15.Warn("can't read version info of "+client, "image", image, "err", err)
+			log15.Warn("can't read version info of "+client.Name, "image", image, "err", err)
 		}
-		r.clientDefs[client] = &ClientDefinition{
-			Name:    client,
+		r.clientDefs[client.Name] = &ClientDefinition{
+			Name:    client.Name,
 			Version: strings.TrimSpace(string(version)),
 			Image:   image,
 			Meta:    *meta,
@@ -173,12 +173,12 @@ func (r *Runner) run(ctx context.Context, sim string, env SimEnv) (SimResult, er
 			clientDefs[name] = def
 		}
 	} else {
-		for _, name := range env.ClientList {
-			def, ok := r.clientDefs[name]
+		for _, client := range env.ClientList {
+			def, ok := r.clientDefs[client.Name]
 			if !ok {
-				return SimResult{}, fmt.Errorf("unknown client %q in simulation client list", name)
+				return SimResult{}, fmt.Errorf("unknown client %q in simulation client list", client.Name)
 			}
-			clientDefs[name] = def
+			clientDefs[client.Name] = def
 		}
 	}
 

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRunner(t *testing.T) {
 	var (
-		allClients = []string{"client-1", "client-2", "client-3"}
+		allClients = libhive.ClientsBuildInfo{{Name: "client-1"}, {Name: "client-2"}, {Name: "client-3"}}
 		simClients = allClients[1:]
 	)
 
@@ -34,7 +34,7 @@ func TestRunner(t *testing.T) {
 				if err != nil {
 					t.Fatal("error getting client types:", err)
 				}
-				if names := clientNames(defs); !reflect.DeepEqual(names, simClients) {
+				if names := clientNames(defs); !reflect.DeepEqual(names, simClients.Names()) {
 					t.Fatal("wrong client names:", names)
 				}
 			}

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -43,7 +43,7 @@ type SimEnv struct {
 
 	// These are the clients which are made available to the simulator.
 	// If unset (i.e. nil), all built clients are used.
-	ClientList []string
+	ClientList []ClientBuildInfo
 
 	// This configures the amount of time the simulation waits
 	// for the client to open port 8545 after launching the container.


### PR DESCRIPTION
Adds more optional arguments to the client image building process.

Each argument can be appended by adding an underscore, a single letter, and a colon, to the client name.

Supported arguments are:

	f: docker file name (used to build the client image)
	u: user name (owner of docker/git repository)
	r: repository name
	b: branch or tag name

E.g.
```
--client go-ethereum_f:git_u:mdehoog_b:eip-4844
```

Specifies building image using `Dockerfile.git`, using git repository `github.com/mdehoog/go-ethereum@eip-4844`.

Branch as single unnamed optional argument is still supported:
```
--client go-ethereum_master
```