### PR TITLE
clients/nethermind: Dockerfile support to build Nethermind from git or locally

### DIFF
--- a/clients/nethermind/Dockerfile
+++ b/clients/nethermind/Dockerfile
@@ -1,8 +1,7 @@
 ## Build Nethermind Via Pre-Built Image:
-ARG user=nethermindeth
-ARG repo=hive
-ARG branch=latest
-FROM $user/$repo:$branch
+ARG baseimage=nethermindeth/hive
+ARG tag=latest
+FROM $baseimage:$tag
 
 RUN apt-get update && apt-get install -y jq && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -25,4 +24,3 @@ EXPOSE 8545 30303 30303/udp
 
 ENV NETHERMIND_HIVE_ENABLED true
 ENTRYPOINT ["/nethermind.sh"]
-

--- a/clients/nethermind/Dockerfile
+++ b/clients/nethermind/Dockerfile
@@ -1,30 +1,28 @@
+## Build Nethermind Via Pre-Built Image:
 ARG user=nethermindeth
 ARG repo=hive
 ARG branch=latest
 FROM $user/$repo:$branch
 
-RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
-    echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
-    chmod +x /usr/local/bin/jq
+RUN apt-get update && apt-get install -y jq && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Create version.txt
+RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
+
+# Add genesis mapper script, startup script, and enode URL retriever script
 ADD genesis.json /genesis.json
 ADD mapper.jq /mapper.jq
 ADD mkconfig.jq /mkconfig.jq
-ADD enode.sh /enode.sh
 ADD nethermind.sh /nethermind.sh
-
-RUN chmod +x /nethermind.sh
-
-# Add the enode script.
-RUN mkdir /hive-bin
 ADD enode.sh /hive-bin/enode.sh
-RUN chmod +x /hive-bin/enode.sh
 
-# Write the version file.
-RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
+# Set execute permissions for scripts
+RUN chmod +x /nethermind.sh /hive-bin/enode.sh
+
+# Expose networking ports
+EXPOSE 8545 30303 30303/udp
 
 ENV NETHERMIND_HIVE_ENABLED true
-
-EXPOSE 8545 30303 30303/udp
 ENTRYPOINT ["/nethermind.sh"]
+

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -17,9 +17,10 @@ FROM mcr.microsoft.com/dotnet/aspnet:7.0
 
 # Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+WORKDIR /nethermind
 
-RUN apt-get update && apt-get install -y jq && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y jq libsnappy-dev libc6-dev libc6 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create version.txt
 RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && \
@@ -40,3 +41,4 @@ EXPOSE 8545 30303 30303/udp
 
 ENV NETHERMIND_HIVE_ENABLED true
 ENTRYPOINT ["/nethermind.sh"]
+

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -1,0 +1,38 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /nethermind
+ARG user=nethermindeth
+ARG repo=nethermind
+ARG branch=master
+
+RUN git clone -b $branch https://github.com/$user/$repo --recursive .
+RUN cd src/Nethermind/Nethermind.Runner && dotnet build -c release
+
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
+COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
+    echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
+    chmod +x /usr/local/bin/jq
+
+ADD genesis.json /genesis.json
+ADD mapper.jq /mapper.jq
+ADD mkconfig.jq /mkconfig.jq
+ADD enode.sh /enode.sh
+ADD nethermind.sh /nethermind.sh
+
+RUN chmod +x /nethermind.sh
+
+# Add the enode script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Write the version file.
+RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
+RUN dotnet /nethermind/Nethermind.Runner.dll --version
+
+ENV NETHERMIND_HIVE_ENABLED true
+
+EXPOSE 8545 30303 30303/udp
+ENTRYPOINT ["/nethermind.sh"]

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /nethermind
 ARG user=nethermindeth
 ARG repo=nethermind
 ARG branch=master

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -18,7 +18,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:7.0
 # Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
 
-RUN apt-get update && apt-get install -y jq wget && \
+RUN apt-get update && apt-get install -y jq && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -1,39 +1,42 @@
+### Build Nethermind From Git:
+
+## Builder stage: Compiles nethermind from a git repository
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
-WORKDIR /nethermind
+
 ARG user=nethermindeth
 ARG repo=nethermind
 ARG branch=master
 
-RUN git clone -b $branch https://github.com/$user/$repo --recursive .
-RUN cd /nethermind/src/Nethermind/Nethermind.Runner && dotnet build -c release
+RUN echo "Cloning: $user/$repo - $branch" && \
+    git clone -b $branch https://github.com/$user/$repo && \
+    cd /nethermind/src/Nethermind/Nethermind.Runner && \
+    dotnet build -c release
 
+## Final stage: Sets up the environment for running nethermind
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
+
+# Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
-WORKDIR /nethermind
 
-RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
-    echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
-    chmod +x /usr/local/bin/jq
+RUN apt-get update && apt-get install -y jq wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Create version.txt
+RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && \
+    tail -n 1 /raw_version.txt > /version.txt
+
+# Add genesis mapper script, startup script, and enode URL retriever script
 ADD genesis.json /genesis.json
 ADD mapper.jq /mapper.jq
 ADD mkconfig.jq /mkconfig.jq
-ADD enode.sh /enode.sh
 ADD nethermind.sh /nethermind.sh
-
-RUN chmod +x /nethermind.sh
-
-# Add the enode script.
-RUN mkdir /hive-bin
 ADD enode.sh /hive-bin/enode.sh
-RUN chmod +x /hive-bin/enode.sh
 
-# Write the version file.
-RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
-RUN dotnet /nethermind/Nethermind.Runner.dll --version
+# Set execute permissions for scripts
+RUN chmod +x /nethermind.sh /hive-bin/enode.sh
+
+# Expose networking ports
+EXPOSE 8545 30303 30303/udp
 
 ENV NETHERMIND_HIVE_ENABLED true
-
-EXPOSE 8545 30303 30303/udp
 ENTRYPOINT ["/nethermind.sh"]

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -1,14 +1,14 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
-WORKDIR /nethermind
 ARG user=nethermindeth
 ARG repo=nethermind
 ARG branch=master
 
 RUN git clone -b $branch https://github.com/$user/$repo --recursive .
-RUN cd src/Nethermind/Nethermind.Runner && dotnet build -c release
+RUN cd /nethermind/src/Nethermind/Nethermind.Runner && dotnet build -c release
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+WORKDIR /nethermind
 
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -3,12 +3,11 @@
 ## Builder stage: Compiles nethermind from a git repository
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 
-ARG user=nethermindeth
-ARG repo=nethermind
-ARG branch=master
+ARG github=nethermindeth/nethermind
+ARG tag=master
 
 RUN echo "Cloning: $user/$repo - $branch" && \
-    git clone -b $branch https://github.com/$user/$repo && \
+    git clone -b $tag https://github.com/$github && \
     cd /nethermind/src/Nethermind/Nethermind.Runner && \
     dotnet build -c release
 
@@ -41,4 +40,3 @@ EXPOSE 8545 30303 30303/udp
 
 ENV NETHERMIND_HIVE_ENABLED true
 ENTRYPOINT ["/nethermind.sh"]
-

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -15,9 +15,10 @@ FROM mcr.microsoft.com/dotnet/aspnet:7.0
 
 # Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+WORKDIR /nethermind
 
-RUN apt-get update && apt-get install -y jq && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y jq libsnappy-dev libc6-dev libc6 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create version.txt
 RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -1,13 +1,13 @@
 # Build nethermind from a local source:
-# Copy your local client within this directory
+# Copy your local client within this directory.
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ADD nethermind /nethermind
-WORKDIR /nethermind
-RUN cd src/Nethermind/Nethermind.Runner && dotnet build -c release
+RUN cd /nethermind/src/Nethermind/Nethermind.Runner && dotnet build -c release
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+WORKDIR /nethermind
 
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -16,7 +16,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:7.0
 # Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
 
-RUN apt-get update && apt-get install -y jq wget && \
+RUN apt-get update && apt-get install -y jq && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -1,0 +1,37 @@
+# Build nethermind from a local source:
+# Copy your local client within this directory
+
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+ADD nethermind /nethermind
+WORKDIR /nethermind
+RUN cd src/Nethermind/Nethermind.Runner && dotnet build -c release
+
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
+COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
+    echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
+    chmod +x /usr/local/bin/jq
+
+ADD genesis.json /genesis.json
+ADD mapper.jq /mapper.jq
+ADD mkconfig.jq /mkconfig.jq
+ADD enode.sh /enode.sh
+ADD nethermind.sh /nethermind.sh
+
+RUN chmod +x /nethermind.sh
+
+# Add the enode script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Write the version file.
+RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
+RUN dotnet /nethermind/Nethermind.Runner.dll --version
+
+ENV NETHERMIND_HIVE_ENABLED true
+
+EXPOSE 8545 30303 30303/udp
+ENTRYPOINT ["/nethermind.sh"]

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -1,37 +1,39 @@
-# Build nethermind from a local source:
-# Copy your local client within this directory.
+### Build Nethermind Locally:
+### Requires a copy of nethermind/ -> hive/clients/nethermind/
 
+## Builder stage: Compiles nethermind from a local directory
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
-ADD nethermind /nethermind
+
+# Default local client path: clients/nethermind/<nethermind>
+ARG local_path=nethermind
+ADD $local_path /nethermind
+
 RUN cd /nethermind/src/Nethermind/Nethermind.Runner && dotnet build -c release
 
+## Final stage: Sets up the environment for running nethermind
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
+
+# Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
-WORKDIR /nethermind
 
-RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
-    echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
-    chmod +x /usr/local/bin/jq
+RUN apt-get update && apt-get install -y jq wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Create version.txt
+RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
+
+# Add genesis mapper script, startup script, and enode URL retriever script
 ADD genesis.json /genesis.json
 ADD mapper.jq /mapper.jq
 ADD mkconfig.jq /mkconfig.jq
-ADD enode.sh /enode.sh
 ADD nethermind.sh /nethermind.sh
-
-RUN chmod +x /nethermind.sh
-
-# Add the enode script.
-RUN mkdir /hive-bin
 ADD enode.sh /hive-bin/enode.sh
-RUN chmod +x /hive-bin/enode.sh
 
-# Write the version file.
-RUN dotnet /nethermind/Nethermind.Runner.dll --version > /raw_version.txt && tail -n 1 /raw_version.txt > /version.txt
-RUN dotnet /nethermind/Nethermind.Runner.dll --version
+# Set execute permissions for scripts
+RUN chmod +x /nethermind.sh /hive-bin/enode.sh
+
+# Expose networking ports
+EXPOSE 8545 30303 30303/udp
 
 ENV NETHERMIND_HIVE_ENABLED true
-
-EXPOSE 8545 30303 30303/udp
 ENTRYPOINT ["/nethermind.sh"]


### PR DESCRIPTION
Requires: #767.

Adds `clients/nethermind/Dockerfile.git` to build Nethermind from any git branch.
Adds `clients/nethermind/Dockerfile.local` to build Nethermind from a local directory.