### PR TITLE
clients/nethermind: add dataGasUsed to mapper

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -163,6 +163,7 @@ def clique_engine:
     "extraData": .extraData,
     "gasLimit": .gasLimit,
     "baseFeePerGas": .baseFeePerGas,
+    "dataGasUsed": .dataGasUsed,
     "excessDataGas": .excessDataGas,
   },
   "accounts": ((.alloc|with_entries(.key|="0x"+.)) * {


### PR DESCRIPTION
Adds `dataGasUsed` to the genesis mapper of Nethermind, for it to be able to start from Cancun fork.