### PR TITLE
clients/besu: Dockerfile support to build Erigon from git or locally.

### DIFF
--- a/clients/besu/Dockerfile
+++ b/clients/besu/Dockerfile
@@ -1,29 +1,28 @@
+## Build Besu Via Pre-Built Image:
+ARG user=hyperledger
+ARG repo=besu
 ARG branch=develop
-FROM hyperledger/besu:$branch
+FROM $user/$repo:$branch
 
 USER root
-RUN apt-get update && apt-get install -y curl
-RUN curl -L -o /usr/local/bin/jq 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64' && \
-    echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' | sha256sum -c && \
-    chmod +x /usr/local/bin/jq
 
-# Inject the startup script.
-ADD besu.sh /opt/besu/bin/besu-hive.sh
-RUN chmod +x /opt/besu/bin/besu-hive.sh
-ADD mapper.jq /mapper.jq
-ADD genesis.json /genesis.json
+# Update, install curl, download and install jq, and clean up in one step
+RUN apt-get update && apt-get install -y curl jq && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Inject the enode URL retriever script.
-RUN mkdir /hive-bin
-ADD enode.sh /hive-bin/enode.sh
-RUN chmod +x /hive-bin/enode.sh
+# Create version.txt
+RUN /opt/besu/bin/besu --version > /version.txt
 
-RUN ./bin/besu --version > /version.txt
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY besu.sh /opt/besu/bin/besu-hive.sh
+COPY enode.sh /hive-bin/enode.sh
 
-# Expose JVM debugger port.
-EXPOSE 5005
+# Set execute permissions for scripts
+RUN chmod +x /opt/besu/bin/besu-hive.sh /hive-bin/enode.sh
 
-# Expose the usual networking ports to allow outside access to the node.
-EXPOSE 8545 8546 8551 30303 30303/udp
+# Expose networking ports (incl 5005 for JVM debugging)
+EXPOSE 8545 8546 8551 30303 30303/udp 5005
 
 ENTRYPOINT ["/opt/besu/bin/besu-hive.sh"]

--- a/clients/besu/Dockerfile.git
+++ b/clients/besu/Dockerfile.git
@@ -1,0 +1,38 @@
+### Build Besu From Git:
+
+## Builder stage: Compiles besu from a git repository
+FROM openjdk:17-jdk-slim as builder
+
+ARG branch=main
+ARG user=hyperledger
+ARG repo=besu
+
+RUN apt-get update && apt-get install -y git libsodium-dev libnss3-dev \
+    && git clone --depth 1 --branch $branch https://github.com/$user/$repo \
+    && cd besu && ./gradlew installDist
+
+## Final stage: Sets up the environment for running besu
+FROM openjdk:17-jdk-slim
+
+# Copy compiled binary from builder
+COPY --from=builder /besu/build/install/besu /opt/besu
+
+RUN apt-get update && apt-get install -y curl jq libsodium23 libnss3-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create version.txt
+RUN /opt/besu/bin/besu --version > /version.txt
+
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY besu.sh /opt/besu/bin/besu-hive.sh
+COPY enode.sh /hive-bin/enode.sh
+
+# Set execute permissions for scripts
+RUN chmod +x /opt/besu/bin/besu-hive.sh /hive-bin/enode.sh
+
+# Expose networking ports (incl 5005 for JVM debugging)
+EXPOSE 8545 8546 8551 30303 30303/udp 5005
+
+ENTRYPOINT ["/opt/besu/bin/besu-hive.sh"]

--- a/clients/besu/Dockerfile.local
+++ b/clients/besu/Dockerfile.local
@@ -1,0 +1,35 @@
+### Build Besu Locally:
+
+## Builder stage: Compiles besu from a local directory
+FROM openjdk:17-jdk-slim as builder
+
+COPY besu besu
+
+RUN apt-get update && apt-get install -y git libsodium-dev libnss3-dev \
+    && cd besu && ./gradlew installDist
+
+## Final stage: Sets up the environment for running besu
+FROM openjdk:17-jdk-slim
+
+# Copy compiled binary from builder
+COPY --from=builder /besu/build/install/besu /opt/besu
+
+RUN apt-get update && apt-get install -y curl jq libsodium23 libnss3-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create version.txt
+RUN /opt/besu/bin/besu --version > /version.txt
+
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY besu.sh /opt/besu/bin/besu-hive.sh
+COPY enode.sh /hive-bin/enode.sh
+
+# Set execute permissions for scripts
+RUN chmod +x /opt/besu/bin/besu-hive.sh /hive-bin/enode.sh
+
+# Expose networking ports (incl 5005 for JVM debugging)
+EXPOSE 8545 8546 8551 30303 30303/udp 5005
+
+ENTRYPOINT ["/opt/besu/bin/besu-hive.sh"]


### PR DESCRIPTION
Requires: https://github.com/ethereum/hive/pull/767.

Updates clients/besu/Dockerfile.
Adds clients/besu/Dockerfile.git to build Besu from any git branch.
Adds clients/besu/Dockerfile.local to build Besu from a local directory.