### PR TITLE
clients/ethereumjs: Fix mapper

### DIFF
--- a/clients/ethereumjs/mapper.jq
+++ b/clients/ethereumjs/mapper.jq
@@ -57,5 +57,5 @@ def to_bool:
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
-  }|remove_empty
-}
+  }
+} | remove_empty


### PR DESCRIPTION
Fixes mapper of the Ethereum JS client to remove all fields with null values.