### PR TITLE
simulators/ethereum/engine: Per-fork Exchange Capabilities  Tests

### DIFF
--- a/simulators/ethereum/engine/go.mod
+++ b/simulators/ethereum/engine/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.11.4
 	github.com/ethereum/hive v0.0.0-20230313141339-8e3200bfc09e
 	github.com/golang-jwt/jwt/v4 v4.4.3
+	github.com/pkg/errors v0.9.1
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 )
 
@@ -59,7 +60,6 @@ require (
 	github.com/mitchellh/pointerstructure v1.2.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/peterh/liner v1.2.2 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -58,7 +58,7 @@ func main() {
 	addTestsToSuite(simulator, &engine, specToInterface(suite_engine.Tests), "full")
 	addTestsToSuite(simulator, &transition, specToInterface(suite_transition.Tests), "full")
 	addTestsToSuite(simulator, &auth, specToInterface(suite_auth.Tests), "full")
-	addTestsToSuite(simulator, &excap, specToInterface(suite_ex_cap.Tests), "full")
+	addTestsToSuite(simulator, &excap, suite_ex_cap.Tests, "full")
 	//suite_sync.AddSyncTestsToSuite(simulator, &sync, suite_sync.Tests)
 	addTestsToSuite(simulator, &withdrawals, suite_withdrawals.Tests, "full")
 

--- a/simulators/ethereum/engine/suites/exchange_capabilities/tests.go
+++ b/simulators/ethereum/engine/suites/exchange_capabilities/tests.go
@@ -1,32 +1,64 @@
 package suite_exchange_capabilities
 
 import (
+	"math/big"
+
 	"github.com/ethereum/hive/simulators/ethereum/engine/test"
 	"golang.org/x/exp/slices"
 )
 
-var Tests = []test.Spec{
-	{
-		Name: "Exchange Capabilities",
-		Run:  exCapTests,
+var (
+	ShanghaiCapabilities = []string{
+		"engine_newPayloadV1",
+		"engine_newPayloadV2",
+		"engine_forkchoiceUpdatedV1",
+		"engine_forkchoiceUpdatedV2",
+		"engine_getPayloadV1",
+		"engine_getPayloadV2",
+	}
+	CancunCapabilities = []string{
+		"engine_newPayloadV1",
+		"engine_newPayloadV2",
+		"engine_newPayloadV3",
+		"engine_forkchoiceUpdatedV1",
+		"engine_forkchoiceUpdatedV2",
+		"engine_getPayloadV1",
+		"engine_getPayloadV2",
+		"engine_getPayloadV3",
+	}
+)
+
+var Tests = []test.SpecInterface{
+	ExchangeCapabilitiesSpec{
+		Spec: test.Spec{
+			Name: "Exchange Capabilities - Shanghai",
+			ForkConfig: test.ForkConfig{
+				ShanghaiTimestamp: big.NewInt(0),
+			},
+		},
+		MinimalExpectedCapabilitiesSet: ShanghaiCapabilities,
+	},
+	ExchangeCapabilitiesSpec{
+		Spec: test.Spec{
+			Name: "Exchange Capabilities - Shanghai (Not active)",
+			ForkConfig: test.ForkConfig{
+				ShanghaiTimestamp: big.NewInt(1000),
+			},
+		},
+		MinimalExpectedCapabilitiesSet: ShanghaiCapabilities,
 	},
 }
 
-var minimalSetExpectedSupportedELCapabilities = []string{
-	"engine_newPayloadV1",
-	"engine_newPayloadV2",
-	"engine_forkchoiceUpdatedV1",
-	"engine_forkchoiceUpdatedV2",
-	"engine_getPayloadV1",
-	"engine_getPayloadV2",
-	// "engine_getPayloadBodiesByRangeV1",
+type ExchangeCapabilitiesSpec struct {
+	test.Spec
+	MinimalExpectedCapabilitiesSet []string
 }
 
-func exCapTests(t *test.Env) {
-	if returnedCapabilities, err := t.HiveEngine.ExchangeCapabilities(t.TestContext, minimalSetExpectedSupportedELCapabilities); err != nil {
+func (s ExchangeCapabilitiesSpec) Execute(t *test.Env) {
+	if returnedCapabilities, err := t.HiveEngine.ExchangeCapabilities(t.TestContext, s.MinimalExpectedCapabilitiesSet); err != nil {
 		t.Fatalf("FAIL (%s): Unable request capabilities: %v", t.TestName, err)
 	} else {
-		for _, cap := range minimalSetExpectedSupportedELCapabilities {
+		for _, cap := range s.MinimalExpectedCapabilitiesSet {
 			if !slices.Contains(returnedCapabilities, cap) {
 				t.Fatalf("FAIL (%s): Expected capability (%s) not found", t.TestName, cap)
 			}

--- a/simulators/ethereum/go.work.sum
+++ b/simulators/ethereum/go.work.sum
@@ -114,6 +114,7 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.9.1-0.20230105202408-1a7a29904a7c/go.mod h1:CkbdF9hbRidRJYMRzmfX8TMOr95I2pYXRHF18MzRrvA=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
@@ -417,6 +418,7 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
@@ -458,6 +460,7 @@ github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
+github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
@@ -914,6 +917,7 @@ k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+rsc.io/tmplfunc v0.0.3 h1:53XFQh69AfOa8Tw0Jm7t+GV7KZhOi6jzsCzTtKbMvzU=
 rsc.io/tmplfunc v0.0.3/go.mod h1:AG3sTPzElb1Io3Yg4voV9AGZJuleGAwaVRxL9M49PhA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=


### PR DESCRIPTION
Changes the `engine-exchange-capabilities` test suite to run with proper fork configuration, with and without the fork being already active.

Currently only Shanghai, and Cancun should be added in #759 