### PR TITLE
clients/nethermind: Add excessDataGas to genesis mapper.

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -163,6 +163,7 @@ def clique_engine:
     "extraData": .extraData,
     "gasLimit": .gasLimit,
     "baseFeePerGas": .baseFeePerGas,
+    "excessDataGas": .excessDataGas,
   },
   "accounts": ((.alloc|with_entries(.key|="0x"+.)) * {
     "0x0000000000000000000000000000000000000001": {

--- a/clients/nethermind/nethermind.sh
+++ b/clients/nethermind/nethermind.sh
@@ -62,6 +62,7 @@ jq . /chainspec/test.json
 
 # Generate the config file.
 mkdir /configs
+echo "Supplied genesis state:" 
 jq -n -f /mkconfig.jq > /configs/test.cfg
 
 echo "test.cfg"


### PR DESCRIPTION
Simply adds `excessDataGas` to the genesis field within `clients/nethermind/mapper.jq`, alongside an `echo` command within `clients/nethermind/nethermind.sh` to match the logging of other clients.