### PR TITLE
libhive: client build args and alternative dockerfiles

### DIFF
--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -5,32 +5,6 @@ ARG repo=client-go
 ARG branch=latest
 FROM $user/$repo:$branch as builder
 
-## ----
-## Uncomment the steps below (and comment out the steps above!) to build
-## go-ethereum from a git branch.
-
-# FROM alpine:latest as builder
-# ARG user=ethereum
-# ARG repo=go-ethereum
-# ARG branch=master
-# RUN \
-#   apk add --update bash curl jq go git make gcc musl-dev         \
-#         ca-certificates linux-headers                         && \
-#   git clone --depth 1 --branch $branch                           \
-#       https://github.com/$user/$repo                          && \
-#   (cd go-ethereum && make geth)                               && \
-#   (cd go-ethereum                                             && \
-#   echo "{}"                                                      \
-#   | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
-#   | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
-#   | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
-#   > /version.json)                                            && \
-#   cp go-ethereum/build/bin/geth /usr/local/bin/geth           && \
-#   apk del go git make gcc musl-dev linux-headers              && \
-#   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
-
-## ----
-
 FROM alpine:latest
 RUN apk add --update bash curl jq
 COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth

--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -1,9 +1,7 @@
-## By default, geth is pulled from Docker Hub.
+ARG baseimage=ethereum/client-go
+ARG tag=latest
 
-ARG user=ethereum
-ARG repo=client-go
-ARG branch=latest
-FROM $user/$repo:$branch as builder
+FROM $baseimage:$tag as builder
 
 FROM alpine:latest
 RUN apk add --update bash curl jq

--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -1,21 +1,9 @@
-## By default, the geth is pulled from Docker Hub.
+## By default, geth is pulled from Docker Hub.
 
+ARG user=ethereum
+ARG repo=client-go
 ARG branch=latest
-FROM ethereum/client-go:$branch as builder
-
-## ----
-## Uncomment the steps below (and comment out the steps above!) to build go-ethereum
-## from local sources in the ./go-ethereum directory.
-
-# FROM golang:1-alpine as builder
-# ARG branch=master
-# ADD go-ethereum /go-ethereum
-# WORKDIR /go-ethereum
-# RUN apk add --update bash curl jq git make
-# RUN make geth
-# RUN mv ./build/bin/geth /usr/local/bin/geth
-
-## ----
+FROM $user/$repo:$branch as builder
 
 ## ----
 ## Uncomment the steps below (and comment out the steps above!) to build

--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -1,0 +1,52 @@
+## Pulls geth from a git repository and builds it from source.
+
+FROM alpine:latest as builder
+ARG user=ethereum
+ARG repo=go-ethereum
+ARG branch=master
+
+RUN \
+  apk add --update bash curl jq go git make gcc musl-dev         \
+        ca-certificates linux-headers                         && \
+  git clone --depth 1 --branch $branch                           \
+      https://github.com/$user/$repo                          && \
+  (cd go-ethereum && make geth)                               && \
+  (cd go-ethereum                                             && \
+  echo "{}"                                                      \
+  | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
+  | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
+  | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
+  > /version.json)                                            && \
+  cp go-ethereum/build/bin/geth /usr/local/bin/geth           && \
+  apk del go git make gcc musl-dev linux-headers              && \
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+
+FROM alpine:latest
+RUN apk add --update bash curl jq
+COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
+
+# Generate the version.txt file.
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script.
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Add a default genesis file.
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
+
+# Generate the ethash verification caches
+RUN \
+ /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
+ /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -44,9 +44,4 @@ ADD genesis.json /genesis.json
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 8546 8547 8551 30303 30303/udp
 
-# Generate the ethash verification caches
-RUN \
- /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
- /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
-
 ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -1,24 +1,17 @@
 ## Pulls geth from a git repository and builds it from source.
 
 FROM alpine:latest as builder
-ARG user=ethereum
-ARG repo=go-ethereum
-ARG branch=master
+ARG github=ethereum/go-ethereum
+ARG tag=master
 
 RUN \
-  apk add --update bash curl jq go git make gcc musl-dev         \
-        ca-certificates linux-headers                         && \
-  git clone --depth 1 --branch $branch                           \
-      https://github.com/$user/$repo                          && \
-  (cd go-ethereum && make geth)                               && \
-  (cd go-ethereum                                             && \
-  echo "{}"                                                      \
-  | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
-  | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
-  | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
-  > /version.json)                                            && \
-  cp go-ethereum/build/bin/geth /usr/local/bin/geth           && \
-  apk del go git make gcc musl-dev linux-headers              && \
+  apk add --update bash curl jq go git make gcc musl-dev              \
+        ca-certificates linux-headers                              && \
+  git clone --depth 1 --branch $tag https://github.com/$github     && \
+  cd go-ethereum                                                   && \
+  make geth                                                        && \
+  cp go-ethereum/build/bin/geth /usr/local/bin/geth                && \
+  apk del go git make gcc musl-dev linux-headers                   && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 FROM alpine:latest

--- a/clients/go-ethereum/Dockerfile.local
+++ b/clients/go-ethereum/Dockerfile.local
@@ -30,9 +30,4 @@ ADD genesis.json /genesis.json
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 8546 8547 8551 30303 30303/udp
 
-# Generate the ethash verification caches
-RUN \
- /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
- /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
-
 ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum/Dockerfile.local
+++ b/clients/go-ethereum/Dockerfile.local
@@ -1,0 +1,38 @@
+## Build geth from source from a local directory called go-ethereum.
+
+FROM golang:1-alpine as builder
+ADD go-ethereum /go-ethereum
+WORKDIR /go-ethereum
+RUN apk add --update bash curl jq git make
+RUN make geth
+RUN mv ./build/bin/geth /usr/local/bin/geth
+
+FROM alpine:latest
+RUN apk add --update bash curl jq
+COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
+
+# Generate the version.txt file.
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script.
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Add a default genesis file.
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
+
+# Generate the ethash verification caches
+RUN \
+ /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
+ /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
+
+ENTRYPOINT ["/geth.sh"]

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -20,6 +20,45 @@ name like:
 
     ./hive --sim my-simulation --client go-ethereum_v1.9.23,go_ethereum_v1.9.22
 
+Other arguments to the docker image building process of the client can be specified by
+using YAML or JSON file as argument.
+
+    ./hive --sim my-simulation --client clients.yaml
+
+```yaml
+- name: go-ethereum
+  dockerfile: git
+- name: nethermind
+  user: nethermindeth
+  repo: hive
+  branch: latest
+```
+
+    ./hive --sim my-simulation --client clients.json
+
+```json
+[
+	{
+		"name": "go-ethereum",
+		"dockerfile": "git"
+	},
+	{
+		"name": "nethermind",
+		"user": "nethermindeth",
+		"repo": "hive",
+		"branch": "latest",
+	}
+]
+```
+
+Supported client build arguments are:
+
+	- name: Name of the client, eg: besu, go-ethereum, etc
+	- dockerfile: Dockerfile to use. E.g. using `dockerfile==git` will build using `Dockerfile.git` instead of the default `Dockerfile`
+	- user: GitHub/DockerHub user or organization name that owns the repository
+	- repo: Repository name
+	- branch: Git branch or docker tag name to use during build process
+
 See the [go-ethereum client definition][geth-docker] for an example of a client
 Dockerfile.
 
@@ -35,7 +74,7 @@ list:
 
 The role list is available to simulators and can be used to differentiate between clients
 based on features. Declaring a client role also signals that the client supports certain
-role-specific environment variables and files. If `hive.yml` is missing or doesn't declare
+role-specific environment variables and files. If `hive.yaml` is missing or doesn't declare
 roles, the `eth1` role is assumed.
 
 ### /version.txt

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -8,64 +8,29 @@ Clients are docker images which can be instantiated by a simulation. A client de
 consists of a Dockerfile and associated resources. Client definitions live in
 subdirectories of `clients/` in the hive repository.
 
+See the [go-ethereum client definition][geth-docker] for an example of a client
+Dockerfile.
+
 When hive runs a simulation, it first builds all client docker images using their
 Dockerfile, i.e. it basically runs `docker build .` in the client directory. Since most
 client definitions wrap an existing Ethereum client, and building the client from source
 may take a long time, it is usually best to base the hive client wrapper on a pre-built
 docker image from Docker Hub.
 
-Client Dockerfiles should support an optional argument named `branch`, which specifies the
-requested client version. This argument can be set by users by appending it to the client
-name like:
+The client Dockerfile should support an optional argument named `branch`, which specifies
+the requested client version. This argument can be set by users by appending it to the
+client name like:
 
     ./hive --sim my-simulation --client go-ethereum_v1.9.23,go_ethereum_v1.9.22
 
-Other arguments to the docker image building process of the client can be specified by
-using YAML or JSON file as argument.
+Other build arguments can also be set using a YAML file, see the [hive command
+documentation][hive-client-yaml] for more information.
 
-    ./hive --sim my-simulation --client clients.yaml
+### Alternative Dockerfiles
 
-```yaml
-- client: go-ethereum
-  dockerfile: git
-- client: nethermind
-  build_args:
-    user: nethermindeth
-    repo: hive
-    branch: latest
-```
-
-    ./hive --sim my-simulation --client clients.json
-
-```json
-[
-	{
-		"client": "go-ethereum",
-		"dockerfile": "git"
-	},
-	{
-		"client": "nethermind",
-		"build_args": {
-			"user": "nethermindeth",
-			"repo": "hive",
-			"branch": "latest"
-		}
-	}
-]
-```
-
-Parameters supported for each client described in this file are:
- - client: Name of the client to use to build the image
- - dockerfile: Dockerfile to use. E.g. using `dockerfile==git` will build using `Dockerfile.git` instead of the default `Dockerfile`
- - build_args: Build arguments passed to the docker build engine to use when building the image
-
-Supported docker image build arguments depend on the client and the docker image being used, but common client build arguments are:
- - user: GitHub/DockerHub user or organization name that owns the repository
- - repo: Repository name
- - branch: Git branch or docker tag name to use during build process
-
-See the [go-ethereum client definition][geth-docker] for an example of a client
-Dockerfile.
+There can be other Dockerfiles besides the main one. Typically, a client should also
+provide a `Dockerfile.git` that builds the client from source code. Alternative
+Dockerfiles can be selected through hive's `-client-file` YAML configuration.
 
 ### hive.yaml
 
@@ -199,6 +164,7 @@ For the server role, the following additional variables should be supported:
 
 [LES]: https://github.com/ethereum/devp2p/blob/master/caps/les.md
 [geth-docker]: ../clients/go-ethereum/Dockerfile
+[hive-client-yaml]: ./commandline.md#client-build-parameters
 [oe-genesis-jq]: ../clients/openethereum/mapper.jq
 [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
 [EIP-606]: https://eips.ethereum.org/EIPS/eip-606

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -26,12 +26,13 @@ using YAML or JSON file as argument.
     ./hive --sim my-simulation --client clients.yaml
 
 ```yaml
-- name: go-ethereum
+- client: go-ethereum
   dockerfile: git
-- name: nethermind
-  user: nethermindeth
-  repo: hive
-  branch: latest
+- client: nethermind
+  build_args:
+    user: nethermindeth
+    repo: hive
+    branch: latest
 ```
 
     ./hive --sim my-simulation --client clients.json
@@ -39,25 +40,29 @@ using YAML or JSON file as argument.
 ```json
 [
 	{
-		"name": "go-ethereum",
+		"client": "go-ethereum",
 		"dockerfile": "git"
 	},
 	{
-		"name": "nethermind",
-		"user": "nethermindeth",
-		"repo": "hive",
-		"branch": "latest",
+		"client": "nethermind",
+		"build_args": {
+			"user": "nethermindeth",
+			"repo": "hive",
+			"branch": "latest"
+		}
 	}
 ]
 ```
 
-Supported client build arguments are:
+Parameters supported for each client described in this file are:
+ - client: Name of the client to use to build the image
+ - dockerfile: Dockerfile to use. E.g. using `dockerfile==git` will build using `Dockerfile.git` instead of the default `Dockerfile`
+ - build_args: Build arguments passed to the docker build engine to use when building the image
 
-	- name: Name of the client, eg: besu, go-ethereum, etc
-	- dockerfile: Dockerfile to use. E.g. using `dockerfile==git` will build using `Dockerfile.git` instead of the default `Dockerfile`
-	- user: GitHub/DockerHub user or organization name that owns the repository
-	- repo: Repository name
-	- branch: Git branch or docker tag name to use during build process
+Supported docker image build arguments depend on the client and the docker image being used, but common client build arguments are:
+ - user: GitHub/DockerHub user or organization name that owns the repository
+ - repo: Repository name
+ - branch: Git branch or docker tag name to use during build process
 
 See the [go-ethereum client definition][geth-docker] for an example of a client
 Dockerfile.

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -39,13 +39,39 @@ version by appending it to the client name with `_`, for example:
 
     ./hive --sim devp2p --client go-ethereum_v1.9.22,go-ethereum_v1.9.23
 
-Simulation runs can be customized in many ways. Here's an overview of the available
-command-line options.
+### Client Build Parameters
 
-`--client.checktimelimit <timeout>`: The timeout of waiting for clients to open up TCP
-port 8545. If a very long chain is imported, this timeout may need to be quite long. A
-lower value means that hive won't wait as long in case the node crashes and never opens
-the RPC port. Defaults to 3 minutes.
+The client list for a run can also be given in a YAML file. This also allows further
+customization of the build arguments of the client. To enable the YAML file, use the
+`--client-file` option:
+
+    ./hive --sim my-simulation --client-file clients.yaml
+
+Here is an example clients.yaml file:
+
+    - client: go-ethereum
+      dockerfile: git
+    - client: nethermind
+      build_args:
+        user: nethermindeth
+        repo: hive
+        branch: latest
+
+For each client in the list, the following options can be given:
+
+ - `client`: name of the client to use to build the image
+ - `dockerfile`: the Dockerfile extension to use. For example, specifying `git` here will
+   build the client using `Dockerfile.git` instead of the default `Dockerfile`
+ - `build_args`: build arguments passed to the Dockerfile
+
+Supported build arguments depend on the client and the docker image being used, but common
+client build arguments are:
+
+ - `user`: GitHub/DockerHub user or organization name that owns the repository
+ - `repo`: repository name
+ - `branch`: git branch or docker tag name to use
+
+### Docker Options
 
 `--docker.pull`: Setting this option makes hive re-pull the base images of all built
 docker containers.
@@ -56,16 +82,7 @@ docker containers.
 rebuild. You can use this option during simulator development to ensure a new image is
 built even when there are no changes to the simulator code.
 
-`--sim.timelimit <timeout>`: Simulation timeout. Hive aborts the simulator if it exceeds
-this time. There is no default timeout.
-
-`--sim.loglevel <level>`: Selects log level of client instances. Supports values 0-5,
-defaults to 3. Note that this value may be overridden by simulators for specific clients.
-This sets the default value of `HIVE_LOGLEVEL` in client containers.
-
-`--sim.parallelism <number>`: Sets max number of parallel clients/containers. This is
-interpreted by simulators. It sets the `HIVE_PARALLELISM` environment variable. Defaults
-to 1.
+### Simulation Options
 
 `--sim.limit <pattern>`: Specifies a regular expression to selectively enable suites and
 test cases. This is interpreted by simulators. It sets the `HIVE_TEST_PATTERN` environment
@@ -85,6 +102,22 @@ This command runs the `consensus` simulator and runs only tests from the `stBugs
 directory (note the first `/`, matching any suite name):
 
     ./hive --sim ethereum/consensus --sim.limit /stBugs/
+
+`--sim.timelimit <timeout>`: Simulation timeout. Hive aborts the simulator if it exceeds
+this time. There is no default timeout.
+
+`--client.checktimelimit <timeout>`: The timeout of waiting for clients to open up TCP
+port 8545. If a very long chain is imported, this timeout may need to be quite long. A
+lower value means that hive won't wait as long in case the node crashes and never opens
+the RPC port. Defaults to 3 minutes.
+
+`--sim.loglevel <level>`: Selects log level of client instances. Supports values 0-5,
+defaults to 3. Note that this value may be overridden by simulators for specific clients.
+This sets the default value of `HIVE_LOGLEVEL` in client containers.
+
+`--sim.parallelism <number>`: Sets max number of parallel clients/containers. This is
+interpreted by simulators. It sets the `HIVE_PARALLELISM` environment variable. Defaults
+to 1.
 
 ## Viewing simulation results (hiveview)
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -42,8 +42,8 @@ version by appending it to the client name with `_`, for example:
 ### Client Build Parameters
 
 The client list for a run can also be given in a YAML file. This also allows further
-customization of the build arguments of the client. To enable the YAML file, use the
-`--client-file` option:
+customization of the build arguments of the client. Specify the `--client-file` option to
+use a client list file.
 
     ./hive --sim my-simulation --client-file clients.yaml
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -53,23 +53,26 @@ Here is an example clients.yaml file:
       dockerfile: git
     - client: nethermind
       build_args:
-        user: nethermindeth
-        repo: hive
-        branch: latest
+        baseimage: nethermindeth/hive
+        tag: latest
 
 For each client in the list, the following options can be given:
 
- - `client`: name of the client to use to build the image
- - `dockerfile`: the Dockerfile extension to use. For example, specifying `git` here will
-   build the client using `Dockerfile.git` instead of the default `Dockerfile`
- - `build_args`: build arguments passed to the Dockerfile
+ - `client`: Name of the client. This must refer to a known client in the clients/ directory.
+ - `dockerfile`: The Dockerfile extension to use. For example, specifying `git` here will
+   build the client using `Dockerfile.git` instead of the default `Dockerfile`.
+ - `nametag`: this can be used to assign a more descriptive name to the client. If unset,
+   a unique nametag will be chosen based on the version tag and/or build arguments.
+ - `build_args`: Build arguments passed to the Dockerfile, see below.
 
-Supported build arguments depend on the client and the docker image being used, but common
-client build arguments are:
+Supported build arguments depend on the client and the docker image being used. Common build
+arguments are:
 
- - `user`: GitHub/DockerHub user or organization name that owns the repository
- - `repo`: repository name
- - `branch`: git branch or docker tag name to use
+ - `tag`: The git commit/tag/branch or docker tag name to use.
+ - `baseimage`: For clients pulled from DockerHub, this can be used to override the organization
+   and image name. Example `ethereum/client-go`.
+ - `github`: For client Dockerfiles building from git, this setting can be used to change
+   the source code repository (fork) on GitHub. Example: `ethereum/go-ethereum`.
 
 ### Docker Options
 

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
-	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -910,6 +910,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20230206171751-46f607a40771 h1:xP7rWLUr1e1n2xkK5YB4LI0hPEy3LJC6Wk+D4pGlOJg=
 golang.org/x/exp v0.0.0-20230206171751-46f607a40771/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/hive.go
+++ b/hive.go
@@ -38,7 +38,7 @@ func main() {
 			"the client image will use the given git branch or docker tag. Multiple instances of\n"+
 			"a single client type may be requested with different branches.\n"+
 			"Example: \"besu_latest,besu_20.10.2\"\n"+
-			"If a valid file is specified instead, the client configuration will be parsed from this file as YALM or JSON.\n")
+			"If a valid file is specified instead, the client configuration will be parsed from this file as YAML or JSON.\n")
 		clientTimeout = flag.Duration("client.checktimelimit", 3*time.Minute, "The `timeout` of waiting for clients to open up the RPC port.\n"+
 			"If a very long chain is imported, this timeout may need to be quite large.\n"+
 			"A lower value means that hive won't wait as long in case the node crashes and\n"+

--- a/hive.go
+++ b/hive.go
@@ -120,7 +120,7 @@ func main() {
 	checkFlagsExclusive("client", "client-file")
 	var clientList []libhive.ClientDesignator
 	if *clientsFile != "" {
-		clientList, err = parseClientsFile(*clientsFile)
+		clientList, err = parseClientsFile(&inv, *clientsFile)
 		if err != nil {
 			fatal("-client-file:", err)
 		}
@@ -166,13 +166,13 @@ func fatal(args ...interface{}) {
 	os.Exit(1)
 }
 
-func parseClientsFile(file string) ([]libhive.ClientDesignator, error) {
+func parseClientsFile(inv *libhive.Inventory, file string) ([]libhive.ClientDesignator, error) {
 	f, err := os.Open(file)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	return libhive.ParseClientListYAML(f)
+	return libhive.ParseClientListYAML(inv, f)
 }
 
 func checkFlagsExclusive(flagNames ...string) {

--- a/hive.go
+++ b/hive.go
@@ -149,7 +149,7 @@ func fatal(args ...interface{}) {
 	os.Exit(1)
 }
 
-func parseClients(input string) ([]libhive.ClientBuildInfo, error) {
+func parseClients(input string) ([]libhive.ClientDesignator, error) {
 	// First check if the input is a path to a file.
 	if _, err := os.Stat(input); err == nil {
 		// Read the file as yaml/json and try to parse the list of client info.
@@ -158,9 +158,9 @@ func parseClients(input string) ([]libhive.ClientBuildInfo, error) {
 			return nil, err
 		}
 		defer f.Close()
-		return libhive.ClientsBuildInfoFromFile(f)
+		return libhive.ParseClientListYAML(f)
 	} else {
 		// Otherwise, parse the input as a comma-separated list of client info.
-		return libhive.ClientsBuildInfoFromString(input)
+		return libhive.ParseClientList(input)
 	}
 }

--- a/hive.go
+++ b/hive.go
@@ -125,7 +125,7 @@ func main() {
 			fatal("-client-file:", err)
 		}
 	} else {
-		clientList, err = libhive.ParseClientList(*clients)
+		clientList, err = libhive.ParseClientList(&inv, *clients)
 		if err != nil {
 			fatal("-client:", err)
 		}

--- a/internal/fakes/builder.go
+++ b/internal/fakes/builder.go
@@ -9,10 +9,10 @@ import (
 
 // BuilderHooks can be used to override the behavior of the fake builder.
 type BuilderHooks struct {
-	BuildClientImage    func(context.Context, libhive.ClientBuildInfo) (string, error)
+	BuildClientImage    func(context.Context, libhive.ClientDesignator) (string, error)
 	BuildSimulatorImage func(context.Context, string) (string, error)
 	ReadFile            func(ctx context.Context, image string, file string) ([]byte, error)
-	ReadClientMetadata  func(client libhive.ClientBuildInfo) (*libhive.ClientMetadata, error)
+	ReadClientMetadata  func(client libhive.ClientDesignator) (*libhive.ClientMetadata, error)
 }
 
 // fakeBuilder implements Backend without docker.
@@ -29,7 +29,7 @@ func NewBuilder(hooks *BuilderHooks) libhive.Builder {
 	return b
 }
 
-func (b *fakeBuilder) BuildClientImage(ctx context.Context, client libhive.ClientBuildInfo) (string, error) {
+func (b *fakeBuilder) BuildClientImage(ctx context.Context, client libhive.ClientDesignator) (string, error) {
 	if b.hooks.BuildClientImage != nil {
 		return b.hooks.BuildClientImage(ctx, client)
 	}
@@ -47,7 +47,7 @@ func (b *fakeBuilder) BuildImage(ctx context.Context, name string, fsys fs.FS) e
 	return nil
 }
 
-func (b *fakeBuilder) ReadClientMetadata(client libhive.ClientBuildInfo) (*libhive.ClientMetadata, error) {
+func (b *fakeBuilder) ReadClientMetadata(client libhive.ClientDesignator) (*libhive.ClientMetadata, error) {
 	if b.hooks.ReadClientMetadata != nil {
 		return b.hooks.ReadClientMetadata(client)
 	}

--- a/internal/fakes/builder.go
+++ b/internal/fakes/builder.go
@@ -33,7 +33,7 @@ func (b *fakeBuilder) BuildClientImage(ctx context.Context, client libhive.Clien
 	if b.hooks.BuildClientImage != nil {
 		return b.hooks.BuildClientImage(ctx, client)
 	}
-	return "fakebuild/client/" + client.Name + ":latest", nil
+	return "fakebuild/client/" + client.Client + ":latest", nil
 }
 
 func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string) (string, error) {

--- a/internal/fakes/builder.go
+++ b/internal/fakes/builder.go
@@ -9,10 +9,10 @@ import (
 
 // BuilderHooks can be used to override the behavior of the fake builder.
 type BuilderHooks struct {
-	BuildClientImage    func(context.Context, string) (string, error)
+	BuildClientImage    func(context.Context, libhive.ClientBuildInfo) (string, error)
 	BuildSimulatorImage func(context.Context, string) (string, error)
 	ReadFile            func(ctx context.Context, image string, file string) ([]byte, error)
-	ReadClientMetadata  func(name string) (*libhive.ClientMetadata, error)
+	ReadClientMetadata  func(client libhive.ClientBuildInfo) (*libhive.ClientMetadata, error)
 }
 
 // fakeBuilder implements Backend without docker.
@@ -29,11 +29,11 @@ func NewBuilder(hooks *BuilderHooks) libhive.Builder {
 	return b
 }
 
-func (b *fakeBuilder) BuildClientImage(ctx context.Context, client string) (string, error) {
+func (b *fakeBuilder) BuildClientImage(ctx context.Context, client libhive.ClientBuildInfo) (string, error) {
 	if b.hooks.BuildClientImage != nil {
 		return b.hooks.BuildClientImage(ctx, client)
 	}
-	return "fakebuild/client/" + client + ":latest", nil
+	return "fakebuild/client/" + client.Name + ":latest", nil
 }
 
 func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string) (string, error) {
@@ -47,9 +47,9 @@ func (b *fakeBuilder) BuildImage(ctx context.Context, name string, fsys fs.FS) e
 	return nil
 }
 
-func (b *fakeBuilder) ReadClientMetadata(name string) (*libhive.ClientMetadata, error) {
+func (b *fakeBuilder) ReadClientMetadata(client libhive.ClientBuildInfo) (*libhive.ClientMetadata, error) {
 	if b.hooks.ReadClientMetadata != nil {
-		return b.hooks.ReadClientMetadata(name)
+		return b.hooks.ReadClientMetadata(client)
 	}
 	m := libhive.ClientMetadata{Roles: []string{"eth1"}}
 	return &m, nil

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -258,7 +258,7 @@ func (b *Builder) buildImage(ctx context.Context, contextDir, dockerFile, imageT
 	logctx := []interface{}{"dir", contextDir, "nocache", opts.NoCache, "pull", opts.Pull}
 	if len(buildArgs) > 0 {
 		for _, arg := range buildArgs {
-			logctx = append(logctx, "buildarg", fmt.Sprintf("%s=%s", arg.Name, arg.Value))
+			logctx = append(logctx, arg.Name, arg.Value)
 		}
 		opts.BuildArgs = buildArgs
 	}

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -65,7 +65,7 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
 	tag := fmt.Sprintf("hive/clients/%s:latest", client.String())
 	dockerFile := client.Dockerfile()
 	buildArgs := make([]docker.BuildArg, 0)
-	for key, value := range client.BuildEnv {
+	for key, value := range client.BuildArgs {
 		buildArgs = append(buildArgs, docker.BuildArg{Name: key, Value: value})
 	}
 	err := b.buildImage(ctx, dir, dockerFile, tag, buildArgs...)

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -40,8 +40,8 @@ func NewBuilder(client *docker.Client, cfg *Config, auth Authenticator) *Builder
 }
 
 // ReadClientMetadata reads metadata of the given client.
-func (b *Builder) ReadClientMetadata(name string) (*libhive.ClientMetadata, error) {
-	dir := b.config.Inventory.ClientDirectory(name)
+func (b *Builder) ReadClientMetadata(client libhive.ClientBuildInfo) (*libhive.ClientMetadata, error) {
+	dir := b.config.Inventory.ClientDirectory(client)
 	f, err := os.Open(filepath.Join(dir, "hive.yaml"))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -60,11 +60,25 @@ func (b *Builder) ReadClientMetadata(name string) (*libhive.ClientMetadata, erro
 }
 
 // BuildClientImage builds a docker image of the given client.
-func (b *Builder) BuildClientImage(ctx context.Context, name string) (string, error) {
-	dir := b.config.Inventory.ClientDirectory(name)
-	_, branch := libhive.SplitClientName(name)
-	tag := fmt.Sprintf("hive/clients/%s:latest", name)
-	err := b.buildImage(ctx, dir, "Dockerfile", branch, tag)
+func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientBuildInfo) (string, error) {
+	dir := b.config.Inventory.ClientDirectory(client)
+	tag := fmt.Sprintf("hive/clients/%s:latest", client.String())
+	dockerFile := "Dockerfile"
+	if client.DockerFile != "" {
+		// Custom Dockerfile.
+		dockerFile += "." + client.DockerFile
+	}
+	buildArgs := make([]docker.BuildArg, 0)
+	if client.User != "" {
+		buildArgs = append(buildArgs, docker.BuildArg{Name: "user", Value: client.User})
+	}
+	if client.Repo != "" {
+		buildArgs = append(buildArgs, docker.BuildArg{Name: "repo", Value: client.Repo})
+	}
+	if client.TagBranch != "" {
+		buildArgs = append(buildArgs, docker.BuildArg{Name: "branch", Value: client.TagBranch})
+	}
+	err := b.buildImage(ctx, dir, dockerFile, tag, buildArgs...)
 	return tag, err
 }
 
@@ -86,7 +100,7 @@ func (b *Builder) BuildSimulatorImage(ctx context.Context, name string) (string,
 		}
 	}
 	tag := fmt.Sprintf("hive/simulators/%s:latest", name)
-	err := b.buildImage(ctx, buildContextPath, buildDockerfile, "", tag)
+	err := b.buildImage(ctx, buildContextPath, buildDockerfile, tag)
 	return tag, err
 }
 
@@ -230,7 +244,7 @@ func (b *Builder) ReadFile(ctx context.Context, image, path string) ([]byte, err
 
 // buildImage builds a single docker image from the specified context.
 // branch specifes a build argument to use a specific base image branch or github source branch.
-func (b *Builder) buildImage(ctx context.Context, contextDir, dockerFile, branch, imageTag string) error {
+func (b *Builder) buildImage(ctx context.Context, contextDir, dockerFile, imageTag string, buildArgs ...docker.BuildArg) error {
 	logger := b.logger.New("image", imageTag)
 	context, err := filepath.Abs(contextDir)
 	if err != nil {
@@ -242,9 +256,11 @@ func (b *Builder) buildImage(ctx context.Context, contextDir, dockerFile, branch
 	opts.ContextDir = context
 	opts.Dockerfile = dockerFile
 	logctx := []interface{}{"dir", contextDir, "nocache", opts.NoCache, "pull", opts.Pull}
-	if branch != "" {
-		logctx = append(logctx, "branch", branch)
-		opts.BuildArgs = []docker.BuildArg{{Name: "branch", Value: branch}}
+	if len(buildArgs) > 0 {
+		for _, arg := range buildArgs {
+			logctx = append(logctx, "buildarg", fmt.Sprintf("%s=%s", arg.Name, arg.Value))
+		}
+		opts.BuildArgs = buildArgs
 	}
 
 	logger.Info("building image", logctx...)

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -64,9 +64,9 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientBui
 	dir := b.config.Inventory.ClientDirectory(client)
 	tag := fmt.Sprintf("hive/clients/%s:latest", client.String())
 	dockerFile := "Dockerfile"
-	if client.DockerFile != "" {
+	if client.Dockerfile != "" {
 		// Custom Dockerfile.
-		dockerFile += "." + client.DockerFile
+		dockerFile += "." + client.Dockerfile
 	}
 	buildArgs := make([]docker.BuildArg, 0)
 	for key, value := range client.BuildArguments {

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -67,7 +67,14 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
 	buildArgs := make([]docker.BuildArg, 0)
 	for key, value := range client.BuildArgs {
 		buildArgs = append(buildArgs, docker.BuildArg{Name: key, Value: value})
+
+		// Backwards-compatibility for non-updated client Dockerfiles.
+		// TODO(fjl): remove this when all clients have been updated to "tag".
+		if key == "tag" {
+			buildArgs = append(buildArgs, docker.BuildArg{Name: "branch", Value: value})
+		}
 	}
+
 	err := b.buildImage(ctx, dir, dockerFile, tag, buildArgs)
 	return tag, err
 }

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -69,14 +69,8 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientBui
 		dockerFile += "." + client.DockerFile
 	}
 	buildArgs := make([]docker.BuildArg, 0)
-	if client.User != "" {
-		buildArgs = append(buildArgs, docker.BuildArg{Name: "user", Value: client.User})
-	}
-	if client.Repo != "" {
-		buildArgs = append(buildArgs, docker.BuildArg{Name: "repo", Value: client.Repo})
-	}
-	if client.TagBranch != "" {
-		buildArgs = append(buildArgs, docker.BuildArg{Name: "branch", Value: client.TagBranch})
+	for key, value := range client.BuildArguments {
+		buildArgs = append(buildArgs, docker.BuildArg{Name: key, Value: value})
 	}
 	err := b.buildImage(ctx, dir, dockerFile, tag, buildArgs...)
 	return tag, err

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -68,7 +68,7 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
 	for key, value := range client.BuildArgs {
 		buildArgs = append(buildArgs, docker.BuildArg{Name: key, Value: value})
 	}
-	err := b.buildImage(ctx, dir, dockerFile, tag, buildArgs...)
+	err := b.buildImage(ctx, dir, dockerFile, tag, buildArgs)
 	return tag, err
 }
 
@@ -90,7 +90,7 @@ func (b *Builder) BuildSimulatorImage(ctx context.Context, name string) (string,
 		}
 	}
 	tag := fmt.Sprintf("hive/simulators/%s:latest", name)
-	err := b.buildImage(ctx, buildContextPath, buildDockerfile, tag)
+	err := b.buildImage(ctx, buildContextPath, buildDockerfile, tag, nil)
 	return tag, err
 }
 
@@ -234,7 +234,7 @@ func (b *Builder) ReadFile(ctx context.Context, image, path string) ([]byte, err
 
 // buildImage builds a single docker image from the specified context.
 // branch specifes a build argument to use a specific base image branch or github source branch.
-func (b *Builder) buildImage(ctx context.Context, contextDir, dockerFile, imageTag string, buildArgs ...docker.BuildArg) error {
+func (b *Builder) buildImage(ctx context.Context, contextDir, dockerFile, imageTag string, buildArgs []docker.BuildArg) error {
 	logger := b.logger.New("image", imageTag)
 	context, err := filepath.Abs(contextDir)
 	if err != nil {

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -62,7 +62,7 @@ func (b *Builder) ReadClientMetadata(client libhive.ClientDesignator) (*libhive.
 // BuildClientImage builds a docker image of the given client.
 func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDesignator) (string, error) {
 	dir := b.config.Inventory.ClientDirectory(client)
-	tag := fmt.Sprintf("hive/clients/%s:latest", client.String())
+	tag := fmt.Sprintf("hive/clients/%s:latest", client.Name())
 	dockerFile := client.Dockerfile()
 	buildArgs := make([]docker.BuildArg, 0)
 	for key, value := range client.BuildArgs {

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -80,8 +80,8 @@ type ContainerInfo struct {
 
 // Builder can build docker images of clients and simulators.
 type Builder interface {
-	ReadClientMetadata(name string) (*ClientMetadata, error)
-	BuildClientImage(ctx context.Context, name string) (string, error)
+	ReadClientMetadata(client ClientBuildInfo) (*ClientMetadata, error)
+	BuildClientImage(ctx context.Context, client ClientBuildInfo) (string, error)
 	BuildSimulatorImage(ctx context.Context, name string) (string, error)
 	BuildImage(ctx context.Context, name string, fsys fs.FS) error
 

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -80,8 +80,8 @@ type ContainerInfo struct {
 
 // Builder can build docker images of clients and simulators.
 type Builder interface {
-	ReadClientMetadata(client ClientBuildInfo) (*ClientMetadata, error)
-	BuildClientImage(ctx context.Context, client ClientBuildInfo) (string, error)
+	ReadClientMetadata(client ClientDesignator) (*ClientMetadata, error)
+	BuildClientImage(ctx context.Context, client ClientDesignator) (string, error)
 	BuildSimulatorImage(ctx context.Context, name string) (string, error)
 	BuildImage(ctx context.Context, name string, fsys fs.FS) error
 

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -29,15 +29,25 @@ type ClientBuildInfo struct {
 }
 
 func (c ClientBuildInfo) String() string {
-	var values []string
-	values = append(values, c.Client)
+	var b strings.Builder
+	b.WriteString(c.Client)
 	if c.Dockerfile != "" {
-		values = append(values, c.Dockerfile)
+		b.WriteString("_")
+		b.WriteString(c.Dockerfile)
 	}
-	for k, v := range c.BuildArguments {
-		values = append(values, k, v)
+
+	var keys []string
+	for k := range c.BuildArguments {
+		keys = append(keys, k)
 	}
-	return strings.Join(values, "_")
+	sort.Strings(keys)
+	for _, k := range keys {
+		b.WriteString("_")
+		b.WriteString(k)
+		b.WriteString("_")
+		b.WriteString(c.BuildArguments[k])
+	}
+	return b.String()
 }
 
 // Parses client build info from a string.

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -60,21 +60,11 @@ func ParseClientBuildInfoString(fullString string) (ClientBuildInfo, error) {
 	return res, nil
 }
 
-type ClientsBuildInfo []ClientBuildInfo
-
-func (c ClientsBuildInfo) Names() []string {
-	names := make([]string, len(c))
-	for i, client := range c {
-		names[i] = client.Client
-	}
-	return names
-}
-
 // clientDelimiter separates multiple clients in the parameter string.
 const clientDelimiter = ","
 
-func ClientsBuildInfoFromString(arg string) (ClientsBuildInfo, error) {
-	var res ClientsBuildInfo
+func ClientsBuildInfoFromString(arg string) ([]ClientBuildInfo, error) {
+	var res []ClientBuildInfo
 	for _, name := range strings.Split(arg, clientDelimiter) {
 		if clientBuildInfo, err := ParseClientBuildInfoString(name); err != nil {
 			return nil, err
@@ -85,8 +75,8 @@ func ClientsBuildInfoFromString(arg string) (ClientsBuildInfo, error) {
 	return res, nil
 }
 
-func ClientsBuildInfoFromFile(file io.Reader) (ClientsBuildInfo, error) {
-	var res ClientsBuildInfo
+func ClientsBuildInfoFromFile(file io.Reader) ([]ClientBuildInfo, error) {
+	var res []ClientBuildInfo
 	err := yaml.NewDecoder(file).Decode(&res)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse clients file: %w", err)

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -15,16 +15,16 @@ import (
 // branchDelimiter is what separates the client name from the branch, eg: besu_nightly, go-ethereum_master.
 const branchDelimiter = "_"
 
-// All other build arguments for a client must be passed by using a YAML/JSON file
+// ClientBuildInfo represents the build configuration of a client.
+// The parameters set here are used when building the client docker image.
 type ClientBuildInfo struct {
-	// Client is the name of the client, eg: besu, go-ethereum, etc.
 	Client string `yaml:"client"`
 
 	// Dockerfile is the name of the Dockerfile to use for building the client.
-	// E.g. using `Dockerfile==git` will build using `Dockerfile.git`.
+	// E.g. using Dockerfile == 'git' will build using Dockerfile.git.
 	Dockerfile string `yaml:"dockerfile"`
 
-	// Build parameters used to build the docker image for the client.
+	// Parameters passed as environment to the docker build.
 	BuildArguments map[string]string `yaml:"build_args"`
 }
 

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -56,7 +56,7 @@ func (c ClientDesignator) String() string {
 // Dockerfile gives the name of the Dockerfile to use when building the client.
 func (c ClientDesignator) Dockerfile() string {
 	if c.DockerfileExt == "" {
-		return c.Client
+		return "Dockerfile"
 	}
 	return "Dockerfile." + c.DockerfileExt
 }

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -12,12 +12,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// branchDelimiter is what separates the client name from the branch, eg: besu_nightly, go-ethereum_master.
-const branchDelimiter = "_"
-
-// clientDelimiter separates multiple clients in the parameter string.
-const clientDelimiter = ","
-
 // ClientDesignator specifies a client and build parameters for it.
 type ClientDesignator struct {
 	Client string `yaml:"client"`
@@ -26,8 +20,8 @@ type ClientDesignator struct {
 	// client. Example: setting this to "git" will build using "Dockerfile.git".
 	DockerfileExt string `yaml:"dockerfile"`
 
-	// Parameters passed as environment to the docker build.
-	BuildEnv map[string]string `yaml:"build_args"`
+	// Arguments passed to the docker build.
+	BuildArgs map[string]string `yaml:"build_args"`
 }
 
 // String returns a unique string representation of the client build configuration.
@@ -40,7 +34,7 @@ func (c ClientDesignator) String() string {
 	}
 
 	var keys []string
-	for k := range c.BuildEnv {
+	for k := range c.BuildArgs {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
@@ -48,7 +42,7 @@ func (c ClientDesignator) String() string {
 		b.WriteString("_")
 		b.WriteString(k)
 		b.WriteString("_")
-		b.WriteString(c.BuildEnv[k])
+		b.WriteString(c.BuildArgs[k])
 	}
 	return b.String()
 }
@@ -61,6 +55,11 @@ func (c ClientDesignator) Dockerfile() string {
 	return "Dockerfile." + c.DockerfileExt
 }
 
+const (
+	branchDelimiter = "_" // separates the client name and branch, eg: besu_nightly
+	clientDelimiter = "," // separates client names in a list
+)
+
 // parseClientDesignator parses a client name string.
 func parseClientDesignator(fullString string) (ClientDesignator, error) {
 	var res ClientDesignator
@@ -71,7 +70,7 @@ func parseClientDesignator(fullString string) (ClientDesignator, error) {
 		if tag == "" {
 			return res, fmt.Errorf("invalid branch: %s", tag)
 		}
-		res.BuildEnv = map[string]string{"branch": tag}
+		res.BuildArgs = map[string]string{"branch": tag}
 	} else {
 		res.Client = fullString
 	}

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -1,22 +1,118 @@
 package libhive
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // branchDelimiter is what separates the client name from the branch, eg: besu_nightly, go-ethereum_master.
 const branchDelimiter = "_"
 
-// SplitClientName returns the name and branch components of 'name'.
-func SplitClientName(name string) (string, string) {
-	if ix := strings.LastIndex(name, branchDelimiter); ix > 0 {
-		return name[:ix], name[ix+1:]
+// All other build arguments for a client must be passed by using a YAML/JSON file
+type ClientBuildInfo struct {
+	// Name is the name of the client, eg: besu, go-ethereum, etc.
+	Name string `json:"name"       yaml:"name"`
+	// DockerFile is the name of the Dockerfile to use for building the client.
+	// E.g. using `Dockerfile==git` will build using `Dockerfile.git`.
+	DockerFile string `json:"dockerfile" yaml:"dockerfile"`
+	// User is the GitHub/DockerHub user or organization name that owns the
+	// repository.
+	User string `json:"user"       yaml:"user"`
+	// Repo is the name of the repository.
+	Repo string `json:"repo"       yaml:"repo"`
+	// TagBranch is the name of the github branch or docker tag to use to
+	// build the client. If not specified, the default branch will be used.
+	TagBranch string `json:"branch"     yaml:"branch"`
+}
+
+func (c ClientBuildInfo) String() string {
+	// Append all struct fields to a string separated by underscores using reflection.
+	v := reflect.ValueOf(c)
+	var values []string
+	for i := 0; i < v.NumField(); i++ {
+		fieldVal := v.Field(i).String()
+		if fieldVal != "" {
+			values = append(values, v.Field(i).String())
+		}
 	}
-	return name, ""
+	return strings.Join(values, "_")
+}
+
+// Parses client build info from a string.
+func ParseClientBuildInfoString(fullString string) (ClientBuildInfo, error) {
+	res := ClientBuildInfo{}
+	if strings.Count(fullString, branchDelimiter) > 0 {
+		substrings := strings.Split(fullString, branchDelimiter)
+		res.Name = strings.Join(substrings[0:len(substrings)-1], "_")
+		res.TagBranch = substrings[len(substrings)-1]
+		if res.TagBranch == "" {
+			return res, fmt.Errorf("invalid branch: %s", res.TagBranch)
+		}
+	} else {
+		res.Name = fullString
+	}
+	if res.Name == "" {
+		return res, fmt.Errorf("invalid client name: %s", fullString)
+	}
+	return res, nil
+}
+
+type ClientsBuildInfo []ClientBuildInfo
+
+func (c ClientsBuildInfo) Names() []string {
+	names := make([]string, len(c))
+	for i, client := range c {
+		names[i] = client.Name
+	}
+	return names
+}
+
+// clientDelimiter separates multiple clients in the parameter string.
+const clientDelimiter = ","
+
+func ClientsBuildInfoFromString(arg string) (ClientsBuildInfo, error) {
+	var res ClientsBuildInfo
+	for _, name := range strings.Split(arg, clientDelimiter) {
+		if clientBuildInfo, err := ParseClientBuildInfoString(name); err != nil {
+			return nil, err
+		} else {
+			res = append(res, clientBuildInfo)
+		}
+	}
+	return res, nil
+}
+
+func ClientsBuildInfoFromFile(file io.Reader) (ClientsBuildInfo, error) {
+	// Read the file
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	var res ClientsBuildInfo
+	// First try to unmarshal as yaml
+	errYaml := yaml.Unmarshal(data, &res)
+	if errYaml == nil {
+		return res, nil
+	}
+
+	// If that fails, try to unmarshal as a json
+	errJson := json.Unmarshal(data, &res)
+	if errJson == nil {
+		return res, nil
+	}
+
+	// Combine the errors
+	return nil, fmt.Errorf("unable to parse clients file: %s, json: %s", errYaml.Error(), errJson.Error())
 }
 
 // Inventory keeps names of clients and simulators.
@@ -28,17 +124,15 @@ type Inventory struct {
 
 // HasClient returns true if the inventory contains the given client.
 // The client name may contain a branch specifier.
-func (inv Inventory) HasClient(name string) bool {
-	name, _ = SplitClientName(name)
-	_, ok := inv.Clients[name]
+func (inv Inventory) HasClient(client ClientBuildInfo) bool {
+	_, ok := inv.Clients[client.Name]
 	return ok
 }
 
 // ClientDirectory returns the directory containing the given client's Dockerfile.
 // The client name may contain a branch specifier.
-func (inv Inventory) ClientDirectory(name string) string {
-	name, _ = SplitClientName(name)
-	return filepath.Join(inv.BaseDir, "clients", filepath.FromSlash(name))
+func (inv Inventory) ClientDirectory(client ClientBuildInfo) string {
+	return filepath.Join(inv.BaseDir, "clients", filepath.FromSlash(client.Name))
 }
 
 // HasSimulator returns true if the inventory contains the given simulator.

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -21,9 +21,11 @@ const branchDelimiter = "_"
 type ClientBuildInfo struct {
 	// Client is the name of the client, eg: besu, go-ethereum, etc.
 	Client string `json:"client"       yaml:"client"`
-	// DockerFile is the name of the Dockerfile to use for building the client.
+
+	// Dockerfile is the name of the Dockerfile to use for building the client.
 	// E.g. using `Dockerfile==git` will build using `Dockerfile.git`.
-	DockerFile string `json:"dockerfile" yaml:"dockerfile"`
+	Dockerfile string `json:"dockerfile" yaml:"dockerfile"`
+
 	// Build parameters used to build the docker image for the client.
 	BuildArguments map[string]string `json:"build_args" yaml:"build_args"`
 }
@@ -31,8 +33,8 @@ type ClientBuildInfo struct {
 func (c ClientBuildInfo) String() string {
 	var values []string
 	values = append(values, c.Client)
-	if c.DockerFile != "" {
-		values = append(values, c.DockerFile)
+	if c.Dockerfile != "" {
+		values = append(values, c.Dockerfile)
 	}
 	for k, v := range c.BuildArguments {
 		values = append(values, k, v)

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -98,8 +98,9 @@ func ParseClientList(arg string) ([]ClientDesignator, error) {
 // ParseClientListYAML reads a YAML document containing a list of clients.
 func ParseClientListYAML(file io.Reader) ([]ClientDesignator, error) {
 	var res []ClientDesignator
-	err := yaml.NewDecoder(file).Decode(&res)
-	if err != nil {
+	dec := yaml.NewDecoder(file)
+	dec.KnownFields(true)
+	if err := dec.Decode(&res); err != nil {
 		return nil, fmt.Errorf("unable to parse clients file: %w", err)
 	}
 	return res, nil

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/inconshreveable/log15.v2"
 	"gopkg.in/yaml.v3"
@@ -34,11 +35,7 @@ func (c ClientDesignator) String() string {
 		b.WriteString("_")
 		b.WriteString(c.DockerfileExt)
 	}
-
-	var keys []string
-	for k := range c.BuildArgs {
-		keys = append(keys, k)
-	}
+	keys := maps.Keys(c.BuildArgs)
 	sort.Strings(keys)
 	for _, k := range keys {
 		b.WriteString("_")

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -50,7 +50,7 @@ func TestClientBuildInfoString(t *testing.T) {
 	}{
 		{libhive.ClientBuildInfo{Client: "client"}, "client"},
 		{libhive.ClientBuildInfo{Client: "client", BuildArguments: map[string]string{"repo": "myrepo", "branch": "mybranch"}}, "client_repo_myrepo_branch_mybranch"},
-		{libhive.ClientBuildInfo{Client: "client", DockerFile: "mydockerfile", BuildArguments: map[string]string{"user": "myuser"}}, "client_mydockerfile_user_myuser"},
+		{libhive.ClientBuildInfo{Client: "client", Dockerfile: "mydockerfile", BuildArguments: map[string]string{"user": "myuser"}}, "client_mydockerfile_user_myuser"},
 	}
 	for _, test := range tests {
 		if test.buildInfo.String() != test.want {
@@ -83,8 +83,8 @@ func TestClientBuildInfoFromFile(t *testing.T) {
     some_other_arg: some_other_value
 `,
 			libhive.ClientsBuildInfo{
-				{Client: "go-ethereum", DockerFile: "git"},
-				{Client: "go-ethereum", DockerFile: "local", BuildArguments: map[string]string{"branch": "latest"}},
+				{Client: "go-ethereum", Dockerfile: "git"},
+				{Client: "go-ethereum", Dockerfile: "local", BuildArguments: map[string]string{"branch": "latest"}},
 				{Client: "supereth3000", BuildArguments: map[string]string{"some_other_arg": "some_other_value"}}},
 		},
 	}

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -20,8 +20,8 @@ func TestParseClientBuildInfoString(t *testing.T) {
 	}
 	for _, test := range tests {
 		cInfo, _ := parseClientDesignator(test.name)
-		if cInfo.Client != test.wantClient || !reflect.DeepEqual(test.wantBuildParams, cInfo.BuildEnv) {
-			t.Errorf("ParseClientBuildInfoString(%q) -> (%q, %q), want (%q, %q)", test.name, cInfo.Client, cInfo.BuildEnv, test.wantClient, test.wantBuildParams)
+		if cInfo.Client != test.wantClient || !reflect.DeepEqual(test.wantBuildParams, cInfo.BuildArgs) {
+			t.Errorf("ParseClientBuildInfoString(%q) -> (%q, %q), want (%q, %q)", test.name, cInfo.Client, cInfo.BuildArgs, test.wantClient, test.wantBuildParams)
 		}
 	}
 }
@@ -36,7 +36,7 @@ func TestInvalidSplitClientName(t *testing.T) {
 	for _, test := range tests {
 		cInfo, err := parseClientDesignator(test)
 		if err == nil {
-			t.Errorf("SplitClientName(%q) -> (%q, %q), want error", test, cInfo.Client, cInfo.BuildEnv)
+			t.Errorf("SplitClientName(%q) -> (%q, %q), want error", test, cInfo.Client, cInfo.BuildArgs)
 		}
 	}
 }
@@ -51,11 +51,11 @@ func TestClientDesignatorString(t *testing.T) {
 			string: "client",
 		},
 		{
-			client: ClientDesignator{Client: "client", BuildEnv: map[string]string{"repo": "myrepo", "branch": "mybranch"}},
+			client: ClientDesignator{Client: "client", BuildArgs: map[string]string{"repo": "myrepo", "branch": "mybranch"}},
 			string: "client_branch_mybranch_repo_myrepo",
 		},
 		{
-			client: ClientDesignator{Client: "client", DockerfileExt: "mydockerfile", BuildEnv: map[string]string{"user": "myuser"}},
+			client: ClientDesignator{Client: "client", DockerfileExt: "mydockerfile", BuildArgs: map[string]string{"user": "myuser"}},
 			string: "client_mydockerfile_user_myuser",
 		},
 	}
@@ -81,8 +81,8 @@ func TestClientBuildInfoFromFile(t *testing.T) {
 
 	expectedOutput := []ClientDesignator{
 		{Client: "go-ethereum", DockerfileExt: "git"},
-		{Client: "go-ethereum", DockerfileExt: "local", BuildEnv: map[string]string{"branch": "latest"}},
-		{Client: "supereth3000", BuildEnv: map[string]string{"some_other_arg": "some_other_value"}},
+		{Client: "go-ethereum", DockerfileExt: "local", BuildArgs: map[string]string{"branch": "latest"}},
+		{Client: "supereth3000", BuildArgs: map[string]string{"some_other_arg": "some_other_value"}},
 	}
 
 	r := strings.NewReader(yamlInput)

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -110,7 +110,7 @@ func TestInventory(t *testing.T) {
 	spew.Dump(inv)
 
 	t.Run("HasClient", func(t *testing.T) {
-		clientInfo, err := ParseClientList("go-ethereum_f:git,go-ethereum_latest,supereth3000")
+		clientInfo, err := ParseClientList(&inv, "go-ethereum,go-ethereum_latest,lighthouse-vc")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -123,7 +123,7 @@ func TestInventory(t *testing.T) {
 		if !inv.HasClient(clientInfo[1]) {
 			t.Error("can't find go-ethereum_latest client")
 		}
-		if inv.HasClient(clientInfo[2]) {
+		if inv.HasClient(ClientDesignator{Client: "supereth3000"}) {
 			t.Error("returned true for unknown client")
 		}
 	})

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -69,7 +69,7 @@ func TestClientBuildInfoFromFile(t *testing.T) {
 			`[
 				{"client": "go-ethereum", "dockerfile": "git"},
 				{"client": "go-ethereum", "dockerfile": "local", "build_args": {"branch": "latest"}},
-				{"client": "supereth3000"}
+				{"client": "supereth3000", "build_args": {"some_other_arg": "some_other_value"}}
 			]`,
 			`
 - client: go-ethereum
@@ -79,11 +79,13 @@ func TestClientBuildInfoFromFile(t *testing.T) {
   build_args:
     branch: latest
 - client: supereth3000
+  build_args:
+    some_other_arg: some_other_value
 `,
 			libhive.ClientsBuildInfo{
 				{Client: "go-ethereum", DockerFile: "git"},
 				{Client: "go-ethereum", DockerFile: "local", BuildArguments: map[string]string{"branch": "latest"}},
-				{Client: "supereth3000"}},
+				{Client: "supereth3000", BuildArguments: map[string]string{"some_other_arg": "some_other_value"}}},
 		},
 	}
 

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -2,6 +2,8 @@ package libhive_test
 
 import (
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/hive/internal/libhive"
@@ -9,19 +11,104 @@ import (
 
 func TestSplitClientName(t *testing.T) {
 	tests := []struct {
-		name                   string
-		wantClient, wantBranch string
+		name                                                       string
+		wantClient, wantDockerFile, wantUser, wantRepo, wantBranch string
 	}{
-		{"client", "client", ""},
-		{"client_b", "client", "b"},
-		{"the_client_b", "the_client", "b"},
+		{"client", "client", "", "", "", ""},
+		{"client_b", "client", "", "", "", "b"},
+		{"the_client_b", "the_client", "", "", "", "b"},
+		{"the_client_name_has_many_underscores_b", "the_client_name_has_many_underscores", "", "", "", "b"},
 	}
 	for _, test := range tests {
-		c, b := libhive.SplitClientName(test.name)
-		if c != test.wantClient || b != test.wantBranch {
-			t.Errorf("SpnlitClientName(%q) -> (%q, %q), want (%q, %q)", test.name, c, b, test.wantClient, test.wantBranch)
+		cInfo, _ := libhive.ParseClientBuildInfoString(test.name)
+		if cInfo.Name != test.wantClient || cInfo.TagBranch != test.wantBranch || cInfo.User != test.wantUser || cInfo.Repo != test.wantRepo {
+			t.Errorf("SpnlitClientName(%q) -> (%q, %q, %q, %q), want (%q, %q, %q, %q)", test.name, cInfo.Name, cInfo.TagBranch, cInfo.User, cInfo.Repo, test.wantClient, test.wantBranch, test.wantUser, test.wantRepo)
 		}
 	}
+}
+
+func TestInvalidSplitClientName(t *testing.T) {
+	tests := []string{
+		"",
+		"__",
+		"_somebranch",
+		"client_",
+	}
+	for _, test := range tests {
+		cInfo, err := libhive.ParseClientBuildInfoString(test)
+		if err == nil {
+			t.Errorf("SplitClientName(%q) -> (%q, %q, %q, %q), want error", test, cInfo.Name, cInfo.TagBranch, cInfo.User, cInfo.Repo)
+		}
+	}
+}
+
+func TestClientBuildInfoString(t *testing.T) {
+	tests := []struct {
+		buildInfo libhive.ClientBuildInfo
+		want      string
+	}{
+		{libhive.ClientBuildInfo{Name: "client"}, "client"},
+		{libhive.ClientBuildInfo{Name: "client", Repo: "myrepo", TagBranch: "mytag"}, "client_myrepo_mytag"},
+		{libhive.ClientBuildInfo{Name: "client", DockerFile: "mydockerfile", User: "myuser"}, "client_mydockerfile_myuser"},
+	}
+	for _, test := range tests {
+		if test.buildInfo.String() != test.want {
+			t.Errorf("ClientBuildInfoString -> %q, want %q", test.buildInfo.String(), test.want)
+		}
+	}
+}
+
+func TestClientBuildInfoFromFile(t *testing.T) {
+	jsonYamlTests := []struct {
+		json string
+		yaml string
+		want libhive.ClientsBuildInfo
+	}{
+		{
+			`[
+				{"name": "go-ethereum", "dockerfile": "git"},
+				{"name": "go-ethereum", "branch": "latest", "dockerfile": "local"},
+				{"name": "supereth3000"}
+			]`,
+			`
+- name: go-ethereum
+  dockerfile: git
+- name: go-ethereum
+  branch: latest
+  dockerfile: local
+- name: supereth3000
+`,
+			libhive.ClientsBuildInfo{
+				{Name: "go-ethereum", DockerFile: "git"},
+				{Name: "go-ethereum", TagBranch: "latest", DockerFile: "local"},
+				{Name: "supereth3000"}},
+		},
+	}
+
+	t.Run("ClientBuildInfoFromYaml", func(t *testing.T) {
+		for _, test := range jsonYamlTests {
+			r := strings.NewReader(test.yaml)
+			clientInfo, err := libhive.ClientsBuildInfoFromFile(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(&clientInfo, &test.want) {
+				t.Errorf("ClientBuildInfoFromYaml -> %q, want %q", clientInfo, test.want)
+			}
+		}
+	})
+	t.Run("ClientBuildInfoFromJson", func(t *testing.T) {
+		for _, test := range jsonYamlTests {
+			r := strings.NewReader(test.json)
+			clientInfo, err := libhive.ClientsBuildInfoFromFile(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(&clientInfo, &test.want) {
+				t.Errorf("ClientBuildInfoFromYaml -> %q, want %q", clientInfo, test.want)
+			}
+		}
+	})
 }
 
 func TestInventory(t *testing.T) {
@@ -32,13 +119,20 @@ func TestInventory(t *testing.T) {
 	}
 
 	t.Run("HasClient", func(t *testing.T) {
-		if !inv.HasClient("go-ethereum") {
+		clientInfo, err := libhive.ClientsBuildInfoFromString("go-ethereum_f:git,go-ethereum_latest,supereth3000")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(clientInfo) != 3 {
+			t.Fatal("wrong number of clients")
+		}
+		if !inv.HasClient(clientInfo[0]) {
 			t.Error("can't find go-ethereum client")
 		}
-		if !inv.HasClient("go-ethereum_latest") {
+		if !inv.HasClient(clientInfo[1]) {
 			t.Error("can't find go-ethereum_latest client")
 		}
-		if inv.HasClient("supereth3000") {
+		if inv.HasClient(clientInfo[2]) {
 			t.Error("returned true for unknown client")
 		}
 	})

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestParseClientBuildInfoString(t *testing.T) {
+func TestParseClientDesignator(t *testing.T) {
 	tests := []struct {
 		name            string
 		wantClient      string
@@ -21,7 +21,7 @@ func TestParseClientBuildInfoString(t *testing.T) {
 	for _, test := range tests {
 		cInfo, _ := parseClientDesignator(test.name)
 		if cInfo.Client != test.wantClient || !reflect.DeepEqual(test.wantBuildParams, cInfo.BuildArgs) {
-			t.Errorf("ParseClientBuildInfoString(%q) -> (%q, %q), want (%q, %q)", test.name, cInfo.Client, cInfo.BuildArgs, test.wantClient, test.wantBuildParams)
+			t.Errorf("parseClientDesignator(%q) -> (%q, %q), want (%q, %q)", test.name, cInfo.Client, cInfo.BuildArgs, test.wantClient, test.wantBuildParams)
 		}
 	}
 }
@@ -36,7 +36,7 @@ func TestInvalidSplitClientName(t *testing.T) {
 	for _, test := range tests {
 		cInfo, err := parseClientDesignator(test)
 		if err == nil {
-			t.Errorf("SplitClientName(%q) -> (%q, %q), want error", test, cInfo.Client, cInfo.BuildArgs)
+			t.Errorf("parseClientDesignator(%q) -> (%q, %q), want error", test, cInfo.Client, cInfo.BuildArgs)
 		}
 	}
 }
@@ -66,7 +66,7 @@ func TestClientDesignatorString(t *testing.T) {
 	}
 }
 
-func TestClientBuildInfoFromFile(t *testing.T) {
+func TestParseClientListYAML(t *testing.T) {
 	yamlInput := `
 - client: go-ethereum
   dockerfile: git
@@ -91,7 +91,7 @@ func TestClientBuildInfoFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(&clientInfo, &expectedOutput) {
-		t.Errorf("ClientBuildInfoFromYaml -> %q, want %q", clientInfo, expectedOutput)
+		t.Errorf("ParseClientListYAML -> %v, want %v", clientInfo, expectedOutput)
 	}
 }
 

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -17,9 +17,9 @@ func TestParseClientDesignator(t *testing.T) {
 		wantBuildParams map[string]string
 	}{
 		{"client", "client", nil},
-		{"client_b", "client", map[string]string{"branch": "b"}},
-		{"the_client_b", "the_client", map[string]string{"branch": "b"}},
-		{"the_client_name_has_many_underscores_b", "the_client_name_has_many_underscores", map[string]string{"branch": "b"}},
+		{"client_b", "client", map[string]string{"tag": "b"}},
+		{"the_client_b", "the_client", map[string]string{"tag": "b"}},
+		{"the_client_name_has_many_underscores_b", "the_client_name_has_many_underscores", map[string]string{"tag": "b"}},
 	}
 	for _, test := range tests {
 		cInfo, _ := parseClientDesignator(test.name)
@@ -29,7 +29,7 @@ func TestParseClientDesignator(t *testing.T) {
 	}
 }
 
-func TestInvalidSplitClientName(t *testing.T) {
+func TestParseClientDesignatorUnderscore(t *testing.T) {
 	tests := []string{
 		"",
 		"__",
@@ -68,22 +68,22 @@ func TestClientNaming(t *testing.T) {
 		},
 		{
 			clients: []ClientDesignator{
-				{Client: "c1", BuildArgs: map[string]string{"branch": "latest"}},
-				{Client: "c1", BuildArgs: map[string]string{"branch": "unstable"}},
+				{Client: "c1", BuildArgs: map[string]string{"tag": "latest"}},
+				{Client: "c1", BuildArgs: map[string]string{"tag": "unstable"}},
 			},
 			names: []string{"c1_latest", "c1_unstable"},
 		},
 		{
 			clients: []ClientDesignator{
-				{Client: "c1", BuildArgs: map[string]string{"branch": "latest"}},
-				{Client: "c1", BuildArgs: map[string]string{"branch": "latest", "other": "1"}},
+				{Client: "c1", BuildArgs: map[string]string{"tag": "latest"}},
+				{Client: "c1", BuildArgs: map[string]string{"tag": "latest", "other": "1"}},
 			},
-			names: []string{"c1_branch_latest", "c1_branch_latest_other_1"},
+			names: []string{"c1_latest", "c1_latest_other_1"},
 		},
 		{
 			clients: []ClientDesignator{
 				{Client: "c1", DockerfileExt: "git"},
-				{Client: "c1", BuildArgs: map[string]string{"branch": "latest"}},
+				{Client: "c1", BuildArgs: map[string]string{"tag": "latest"}},
 			},
 			names: []string{"c1", "c1_latest"},
 		},
@@ -97,10 +97,10 @@ func TestClientNaming(t *testing.T) {
 		// Errors:
 		{
 			clients: []ClientDesignator{
-				{Client: "c1", BuildArgs: map[string]string{"branch": "latest"}},
-				{Client: "c1", BuildArgs: map[string]string{"branch": "latest"}},
+				{Client: "c1", BuildArgs: map[string]string{"tag": "latest"}},
+				{Client: "c1", BuildArgs: map[string]string{"tag": "latest"}},
 			},
-			wantErr: fmt.Errorf("duplicate client name \"c1_branch_latest\""),
+			wantErr: fmt.Errorf("duplicate client name \"c1_latest\""),
 		},
 	}
 
@@ -137,20 +137,20 @@ func TestParseClientListYAML(t *testing.T) {
 - client: go-ethereum
   dockerfile: git
   build_args:
-    branch: custom
+    tag: custom
 - client: go-ethereum
   dockerfile: local
 - client: supereth3000
   build_args:
-    some_other_arg: some_other_value
+    github: org/repository
 - client: supereth3000
   nametag: thebest
 `
 
 	expectedOutput := []ClientDesignator{
-		{Client: "go-ethereum", Nametag: "custom", DockerfileExt: "git", BuildArgs: map[string]string{"branch": "custom"}},
+		{Client: "go-ethereum", Nametag: "custom", DockerfileExt: "git", BuildArgs: map[string]string{"tag": "custom"}},
 		{Client: "go-ethereum", DockerfileExt: "local"},
-		{Client: "supereth3000", Nametag: "some_other_arg_some_other_value", BuildArgs: map[string]string{"some_other_arg": "some_other_value"}},
+		{Client: "supereth3000", Nametag: "github_org/repository", BuildArgs: map[string]string{"github": "org/repository"}},
 		{Client: "supereth3000", Nametag: "thebest"},
 	}
 

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -48,9 +48,18 @@ func TestClientBuildInfoString(t *testing.T) {
 		buildInfo libhive.ClientBuildInfo
 		want      string
 	}{
-		{libhive.ClientBuildInfo{Client: "client"}, "client"},
-		{libhive.ClientBuildInfo{Client: "client", BuildArguments: map[string]string{"repo": "myrepo", "branch": "mybranch"}}, "client_repo_myrepo_branch_mybranch"},
-		{libhive.ClientBuildInfo{Client: "client", Dockerfile: "mydockerfile", BuildArguments: map[string]string{"user": "myuser"}}, "client_mydockerfile_user_myuser"},
+		{
+			buildInfo: libhive.ClientBuildInfo{Client: "client"},
+			want:      "client",
+		},
+		{
+			buildInfo: libhive.ClientBuildInfo{Client: "client", BuildArguments: map[string]string{"repo": "myrepo", "branch": "mybranch"}},
+			want:      "client_repo_myrepo_branch_mybranch",
+		},
+		{
+			buildInfo: libhive.ClientBuildInfo{Client: "client", Dockerfile: "mydockerfile", BuildArguments: map[string]string{"user": "myuser"}},
+			want:      "client_mydockerfile_user_myuser",
+		},
 	}
 	for _, test := range tests {
 		if test.buildInfo.String() != test.want {
@@ -60,18 +69,7 @@ func TestClientBuildInfoString(t *testing.T) {
 }
 
 func TestClientBuildInfoFromFile(t *testing.T) {
-	jsonYamlTests := []struct {
-		json string
-		yaml string
-		want libhive.ClientsBuildInfo
-	}{
-		{
-			`[
-				{"client": "go-ethereum", "dockerfile": "git"},
-				{"client": "go-ethereum", "dockerfile": "local", "build_args": {"branch": "latest"}},
-				{"client": "supereth3000", "build_args": {"some_other_arg": "some_other_value"}}
-			]`,
-			`
+	yamlInput := `
 - client: go-ethereum
   dockerfile: git
 - client: go-ethereum
@@ -81,38 +79,22 @@ func TestClientBuildInfoFromFile(t *testing.T) {
 - client: supereth3000
   build_args:
     some_other_arg: some_other_value
-`,
-			libhive.ClientsBuildInfo{
-				{Client: "go-ethereum", Dockerfile: "git"},
-				{Client: "go-ethereum", Dockerfile: "local", BuildArguments: map[string]string{"branch": "latest"}},
-				{Client: "supereth3000", BuildArguments: map[string]string{"some_other_arg": "some_other_value"}}},
-		},
+`
+
+	expectedOutput := libhive.ClientsBuildInfo{
+		{Client: "go-ethereum", Dockerfile: "git"},
+		{Client: "go-ethereum", Dockerfile: "local", BuildArguments: map[string]string{"branch": "latest"}},
+		{Client: "supereth3000", BuildArguments: map[string]string{"some_other_arg": "some_other_value"}},
 	}
 
-	t.Run("ClientBuildInfoFromYaml", func(t *testing.T) {
-		for _, test := range jsonYamlTests {
-			r := strings.NewReader(test.yaml)
-			clientInfo, err := libhive.ClientsBuildInfoFromFile(r)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(&clientInfo, &test.want) {
-				t.Errorf("ClientBuildInfoFromYaml -> %q, want %q", clientInfo, test.want)
-			}
-		}
-	})
-	t.Run("ClientBuildInfoFromJson", func(t *testing.T) {
-		for _, test := range jsonYamlTests {
-			r := strings.NewReader(test.json)
-			clientInfo, err := libhive.ClientsBuildInfoFromFile(r)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(&clientInfo, &test.want) {
-				t.Errorf("ClientBuildInfoFromYaml -> %q, want %q", clientInfo, test.want)
-			}
-		}
-	})
+	r := strings.NewReader(yamlInput)
+	clientInfo, err := libhive.ClientsBuildInfoFromFile(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(&clientInfo, &expectedOutput) {
+		t.Errorf("ClientBuildInfoFromYaml -> %q, want %q", clientInfo, expectedOutput)
+	}
 }
 
 func TestInventory(t *testing.T) {

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -81,7 +81,7 @@ func TestClientBuildInfoFromFile(t *testing.T) {
     some_other_arg: some_other_value
 `
 
-	expectedOutput := libhive.ClientsBuildInfo{
+	expectedOutput := []libhive.ClientBuildInfo{
 		{Client: "go-ethereum", Dockerfile: "git"},
 		{Client: "go-ethereum", Dockerfile: "local", BuildArguments: map[string]string{"branch": "latest"}},
 		{Client: "supereth3000", BuildArguments: map[string]string{"some_other_arg": "some_other_value"}},

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 func TestParseClientDesignator(t *testing.T) {
@@ -85,8 +87,12 @@ func TestParseClientListYAML(t *testing.T) {
 		{Client: "supereth3000", BuildArgs: map[string]string{"some_other_arg": "some_other_value"}},
 	}
 
+	var inv Inventory
+	inv.AddClient("go-ethereum", &InventoryClient{Dockerfiles: []string{"git", "local"}})
+	inv.AddClient("supereth3000", nil)
+
 	r := strings.NewReader(yamlInput)
-	clientInfo, err := ParseClientListYAML(r)
+	clientInfo, err := ParseClientListYAML(&inv, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,6 +107,7 @@ func TestInventory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	spew.Dump(inv)
 
 	t.Run("HasClient", func(t *testing.T) {
 		clientInfo, err := ParseClientList("go-ethereum_f:git,go-ethereum_latest,supereth3000")

--- a/internal/libhive/inventory_test.go
+++ b/internal/libhive/inventory_test.go
@@ -54,7 +54,7 @@ func TestClientBuildInfoString(t *testing.T) {
 		},
 		{
 			buildInfo: libhive.ClientBuildInfo{Client: "client", BuildArguments: map[string]string{"repo": "myrepo", "branch": "mybranch"}},
-			want:      "client_repo_myrepo_branch_mybranch",
+			want:      "client_branch_mybranch_repo_myrepo",
 		},
 		{
 			buildInfo: libhive.ClientBuildInfo{Client: "client", Dockerfile: "mydockerfile", BuildArguments: map[string]string{"user": "myuser"}},

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -77,10 +77,10 @@ func (r *Runner) buildClients(ctx context.Context, clientList []ClientBuildInfo)
 		anyBuilt = true
 		version, err := r.builder.ReadFile(ctx, image, "/version.txt")
 		if err != nil {
-			log15.Warn("can't read version info of "+client.Name, "image", image, "err", err)
+			log15.Warn("can't read version info of "+client.Client, "image", image, "err", err)
 		}
-		r.clientDefs[client.Name] = &ClientDefinition{
-			Name:    client.Name,
+		r.clientDefs[client.Client] = &ClientDefinition{
+			Name:    client.Client,
 			Version: strings.TrimSpace(string(version)),
 			Image:   image,
 			Meta:    *meta,
@@ -174,11 +174,11 @@ func (r *Runner) run(ctx context.Context, sim string, env SimEnv) (SimResult, er
 		}
 	} else {
 		for _, client := range env.ClientList {
-			def, ok := r.clientDefs[client.Name]
+			def, ok := r.clientDefs[client.Client]
 			if !ok {
-				return SimResult{}, fmt.Errorf("unknown client %q in simulation client list", client.Name)
+				return SimResult{}, fmt.Errorf("unknown client %q in simulation client list", client.Client)
 			}
-			clientDefs[client.Name] = def
+			clientDefs[client.Client] = def
 		}
 	}
 

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -42,7 +42,7 @@ func NewRunner(inv Inventory, b Builder, cb ContainerBackend) *Runner {
 }
 
 // Build builds client and simulator images.
-func (r *Runner) Build(ctx context.Context, clientList []ClientBuildInfo, simList []string) error {
+func (r *Runner) Build(ctx context.Context, clientList []ClientDesignator, simList []string) error {
 	if err := r.container.Build(ctx, r.builder); err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (r *Runner) Build(ctx context.Context, clientList []ClientBuildInfo, simLis
 }
 
 // buildClients builds client images.
-func (r *Runner) buildClients(ctx context.Context, clientList []ClientBuildInfo) error {
+func (r *Runner) buildClients(ctx context.Context, clientList []ClientDesignator) error {
 	if len(clientList) == 0 {
 		return errors.New("client list is empty, cannot simulate")
 	}

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -42,7 +42,7 @@ func NewRunner(inv Inventory, b Builder, cb ContainerBackend) *Runner {
 }
 
 // Build builds client and simulator images.
-func (r *Runner) Build(ctx context.Context, clientList, simList []string) error {
+func (r *Runner) Build(ctx context.Context, clientList []ClientBuildInfo, simList []string) error {
 	if err := r.container.Build(ctx, r.builder); err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (r *Runner) Build(ctx context.Context, clientList, simList []string) error 
 }
 
 // buildClients builds client images.
-func (r *Runner) buildClients(ctx context.Context, clientList []string) error {
+func (r *Runner) buildClients(ctx context.Context, clientList []ClientBuildInfo) error {
 	if len(clientList) == 0 {
 		return errors.New("client list is empty, cannot simulate")
 	}
@@ -77,10 +77,10 @@ func (r *Runner) buildClients(ctx context.Context, clientList []string) error {
 		anyBuilt = true
 		version, err := r.builder.ReadFile(ctx, image, "/version.txt")
 		if err != nil {
-			log15.Warn("can't read version info of "+client, "image", image, "err", err)
+			log15.Warn("can't read version info of "+client.Name, "image", image, "err", err)
 		}
-		r.clientDefs[client] = &ClientDefinition{
-			Name:    client,
+		r.clientDefs[client.Name] = &ClientDefinition{
+			Name:    client.Name,
 			Version: strings.TrimSpace(string(version)),
 			Image:   image,
 			Meta:    *meta,
@@ -173,12 +173,12 @@ func (r *Runner) run(ctx context.Context, sim string, env SimEnv) (SimResult, er
 			clientDefs[name] = def
 		}
 	} else {
-		for _, name := range env.ClientList {
-			def, ok := r.clientDefs[name]
+		for _, client := range env.ClientList {
+			def, ok := r.clientDefs[client.Name]
 			if !ok {
-				return SimResult{}, fmt.Errorf("unknown client %q in simulation client list", name)
+				return SimResult{}, fmt.Errorf("unknown client %q in simulation client list", client.Name)
 			}
-			clientDefs[name] = def
+			clientDefs[client.Name] = def
 		}
 	}
 

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -79,8 +79,8 @@ func (r *Runner) buildClients(ctx context.Context, clientList []ClientDesignator
 		if err != nil {
 			log15.Warn("can't read version info of "+client.Client, "image", image, "err", err)
 		}
-		r.clientDefs[client.Client] = &ClientDefinition{
-			Name:    client.Client,
+		r.clientDefs[client.Name()] = &ClientDefinition{
+			Name:    client.Name(),
 			Version: strings.TrimSpace(string(version)),
 			Image:   image,
 			Meta:    *meta,

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -34,7 +34,7 @@ func TestRunner(t *testing.T) {
 				if err != nil {
 					t.Fatal("error getting client types:", err)
 				}
-				if names := clientNames(defs); !reflect.DeepEqual(names, buildInfoNames(simClients)) {
+				if names := clientDefinitionNames(defs); !reflect.DeepEqual(names, clientDesignatorNames(simClients)) {
 					t.Fatal("wrong client names:", names)
 				}
 			}
@@ -68,7 +68,7 @@ func makeTestInventory() libhive.Inventory {
 	return inv
 }
 
-func clientNames(defs []*hivesim.ClientDefinition) []string {
+func clientDefinitionNames(defs []*hivesim.ClientDefinition) []string {
 	names := make([]string, 0, len(defs))
 	for _, def := range defs {
 		names = append(names, def.Name)
@@ -77,7 +77,7 @@ func clientNames(defs []*hivesim.ClientDefinition) []string {
 	return names
 }
 
-func buildInfoNames(clients []libhive.ClientDesignator) []string {
+func clientDesignatorNames(clients []libhive.ClientDesignator) []string {
 	names := make([]string, len(clients))
 	for i, c := range clients {
 		names[i] = c.Client

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRunner(t *testing.T) {
 	var (
-		allClients = []string{"client-1", "client-2", "client-3"}
+		allClients = libhive.ClientsBuildInfo{{Name: "client-1"}, {Name: "client-2"}, {Name: "client-3"}}
 		simClients = allClients[1:]
 	)
 
@@ -34,7 +34,7 @@ func TestRunner(t *testing.T) {
 				if err != nil {
 					t.Fatal("error getting client types:", err)
 				}
-				if names := clientNames(defs); !reflect.DeepEqual(names, simClients) {
+				if names := clientNames(defs); !reflect.DeepEqual(names, simClients.Names()) {
 					t.Fatal("wrong client names:", names)
 				}
 			}

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -61,9 +61,9 @@ func TestRunner(t *testing.T) {
 
 func makeTestInventory() libhive.Inventory {
 	var inv libhive.Inventory
-	inv.AddClient("client-1")
-	inv.AddClient("client-2")
-	inv.AddClient("client-3")
+	inv.AddClient("client-1", nil)
+	inv.AddClient("client-2", nil)
+	inv.AddClient("client-3", nil)
 	inv.AddSimulator("sim-1")
 	return inv
 }

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRunner(t *testing.T) {
 	var (
-		allClients = []libhive.ClientBuildInfo{{Client: "client-1"}, {Client: "client-2"}, {Client: "client-3"}}
+		allClients = []libhive.ClientDesignator{{Client: "client-1"}, {Client: "client-2"}, {Client: "client-3"}}
 		simClients = allClients[1:]
 	)
 
@@ -77,7 +77,7 @@ func clientNames(defs []*hivesim.ClientDefinition) []string {
 	return names
 }
 
-func buildInfoNames(clients []libhive.ClientBuildInfo) []string {
+func buildInfoNames(clients []libhive.ClientDesignator) []string {
 	names := make([]string, len(clients))
 	for i, c := range clients {
 		names[i] = c.Client

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRunner(t *testing.T) {
 	var (
-		allClients = libhive.ClientsBuildInfo{{Client: "client-1"}, {Client: "client-2"}, {Client: "client-3"}}
+		allClients = []libhive.ClientBuildInfo{{Client: "client-1"}, {Client: "client-2"}, {Client: "client-3"}}
 		simClients = allClients[1:]
 	)
 
@@ -34,7 +34,7 @@ func TestRunner(t *testing.T) {
 				if err != nil {
 					t.Fatal("error getting client types:", err)
 				}
-				if names := clientNames(defs); !reflect.DeepEqual(names, simClients.Names()) {
+				if names := clientNames(defs); !reflect.DeepEqual(names, buildInfoNames(simClients)) {
 					t.Fatal("wrong client names:", names)
 				}
 			}
@@ -74,5 +74,13 @@ func clientNames(defs []*hivesim.ClientDefinition) []string {
 		names = append(names, def.Name)
 	}
 	sort.Strings(names)
+	return names
+}
+
+func buildInfoNames(clients []libhive.ClientBuildInfo) []string {
+	names := make([]string, len(clients))
+	for i, c := range clients {
+		names[i] = c.Client
+	}
 	return names
 }

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRunner(t *testing.T) {
 	var (
-		allClients = libhive.ClientsBuildInfo{{Name: "client-1"}, {Name: "client-2"}, {Name: "client-3"}}
+		allClients = libhive.ClientsBuildInfo{{Client: "client-1"}, {Client: "client-2"}, {Client: "client-3"}}
 		simClients = allClients[1:]
 	)
 

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -43,7 +43,7 @@ type SimEnv struct {
 
 	// These are the clients which are made available to the simulator.
 	// If unset (i.e. nil), all built clients are used.
-	ClientList []ClientBuildInfo
+	ClientList []ClientDesignator
 
 	// This configures the amount of time the simulation waits
 	// for the client to open port 8545 after launching the container.

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -43,7 +43,7 @@ type SimEnv struct {
 
 	// These are the clients which are made available to the simulator.
 	// If unset (i.e. nil), all built clients are used.
-	ClientList []string
+	ClientList []ClientBuildInfo
 
 	// This configures the amount of time the simulation waits
 	// for the client to open port 8545 after launching the container.


### PR DESCRIPTION
Allows specifying a `--client-file` parameter which shall be read in YAML or JSON format and must contain the client build modifiers.

Supported modifiers:
- client: Name of the client, eg: besu, go-ethereum, etc
- dockerfile: Dockerfile to use. E.g. using `dockerfile: git` will build using `Dockerfile.git` instead of the default `Dockerfile`
- build_args: Build arguments passed to the docker build engine to use when building the image

Supported docker image build arguments depend on the client and the docker image being used, but common client build arguments are:

 - tag: Git branch or docker tag name to use during build process.
 - github: The repository containing the client source code (for git-based Dockerfiles)
 - baseimage: The client image name on DockerHub.

Also adds example dockerfiles for go-ethereum: `Dockerfile.git`, to build from a git branch, and `Dockerfile.local` to build from a local source path.

This change should allow clients to introduce different Dockerfiles to test using hive in many different environments, such as the CI.