### PR TITLE
sim/pyspec: bubble error

### DIFF
--- a/simulators/ethereum/pyspec/main.go
+++ b/simulators/ethereum/pyspec/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -90,8 +91,11 @@ func fixtureRunner(t *hivesim.T) {
 		}()
 	}
 
+	_, testPattern := t.Sim.TestPattern()
+	re := regexp.MustCompile(testPattern)
+
 	// deliver and run test cases against each client
-	loadFixtureTests(t, fileRoot, func(tc testcase) {
+	loadFixtureTests(t, fileRoot, re, func(tc testcase) {
 		for _, client := range clientTypes {
 			if !client.HasRole("eth1") {
 				continue

--- a/simulators/ethereum/pyspec/types.go
+++ b/simulators/ethereum/pyspec/types.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 
 	api "github.com/ethereum/go-ethereum/beacon/engine"
@@ -144,14 +145,17 @@ type withdrawalsUnmarshaling struct {
 
 // extractFixtureFields extracts the genesis, payloads and post allocation
 // fields from the given fixture test and stores them in the testcase struct.
-func (tc *testcase) extractFixtureFields(fixture fixtureJSON) {
+func (tc *testcase) extractFixtureFields(fixture fixtureJSON) error {
 	// extract genesis fields from fixture test
 	tc.genesis = extractGenesis(fixture)
 
 	// extract payloads from each block
 	payloads := []*api.ExecutableData{}
-	for _, block := range fixture.Blocks {
-		block, _ := block.decodeBlock()
+	for _, bl := range fixture.Blocks {
+		block, err := bl.decodeBlock()
+		if err != nil {
+			return fmt.Errorf("failed to decode block: %v", err)
+		}
 		payload := api.BlockToExecutableData(block, common.Big0).ExecutionPayload
 		payloads = append(payloads, payload)
 	}
@@ -159,6 +163,7 @@ func (tc *testcase) extractFixtureFields(fixture fixtureJSON) {
 
 	// extract post account information
 	tc.postAlloc = &fixture.Post
+	return nil
 }
 
 // extractGenesis extracts the genesis block information from the given fixture


### PR DESCRIPTION
This fixes https://github.com/ethereum/hive/issues/774. It also adds support for `-sim.limit`
Example:
```
user@debian-work:~/workspace/hive$ ./hive --sim ethereum/pyspec --client go-ethereum_latest  --sim.loglevel 3 --docker.output -sim.limit=pyspec/invalid_blob_txs
```
```
INFO[05-05|14:14:41] running simulation: ethereum/pyspec 
INFO[05-05|14:14:42] hiveproxy started                        container=1f6d4f6eb159 addr=172.17.0.2:8081
INFO[05-05|14:14:42] API: suite started                       suite=0 name=pyspec
INFO[05-05|14:14:42] API: test started                        suite=0 test=1 name=pytest_fixture_runner
[34c50e31] parallelism set to: 1
[34c50e31] file root directory: /fixtures/
[34c50e31] skip eips/eip3651/warm_coinbase_call_out_of_gas
[34c50e31] skip eips/eip3651/warm_coinbase_gas_usage
INFO[05-05|14:14:42] API: test started                        suite=0 test=2 name=eips/eip4844/excess_data_gas/invalid_blob_txs/000/type_3_tx_pre_fork/shanghai
INFO[05-05|14:14:42] API: test ended                          suite=0 test=2 pass=false
[34c50e31] skip eips/eip3855/push0
INFO[05-05|14:14:42] API: test started                        suite=0 test=3 name=eips/eip4844/excess_data_gas/invalid_blob_txs/001/empty_type_3_tx_pre_fork/shanghai
INFO[05-05|14:14:42] API: test ended                          suite=0 test=3 pass=false
[34c50e31] skip eips/eip3860/initcode_limit_contract_creating_tx
[34c50e31] skip eips/eip3860/initcode_limit_contract_creating_tx_gas_usage
[34c50e31] skip eips/eip3860/initcode_limit_create2_opcode
[34c50e31] skip eips/eip3860/initcode_limit_create_opcode
INFO[05-05|14:14:42] API: test ended                          suite=0 test=1 pass=true
INFO[05-05|14:14:42] API: suite ended                         suite=0
[34c50e31] test invalid_blob_txs.json / 000/type_3_tx_pre_fork/shanghai: unable to extract fixture fields: failed to decode block: transaction type not supported
[34c50e31] test invalid_blob_txs.json / 001/empty_type_3_tx_pre_fork/shanghai: unable to extract fixture fields: failed to decode block: transaction type not supported
[34c50e31] setting variables required for starting client.
[34c50e31] test failed early: unable to extract fixture fields: failed to decode block: transaction type not supported
[34c50e31] skip example/acl_example/access_list
[34c50e31] skip example/yul_example/yul
[34c50e31] skip security/selfdestruct_balance_bug/tx_selfdestruct_balance_bug
[34c50e31] skip vm/chain_id/chain_id
[34c50e31] skip vm/dup/dup
[34c50e31] skip withdrawals/withdrawals/balance_within_block
[34c50e31] skip withdrawals/withdrawals/large_amount
[34c50e31] skip withdrawals/withdrawals/many_withdrawals
[34c50e31] skip withdrawals/withdrawals/multiple_withdrawals_same_address
[34c50e31] skip withdrawals/withdrawals/newly_created_contract
[34c50e31] skip withdrawals/withdrawals/no_evm_execution
[34c50e31] skip withdrawals/withdrawals/self_destructing_account
[34c50e31] skip withdrawals/withdrawals/use_value_in_contract
[34c50e31] skip withdrawals/withdrawals/use_value_in_tx
[34c50e31] skip withdrawals/withdrawals/zero_amount
[34c50e31] setting variables required for starting client.
[34c50e31] test failed early: unable to extract fixture fields: failed to decode block: transaction type not supported
[34c50e31] failing tests:
[34c50e31] go-ethereum_latest/eips/eip4844/excess_data_gas/invalid_blob_txs/000/type_3_tx_pre_fork/shanghai: unable to extract fixture fields: failed to decode block: transaction type not supported
[34c50e31] go-ethereum_latest/eips/eip4844/excess_data_gas/invalid_blob_txs/001/empty_type_3_tx_pre_fork/shanghai: unable to extract fixture fields: failed to decode block: transaction type not supported
INFO[05-05|14:14:43] simulation ethereum/pyspec finished      suites=1 tests=3 failed=2
```