### PR TITLE
hive: make -client filter the list given in YAML file

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/ethereum/hive/internal/libdocker"
@@ -117,17 +116,20 @@ func main() {
 
 	// Parse the client list.
 	// It can be supplied as a comma-separated list, or as a YAML file.
-	checkFlagsExclusive("client", "client-file")
-	var clientList []libhive.ClientDesignator
+	clientList, err := libhive.ParseClientList(&inv, *clients)
+	if err != nil {
+		fatal("-client:", err)
+	}
 	if *clientsFile != "" {
-		clientList, err = parseClientsFile(&inv, *clientsFile)
+		clientListFromFile, err := parseClientsFile(&inv, *clientsFile)
 		if err != nil {
 			fatal("-client-file:", err)
 		}
-	} else {
-		clientList, err = libhive.ParseClientList(&inv, *clients)
-		if err != nil {
-			fatal("-client:", err)
+		// If YAML file is used, the list is filtered by the -client flag.
+		if flagIsSet("client") {
+			clientList = libhive.FilterClients(clientListFromFile, clientList)
+		} else {
+			clientList = clientListFromFile
 		}
 	}
 
@@ -175,27 +177,12 @@ func parseClientsFile(inv *libhive.Inventory, file string) ([]libhive.ClientDesi
 	return libhive.ParseClientListYAML(inv, f)
 }
 
-func checkFlagsExclusive(flagNames ...string) {
-	set := make(map[string]bool)
-	flag.Visit(func(f *flag.Flag) {
-		set[f.Name] = true
-	})
+func flagIsSet(name string) bool {
 	var found bool
-	for _, name := range flagNames {
-		if set[name] {
-			if found {
-				fatal("flags", flagListString(flagNames), "cannot be used together")
-			}
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
 			found = true
-			set[name] = false
 		}
-	}
-}
-
-func flagListString(names []string) string {
-	flags := make([]string, len(names))
-	for i := range flags {
-		flags[i] = "-" + names[i]
-	}
-	return strings.Join(flags, ", ")
+	})
+	return found
 }

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -290,6 +290,21 @@ func ParseClientListYAML(inv *Inventory, file io.Reader) ([]ClientDesignator, er
 	return res, nil
 }
 
+// FilterClients trims the given list to only include clients matching the 'filter list'.
+func FilterClients(list []ClientDesignator, filter []ClientDesignator) []ClientDesignator {
+	accept := make(set[string])
+	for _, f := range filter {
+		accept.add(f.Name())
+	}
+	var res []ClientDesignator
+	for _, c := range list {
+		if accept.contains(c.Client) || accept.contains(c.Name()) {
+			res = append(res, c)
+		}
+	}
+	return res
+}
+
 var knownBuildArgs = map[string]struct{}{
 	"tag":        {}, // this is the branch/version specifier when pulling the git repo or docker base image
 	"github":     {}, // (for git pull) github repo to clone

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -291,10 +291,10 @@ func ParseClientListYAML(inv *Inventory, file io.Reader) ([]ClientDesignator, er
 }
 
 // FilterClients trims the given list to only include clients matching the 'filter list'.
-func FilterClients(list []ClientDesignator, filter []ClientDesignator) []ClientDesignator {
+func FilterClients(list []ClientDesignator, filter []string) []ClientDesignator {
 	accept := make(set[string])
 	for _, f := range filter {
-		accept.add(f.Name())
+		accept.add(strings.TrimSpace(f))
 	}
 	var res []ClientDesignator
 	for _, c := range list {


### PR DESCRIPTION
This change makes it so we can have all client definitions in one file, and then select the ones that should run.

```
./hive -client-file configs/4844.yaml -client nethermind -sim ethereum/engine
```