### PR TITLE
clients/go-ethereum: fix typo in git dockerfile

### DIFF
--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -10,7 +10,7 @@ RUN \
   git clone --depth 1 --branch $tag https://github.com/$github     && \
   cd go-ethereum                                                   && \
   make geth                                                        && \
-  cp go-ethereum/build/bin/geth /usr/local/bin/geth                && \
+  cp build/bin/geth /usr/local/bin/geth                            && \
   apk del go git make gcc musl-dev linux-headers                   && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Fixes a typo when the built binary is copied in the Dockerfile.git for go-ethereum.