### PR TITLE
clients/go-ethereum: remove deprecated PoW

### DIFF
--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -40,9 +40,4 @@ ADD genesis.json /genesis.json
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 8546 8547 8551 30303 30303/udp
 
-# Generate the ethash verification caches
-RUN \
- /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
- /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
-
 ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -58,10 +58,6 @@ fi
 # It doesn't make sense to dial out, use only a pre-set bootnode.
 FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
 
-if [ "$HIVE_SKIP_POW" != "" ]; then
-    FLAGS="$FLAGS --fakepow"
-fi
-
 # If a specific network ID is requested, use that
 if [ "$HIVE_NETWORK_ID" != "" ]; then
     FLAGS="$FLAGS --networkid $HIVE_NETWORK_ID"

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -131,7 +131,7 @@ if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
     # Create password file.
     echo "Importing clique key..."
     echo "secret" > /geth-password-file.txt
-    $geth --nousb account import --password /geth-password-file.txt <(echo "$HIVE_CLIQUE_PRIVATEKEY")
+    $geth account import --password /geth-password-file.txt <(echo "$HIVE_CLIQUE_PRIVATEKEY")
 
     # Ensure password file is used when running geth in mining mode.
     if [ "$HIVE_MINER" != "" ]; then
@@ -141,7 +141,7 @@ fi
 
 # Configure any mining operation
 if [ "$HIVE_MINER" != "" ] && [ "$HIVE_NODETYPE" != "light" ]; then
-    FLAGS="$FLAGS --mine --miner.threads 1 --miner.etherbase $HIVE_MINER"
+    FLAGS="$FLAGS --mine --miner.etherbase $HIVE_MINER"
 fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then
     FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"

--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -55,5 +55,6 @@ def to_bool:
     "mergeForkBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
+    "terminalTotalDifficultyPassed": true,
   }|remove_empty
 }

--- a/simulators/eth2/engine/Dockerfile
+++ b/simulators/eth2/engine/Dockerfile
@@ -1,10 +1,3 @@
-# Generate the ethash verification caches.
-# Use a static version because this will never need to be updated.
-FROM ethereum/client-go:v1.10.20 AS geth
-RUN \
- /usr/local/bin/geth makecache  1 /ethash && \
- /usr/local/bin/geth makedag    1 /ethash
-
 # Build the simulator binary
 FROM golang:1-alpine AS builder
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
@@ -21,6 +14,5 @@ RUN go build -o ./sim .
 FROM alpine:latest
 ADD . /
 COPY --from=builder /source/engine/sim /
-COPY --from=geth    /ethash /ethash
 
 ENTRYPOINT ["./sim"]

--- a/simulators/ethereum/engine/Dockerfile
+++ b/simulators/ethereum/engine/Dockerfile
@@ -1,7 +1,3 @@
-# Generate the ethash verification caches.
-# Use a static version because this will never need to be updated.
-FROM ethereum/client-go:v1.10.20 AS geth
-
 # This simulation runs Engine API tests.
 FROM golang:1-alpine as builder
 RUN apk add --update gcc musl-dev linux-headers
@@ -16,5 +12,4 @@ FROM alpine:latest
 ADD . /source
 WORKDIR /source
 COPY --from=builder /source/engine .
-COPY --from=geth    /ethash /ethash
 ENTRYPOINT ["./engine"]

--- a/simulators/ethereum/engine/Dockerfile
+++ b/simulators/ethereum/engine/Dockerfile
@@ -1,11 +1,6 @@
 # Generate the ethash verification caches.
 # Use a static version because this will never need to be updated.
 FROM ethereum/client-go:v1.10.20 AS geth
-RUN \
- /usr/local/bin/geth makecache  1     /ethash && \
- /usr/local/bin/geth makecache  30000 /ethash && \
- /usr/local/bin/geth makedag    1     /ethash && \
- /usr/local/bin/geth makedag    30000 /ethash
 
 # This simulation runs Engine API tests.
 FROM golang:1-alpine as builder


### PR DESCRIPTION
Geth PoW mining and real verification, and as a result many of the utilities used in tests such as makecache makedag etc.

The `--fakepow` flag is also removed. Now a merge-ready network is required and in that case a PoW fake verifier will be available. To trigger this we set `"terminalTotalDifficultyPassed": true`.

https://github.com/ethereum/go-ethereum/pull/27178