### PR TITLE
clients/ethereumjs: Dockerfile support to build Ethereumjs locally

### DIFF
--- a/clients/ethereumjs/Dockerfile
+++ b/clients/ethereumjs/Dockerfile
@@ -1,9 +1,9 @@
 ### Build EthereumJS From Git:
 
-FROM node:16-alpine as build
+FROM node:18-alpine as build
 
 ARG github=ethereumjs/ethereumjs-monorepo
-ARG tag=develop-v7
+ARG tag=master
 
 RUN echo "Cloning: $github - $tag" \
     && apk update && apk add --no-cache bash git jq curl python3 gcc make g++ \

--- a/clients/ethereumjs/Dockerfile
+++ b/clients/ethereumjs/Dockerfile
@@ -1,15 +1,14 @@
-### Build Ethereumjs From Git:
+### Build EthereumJS From Git:
 
 FROM node:16-alpine as build
 
-ARG user=ethereumjs
-ARG repo=ethereumjs-monorepo
-ARG branch=develop-v7
+ARG github=ethereumjs/ethereumjs-monorepo
+ARG tag=develop-v7
 
-RUN echo "Cloning: $user/$repo - $branch" \ 
+RUN echo "Cloning: $github - $tag" \
     && apk update && apk add --no-cache bash git jq curl python3 gcc make g++ \
     && rm -rf /var/cache/apk/* \
-    && git clone --depth 1 -b $branch https://github.com/$user/$repo \
+    && git clone --depth 1 -b $tag https://github.com/$github \
     && cd ethereumjs-monorepo && npm i
 
 # Create version.txt

--- a/clients/ethereumjs/Dockerfile.local
+++ b/clients/ethereumjs/Dockerfile.local
@@ -1,15 +1,14 @@
-### Build Ethereumjs From Git:
+### Build Ethereumjs Locally:
+### Requires a copy of ethereumjs-monorepo/ -> hive/clients/ethereumjs/
 
-FROM node:16-alpine as build
+FROM node:16-alpine
 
-ARG user=ethereumjs
-ARG repo=ethereumjs-monorepo
-ARG branch=develop-v7
+# Default local client path: clients/ethereumjs/<ethereumjs-monorepo>
+ARG local_path=ethereumjs-monorepo
+COPY $local_path ethereumjs-monorepo
 
-RUN echo "Cloning: $user/$repo - $branch" \ 
-    && apk update && apk add --no-cache bash git jq curl python3 gcc make g++ \
+RUN apk update && apk add --no-cache bash git jq curl python3 gcc make g++ && \
     && rm -rf /var/cache/apk/* \
-    && git clone --depth 1 -b $branch https://github.com/$user/$repo \
     && cd ethereumjs-monorepo && npm i
 
 # Create version.txt

--- a/clients/ethereumjs/Dockerfile.local
+++ b/clients/ethereumjs/Dockerfile.local
@@ -1,7 +1,7 @@
 ### Build Ethereumjs Locally:
 ### Requires a copy of ethereumjs-monorepo/ -> hive/clients/ethereumjs/
 
-FROM node:16-alpine
+FROM node:18-alpine
 
 # Default local client path: clients/ethereumjs/<ethereumjs-monorepo>
 ARG local_path=ethereumjs-monorepo


### PR DESCRIPTION
Requires: https://github.com/ethereum/hive/pull/767.

Updates clients/ethereumjs/Dockerfile.
Adds clients/ethereumjs/Dockerfile.local to build Ethereumjs from a local directory.