### PR TITLE
clients/erigon: change p2p version priorities to fix several Erigon devp2p tests

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -55,6 +55,8 @@ fi
 mkdir /erigon-hive-datadir
 FLAGS="$FLAGS --datadir /erigon-hive-datadir"
 FLAGS="$FLAGS --db.size.limit 2GB"
+FLAGS="$FLAGS --p2p.protocol 68,67,66"
+
 
 # If a specific network ID is requested, use that
 if [ "$HIVE_NETWORK_ID" != "" ]; then


### PR DESCRIPTION
Use 68 version as default. This fixes 5 failed devp2p tests for Erigon