### PR TITLE
clients/erigon: Dockerfile support to build Erigon from git or locally.

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -1,29 +1,31 @@
+## Build Erigon Via Pre-Built Image:
+ARG user=thorax
+ARG repo=erigon
 ARG branch=devel
-FROM thorax/erigon:$branch
+FROM $user/$repo:$branch
 
 # The upstream erigon container uses a non-root user, but we need
 # to install additional commands, so switch back to root.
 USER root
 
-# Install script tools.
-RUN apk add --update bash curl jq
-
-# Add genesis mapper script.
-ADD genesis.json /genesis.json
-ADD mapper.jq /mapper.jq
-
-# Add the startup script.
-ADD erigon.sh /erigon.sh
-RUN chmod +x /erigon.sh
-
-# Add the enode URL retriever script.
-ADD enode.sh /hive-bin/enode.sh
-RUN chmod +x /hive-bin/enode.sh
+RUN apk add --no-cache \
+    bash \
+    curl \
+    jq
 
 # Create version.txt
-RUN /usr/local/bin/erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
+RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
 
-# Export the usual networking ports to allow outside access to the node.
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY erigon.sh /erigon.sh
+COPY enode.sh /hive-bin/enode.sh
+
+# Set execute permissions for scripts
+RUN chmod +x /erigon.sh /hive-bin/enode.sh
+
+# Expose networking ports
 EXPOSE 8545 8546 8551 30303 30303/udp
 
 ENTRYPOINT ["/erigon.sh"]

--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -8,10 +8,7 @@ FROM $user/$repo:$branch
 # to install additional commands, so switch back to root.
 USER root
 
-RUN apk add --no-cache \
-    bash \
-    curl \
-    jq
+RUN apk add --no-cache bash curl jq
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt

--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -1,8 +1,7 @@
 ## Build Erigon Via Pre-Built Image:
-ARG user=thorax
-ARG repo=erigon
-ARG branch=devel
-FROM $user/$repo:$branch
+ARG baseimage=thorax/erigon
+ARG tag=devel
+FROM $baseimage:$tag
 
 # The upstream erigon container uses a non-root user, but we need
 # to install additional commands, so switch back to root.

--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -1,45 +1,54 @@
-# Builds erigon from a git repository.
+## Build Erigon From Git:
+
+# Builder stage: Compiles erigon from a git repository
 FROM golang:1-alpine as builder
+
 ARG user=ledgerwatch
 ARG repo=erigon
 ARG branch=devel
 
-RUN \
-    apk add --update build-base linux-headers git bash jq          \
-    ca-certificates libstdc++ libgcc musl-dev                   && \
-    git clone --depth 1 --branch $branch                           \
-    https://github.com/$user/$repo                              && \
-    (cd erigon && make erigon)                                  && \
-    (cd erigon                                                  && \
-    echo "{}"                                                      \
-    | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
-    | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
-    | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
-    > /version.json)
+RUN apk add --no-cache \
+    build-base \
+    linux-headers \
+    git \
+    bash \
+    jq \
+    ca-certificates
 
+RUN git clone --depth 1 --branch $branch https://github.com/$user/$repo \
+    && cd erigon \
+    && make erigon \
+    && echo "{}" \
+    | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
+    | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}" \
+    | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}" > /version.json
+
+# Final stage: Sets up the environment for running erigon
 FROM alpine:latest
-RUN apk add --update bash curl jq libstdc++ libgcc
 
 # Copy compiled binary from builder
-COPY --from=builder /build/bin/* /usr/local/bin/
+COPY --from=builder /go/erigon/build/bin/* /usr/local/bin/
+
+RUN apk add --no-cache \
+    bash \
+    curl \
+    jq \
+    libstdc++ \
+    libgcc
 
 # Create version.txt
-RUN /usr/local/bin/erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
+RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
 
-# Add genesis mapper script
-ADD genesis.json /genesis.json
-ADD mapper.jq /mapper.jq
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY erigon.sh /erigon.sh
+COPY enode.sh /hive-bin/enode.sh
 
-# Add the startup script
-ADD erigon.sh /erigon.sh
-RUN chmod +x /erigon.sh
+# Set execute permissions for scripts
+RUN chmod +x /erigon.sh /hive-bin/enode.sh
 
-# Add the enode URL retriever script
-ADD enode.sh /hive-bin/enode.sh
-RUN chmod +x /hive-bin/enode.sh
-
-
-# Export the usual networking ports to allow outside access to the node
+# Expose networking ports
 EXPOSE 8545 8546 8551 30303 30303/udp
 
 ENTRYPOINT ["/erigon.sh"]

--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -3,18 +3,13 @@
 ## Builder stage: Compiles erigon from a git repository
 FROM golang:1-alpine as builder
 
-ARG user=ledgerwatch
-ARG repo=erigon
-ARG branch=devel
+ARG github=ledgerwatch/erigon
+ARG tag=devel
 
-RUN echo "Cloning: $user/$repo - $branch" \
+RUN echo "Cloning: $github - $tag" \
     && apk add bash build-base ca-certificates git jq \
-    && git clone --depth 1 --branch $branch https://github.com/$user/$repo \
-    && cd erigon && make erigon && echo "{}" \
-    | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
-    | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}" \
-    | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}" > /version.json \
-    && cp build/bin/erigon /usr/local/bin/erigon 
+    && git clone --depth 1 --branch $tag https://github.com/$tag \
+    && cp build/bin/erigon /usr/local/bin/erigon
 
 ## Final stage: Sets up the environment for running erigon
 FROM alpine:latest

--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -7,7 +7,8 @@ ARG user=ledgerwatch
 ARG repo=erigon
 ARG branch=devel
 
-RUN apk add bash build-base ca-certificates git jq \
+RUN echo "Cloning: $user/$repo - $branch" \
+    && apk add bash build-base ca-certificates git jq \
     && git clone --depth 1 --branch $branch https://github.com/$user/$repo \
     && cd erigon && make erigon && echo "{}" \
     | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \

--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -1,0 +1,45 @@
+# Builds erigon from a git repository.
+FROM golang:1-alpine as builder
+ARG user=ledgerwatch
+ARG repo=erigon
+ARG branch=devel
+
+RUN \
+    apk add --update build-base linux-headers git bash jq          \
+    ca-certificates libstdc++ libgcc musl-dev                   && \
+    git clone --depth 1 --branch $branch                           \
+    https://github.com/$user/$repo                              && \
+    (cd erigon && make erigon)                                  && \
+    (cd erigon                                                  && \
+    echo "{}"                                                      \
+    | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
+    | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
+    | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
+    > /version.json)
+
+FROM alpine:latest
+RUN apk add --update bash curl jq libstdc++ libgcc
+
+# Copy compiled binary from builder
+COPY --from=builder /build/bin/* /usr/local/bin/
+
+# Create version.txt
+RUN /usr/local/bin/erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
+
+# Add genesis mapper script
+ADD genesis.json /genesis.json
+ADD mapper.jq /mapper.jq
+
+# Add the startup script
+ADD erigon.sh /erigon.sh
+RUN chmod +x /erigon.sh
+
+# Add the enode URL retriever script
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8551 30303 30303/udp
+
+ENTRYPOINT ["/erigon.sh"]

--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -1,40 +1,27 @@
-## Build Erigon From Git:
+### Build Erigon From Git:
 
-# Builder stage: Compiles erigon from a git repository
+## Builder stage: Compiles erigon from a git repository
 FROM golang:1-alpine as builder
 
 ARG user=ledgerwatch
 ARG repo=erigon
 ARG branch=devel
 
-RUN apk add --no-cache \
-    build-base \
-    linux-headers \
-    git \
-    bash \
-    jq \
-    ca-certificates
-
-RUN git clone --depth 1 --branch $branch https://github.com/$user/$repo \
-    && cd erigon \
-    && make erigon \
-    && echo "{}" \
+RUN apk add bash build-base ca-certificates git jq \
+    && git clone --depth 1 --branch $branch https://github.com/$user/$repo \
+    && cd erigon && make erigon && echo "{}" \
     | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
     | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}" \
-    | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}" > /version.json
+    | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}" > /version.json \
+    && cp build/bin/erigon /usr/local/bin/erigon 
 
-# Final stage: Sets up the environment for running erigon
+## Final stage: Sets up the environment for running erigon
 FROM alpine:latest
 
 # Copy compiled binary from builder
-COPY --from=builder /go/erigon/build/bin/* /usr/local/bin/
+COPY --from=builder /usr/local/bin/erigon /usr/local/bin/
 
-RUN apk add --no-cache \
-    bash \
-    curl \
-    jq \
-    libstdc++ \
-    libgcc
+RUN apk add --no-cache bash gcc jq libstdc++
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt

--- a/clients/erigon/Dockerfile.local
+++ b/clients/erigon/Dockerfile.local
@@ -1,33 +1,48 @@
-# Build erigon from source using a local directory.
+## Build Erigon Locally:
+# Requires a copy of erigon/ -> hive/clients/erigon/
+
+# Builder stage: Compiles erigon from a local directory
 FROM golang:1-alpine as builder
-ADD erigon /erigon
+
+COPY erigon /erigon
 WORKDIR /erigon
-RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
+
+RUN apk add --no-cache \
+    build-base \
+    linux-headers \
+    git \
+    bash \
+    jq \
+    ca-certificates
+
 RUN make erigon
 
+# Final stage: Sets up the environment for running erigon
 FROM alpine:latest
-RUN apk add --update bash curl jq libstdc++ libgcc
 
 # Copy compiled binary from builder
 COPY --from=builder /erigon/build/bin/* /usr/local/bin/
 
+RUN apk add --no-cache \
+    bash \
+    curl \
+    jq \
+    libstdc++ \
+    libgcc
+
 # Create version.txt
-RUN /usr/local/bin/erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
+RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
 
-# Add genesis mapper script
-ADD genesis.json /genesis.json
-ADD mapper.jq /mapper.jq
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY erigon.sh /erigon.sh
+COPY enode.sh /hive-bin/enode.sh
 
-# Add the startup script
-ADD erigon.sh /erigon.sh
-RUN chmod +x /erigon.sh
+# Set execute permissions for scripts
+RUN chmod +x /erigon.sh /hive-bin/enode.sh
 
-# Add the enode URL retriever script
-ADD enode.sh /hive-bin/enode.sh
-RUN chmod +x /hive-bin/enode.sh
-
-
-# Export the usual networking ports to allow outside access to the node
+# Expose networking ports
 EXPOSE 8545 8546 8551 30303 30303/udp
 
 ENTRYPOINT ["/erigon.sh"]

--- a/clients/erigon/Dockerfile.local
+++ b/clients/erigon/Dockerfile.local
@@ -1,34 +1,22 @@
-## Build Erigon Locally:
-# Requires a copy of erigon/ -> hive/clients/erigon/
+### Build Erigon Locally:
+### Requires a copy of erigon/ -> hive/clients/erigon/
 
-# Builder stage: Compiles erigon from a local directory
+## Builder stage: Compiles erigon from a local directory
 FROM golang:1-alpine as builder
 
-COPY erigon /erigon
-WORKDIR /erigon
+COPY erigon erigon
 
-RUN apk add --no-cache \
-    build-base \
-    linux-headers \
-    git \
-    bash \
-    jq \
-    ca-certificates
+RUN apk add bash build-base ca-certificates git \
+    && cd erigon && make erigon \
+    && cp build/bin/erigon /usr/local/bin/erigon
 
-RUN make erigon
-
-# Final stage: Sets up the environment for running erigon
+## Final stage: Sets up the environment for running erigon
 FROM alpine:latest
 
 # Copy compiled binary from builder
-COPY --from=builder /erigon/build/bin/* /usr/local/bin/
+COPY --from=builder /usr/local/bin/erigon /usr/local/bin/
 
-RUN apk add --no-cache \
-    bash \
-    curl \
-    jq \
-    libstdc++ \
-    libgcc
+RUN apk add --no-cache bash curl jq libstdc++ libgcc
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt

--- a/clients/erigon/Dockerfile.local
+++ b/clients/erigon/Dockerfile.local
@@ -4,7 +4,9 @@
 ## Builder stage: Compiles erigon from a local directory
 FROM golang:1-alpine as builder
 
-COPY erigon erigon
+# Default local client path: clients/erigon/<erigon>
+ARG local_path=erigon
+COPY $local_path erigon
 
 RUN apk add bash build-base ca-certificates git \
     && cd erigon && make erigon \

--- a/clients/erigon/Dockerfile.local
+++ b/clients/erigon/Dockerfile.local
@@ -1,0 +1,33 @@
+# Build erigon from source using a local directory.
+FROM golang:1-alpine as builder
+ADD erigon /erigon
+WORKDIR /erigon
+RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
+RUN make erigon
+
+FROM alpine:latest
+RUN apk add --update bash curl jq libstdc++ libgcc
+
+# Copy compiled binary from builder
+COPY --from=builder /erigon/build/bin/* /usr/local/bin/
+
+# Create version.txt
+RUN /usr/local/bin/erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt
+
+# Add genesis mapper script
+ADD genesis.json /genesis.json
+ADD mapper.jq /mapper.jq
+
+# Add the startup script
+ADD erigon.sh /erigon.sh
+RUN chmod +x /erigon.sh
+
+# Add the enode URL retriever script
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8551 30303 30303/udp
+
+ENTRYPOINT ["/erigon.sh"]


### PR DESCRIPTION
Requires: https://github.com/ethereum/hive/pull/767.

Adds clients/erigon/Dockerfile.git to build Erigon from any git branch.
Adds clients/erigon/Dockerfile.local to build Erigon from a local directory.