### PR TITLE
clients/erigon: explicit --db.size.limit value

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -54,6 +54,7 @@ fi
 # Create the data directory.
 mkdir /erigon-hive-datadir
 FLAGS="$FLAGS --datadir /erigon-hive-datadir"
+FLAGS="$FLAGS --db.size.limit 2GB"
 
 # If a specific network ID is requested, use that
 if [ "$HIVE_NETWORK_ID" != "" ]; then


### PR DESCRIPTION
After https://github.com/ledgerwatch/erigon/pull/7325 the default DB limit doesn't work with Hive and results in
```
[452f4e7d] [EROR] [04-27|13:51:09.753] Erigon startup                           err="mdbx_env_open: MDBX_TOO_LARGE: Database is too large for current system, e.g. could NOT be mapped into RAM, label: chaindata, trace: [kv_mdbx.go:266 node.go:323 node.go:326 backend.go:205 node.go:106 main.go:59 make_app.go:41 command.go:274 app.go:332 app.go:309 main.go:36 proc.go:250 asm_amd64.s:1598]"
[452f4e7d] mdbx_env_open: MDBX_TOO_LARGE: Database is too large for current system, e.g. could NOT be mapped into RAM, label: chaindata, trace: [kv_mdbx.go:266 node.go:323 node.go:326 backend.go:205 node.go:106 main.go:59 make_app.go:41 command.go:274 app.go:332 app.go:309 main.go:36 proc.go:250 asm_amd64.s:1598]
```

This PR fixes Erigon invocation under Hive.