### PR TITLE
cmd/hiveview: Add Column Filters

### DIFF
--- a/cmd/hiveview/assets/index.html
+++ b/cmd/hiveview/assets/index.html
@@ -30,7 +30,8 @@
           <div id="loading" class="spinner-border text-secondary" role="status" style="width: 26px; height: 26px; display: none;"></div>
         </h2>
         <p id="page-text" style="display: none;">These test suites are available, and can be loaded. Click on 'Load' to load a certain suite.</p>
-        <table id="filetable" class="table table-bordered"></table>
+        <table id="filetable" class="table table-bordered">
+        </table>
       </div>
     </main>
   </body>

--- a/cmd/hiveview/assets/index.html
+++ b/cmd/hiveview/assets/index.html
@@ -30,8 +30,7 @@
           <div id="loading" class="spinner-border text-secondary" role="status" style="width: 26px; height: 26px; display: none;"></div>
         </h2>
         <p id="page-text" style="display: none;">These test suites are available, and can be loaded. Click on 'Load' to load a certain suite.</p>
-        <table id="filetable" class="table table-bordered">
-        </table>
+        <table id="filetable" class="table table-bordered"></table>
       </div>
     </main>
   </body>

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -181,7 +181,6 @@ function selectWithOptions(api, colIdx) {
                 select.append( $('<option value="'+d+'">'+d+'</option>') );
             }
         } );
-    
 }
 
 function statusSelect(api, colIdx) {

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -138,14 +138,14 @@ function showFileListing(data) {
             $('<tr class="filters"><th></th><th></th><th></th><th></th><th></th></tr>')
                 .appendTo($('#filetable thead'));
             dateSelect(api, 0);
-            selectWithOptions(api, 1);
-            selectWithOptions(api, 2);
+            selectWithOptions(api, 1, true);
+            selectWithOptions(api, 2, false);
             statusSelect(api, 3);
         }
     });
 }
 
-function genericSelect(api, colIdx) {
+function genericSelect(api, colIdx, anchoredMatch) {
     const table = $('#filetable').DataTable();
 
     const cell = $('.filters th').eq(
@@ -156,19 +156,24 @@ function genericSelect(api, colIdx) {
     const select = $('<select />')
         .appendTo(cell)
         .on('change', function () {
-            table
-                .column(colIdx)
-                .search($(this).val())
-                .draw();
+            let re = $(this).val();
+            if (anchoredMatch) {
+                re = '^' + re + '$';
+            } else {
+                re = '\\b' + re + '\\b';
+            }
+            console.log(`searching column ${colIdx} with regexp ${re}`);
+            table.column(colIdx).search(re, true, false);
+            table.draw();
         });
-    
+
     select.append($('<option value="">Show all</option>'));
     return select;
 }
 
-function selectWithOptions(api, colIdx) {
+function selectWithOptions(api, colIdx, anchoredMatch) {
     const table = $('#filetable').DataTable();
-    const select = genericSelect(api, colIdx);
+    const select = genericSelect(api, colIdx, anchoredMatch);
 
     // Get the search data for the first column and add to the select list
     table

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -179,23 +179,21 @@ function genericSelect(api, colIdx, anchoredMatch) {
 function selectWithOptions(api, colIdx, anchoredMatch) {
     const table = $('#filetable').DataTable();
     const select = genericSelect(api, colIdx, anchoredMatch);
-    let added = {};
+    let options = new Set();
 
     // Get the search data for the first column and add to the select list
     table
         .column(colIdx)
         .cache('search')
-        .sort()
         .unique()
         .each(function (d) {
             d.split(',').forEach(function (d) {
-                d = d.trim();
-                if (!added[d]) {
-                    added[d] = true;
-                    select.append($('<option value="'+d+'">'+d+'</option>'));
-                }
+                options.add(d.trim());
             });
         });
+    Array.from(options.values()).sort().forEach(function (d) {
+        select.append($('<option value="'+d+'">'+d+'</option>'));
+    });
 }
 
 function statusSelect(api, colIdx) {

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -137,6 +137,7 @@ function showFileListing(data) {
             const api = this.api();
             $('<tr class="filters"><th></th><th></th><th></th><th></th><th></th></tr>')
                 .appendTo($('#filetable thead'));
+            dateSelect(api, 0);
             selectWithOptions(api, 1);
             selectWithOptions(api, 2);
             statusSelect(api, 3);
@@ -188,4 +189,22 @@ function statusSelect(api, colIdx) {
     select.append( $('<option value="✓">SUCCESS</option>') );
     select.append( $('<option value="FAIL">FAIL</option>') );
     select.append( $('<option value="TIMEOUT">TIMEOUT</option>') );
+}
+
+function minusXDaysDate(x) {
+    const date = new Date(new Date().setDate(new Date().getDate() - x))
+    return date.toLocaleDateString()
+}
+
+function dateSelect(api, colIdx) {
+    const select = genericSelect(api, colIdx);
+    const today = new Date().toLocaleDateString();
+    select.append( $('<option value="' + today + '">Today</option>') );
+    select.append( $('<option value="' + minusXDaysDate(1) + '">Yesterday</option>') );
+    select.append( $('<option value="' + minusXDaysDate(2) + '">2 days ago</option>') );
+    select.append( $('<option value="' + minusXDaysDate(3) + '">3 days ago</option>') );
+    select.append( $('<option value="' + minusXDaysDate(4) + '">4 days ago</option>') );
+    select.append( $('<option value="' + minusXDaysDate(5) + '">5 days ago</option>') );
+    select.append( $('<option value="' + minusXDaysDate(6) + '">6 days ago</option>') );
+    select.append( $('<option value="' + minusXDaysDate(7) + '">7 days ago</option>') );
 }

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -179,6 +179,7 @@ function genericSelect(api, colIdx, anchoredMatch) {
 function selectWithOptions(api, colIdx, anchoredMatch) {
     const table = $('#filetable').DataTable();
     const select = genericSelect(api, colIdx, anchoredMatch);
+    let added = {};
 
     // Get the search data for the first column and add to the select list
     table
@@ -187,9 +188,14 @@ function selectWithOptions(api, colIdx, anchoredMatch) {
         .sort()
         .unique()
         .each(function (d) {
-            if (!d.includes(',')) {
+            d.split(',').forEach(function (d) {
+                d = d.trim();
+                if (added[d]) {
+                    return;
+                }
+                added[d] = true;
                 select.append($('<option value="'+d+'">'+d+'</option>'));
-            }
+            });
         });
 }
 

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -157,13 +157,18 @@ function genericSelect(api, colIdx, anchoredMatch) {
         .appendTo(cell)
         .on('change', function () {
             let re = escapeRegExp($(this).val());
-            if (anchoredMatch) {
-                re = '^' + re + '$';
+            if (re !== '') {
+                if (anchoredMatch) {
+                    re = '^' + re + '$';
+                } else {
+                    re = '\\b' + re + '\\b';
+                }
+                console.log(`searching column ${colIdx} with regexp ${re}`);
+                table.column(colIdx).search(re, true, false);
             } else {
-                re = '\\b' + re + '\\b';
+                // Empty query clears search.
+                table.column(colIdx).search('');
             }
-            console.log(`searching column ${colIdx} with regexp ${re}`);
-            table.column(colIdx).search(re, true, false);
             table.draw();
         });
 

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -138,16 +138,23 @@ function showFileListing(data) {
             $('<tr class="filters"><th></th><th></th><th></th><th></th><th></th></tr>')
                 .appendTo($('#filetable thead'));
             dateSelect(api, 0);
-            selectWithOptions(api, 1, true);
-            selectWithOptions(api, 2, false);
+            selectWithOptions(api, 1, anchorStartEnd);
+            selectWithOptions(api, 2, anchorWord);
             statusSelect(api, 3);
         }
     });
 }
 
-function genericSelect(api, colIdx, anchoredMatch) {
-    const table = $('#filetable').DataTable();
+function anchorWord(re) {
+    return '\\b' + re + '\\b';
+}
 
+function anchorStartEnd(re) {
+    return '^' + re + '$';
+}
+
+function genericSelect(api, colIdx, modifyRE) {
+    const table = $('#filetable').DataTable();
     const cell = $('.filters th').eq(
         $(api.column(colIdx).header()).index()
     );
@@ -158,10 +165,8 @@ function genericSelect(api, colIdx, anchoredMatch) {
         .on('change', function () {
             let re = escapeRegExp($(this).val());
             if (re !== '') {
-                if (anchoredMatch) {
-                    re = '^' + re + '$';
-                } else {
-                    re = '\\b' + re + '\\b';
+                if (modifyRE) {
+                    re = modifyRE(re);
                 }
                 console.log(`searching column ${colIdx} with regexp ${re}`);
                 table.column(colIdx).search(re, true, false);
@@ -176,9 +181,9 @@ function genericSelect(api, colIdx, anchoredMatch) {
     return select;
 }
 
-function selectWithOptions(api, colIdx, anchoredMatch) {
+function selectWithOptions(api, colIdx, modifyRE) {
     const table = $('#filetable').DataTable();
-    const select = genericSelect(api, colIdx, anchoredMatch);
+    const select = genericSelect(api, colIdx, modifyRE);
     let options = new Set();
 
     // Get the search data for the first column and add to the select list

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -190,11 +190,10 @@ function selectWithOptions(api, colIdx, anchoredMatch) {
         .each(function (d) {
             d.split(',').forEach(function (d) {
                 d = d.trim();
-                if (added[d]) {
-                    return;
+                if (!added[d]) {
+                    added[d] = true;
+                    select.append($('<option value="'+d+'">'+d+'</option>'));
                 }
-                added[d] = true;
-                select.append($('<option value="'+d+'">'+d+'</option>'));
             });
         });
 }

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -139,11 +139,12 @@ function showFileListing(data) {
                 .appendTo($('#filetable thead'));
             selectWithOptions(api, 1);
             selectWithOptions(api, 2);
+            statusSelect(api, 3);
         }
     });
 }
 
-function selectWithOptions(api, colIdx) {
+function genericSelect(api, colIdx) {
     const table = $('#filetable').DataTable();
 
     const cell = $('.filters th').eq(
@@ -161,6 +162,12 @@ function selectWithOptions(api, colIdx) {
         } );
     
     select.append( $('<option value="">Show all</option>') );
+    return select;
+}
+
+function selectWithOptions(api, colIdx) {
+    const table = $('#filetable').DataTable();
+    const select = genericSelect(api, colIdx);
 
     // Get the search data for the first column and add to the select list
     table
@@ -174,4 +181,11 @@ function selectWithOptions(api, colIdx) {
             }
         } );
     
+}
+
+function statusSelect(api, colIdx) {
+    const select = genericSelect(api, colIdx);
+    select.append( $('<option value="✓">SUCCESS</option>') );
+    select.append( $('<option value="FAIL">FAIL</option>') );
+    select.append( $('<option value="TIMEOUT">TIMEOUT</option>') );
 }

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -59,7 +59,9 @@ function showFileListing(data) {
         suites.push(suite);
     });
 
-    $('#filetable').DataTable({
+    // "const table" makes the table already render here so that column filtering
+    // can then be added as a second row
+    const table = $('#filetable').DataTable({
         data: suites,
         pageLength: 50,
         autoWidth: false,
@@ -134,4 +136,6 @@ function showFileListing(data) {
             },
         ],
     });
+    
+    $('<tr><th></th><th></th><th></th><th></th><th></th></tr>').appendTo($('#filetable thead'))
 }

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -59,9 +59,7 @@ function showFileListing(data) {
         suites.push(suite);
     });
 
-    // "const table" makes the table already render here so that column filtering
-    // can then be added as a second row
-    const table = $('#filetable').DataTable({
+    $('#filetable').DataTable({
         data: suites,
         pageLength: 50,
         autoWidth: false,
@@ -135,7 +133,45 @@ function showFileListing(data) {
                 },
             },
         ],
+        initComplete: function () {
+            const api = this.api();
+            $('<tr class="filters"><th></th><th></th><th></th><th></th><th></th></tr>')
+                .appendTo($('#filetable thead'));
+            selectWithOptions(api, 1);
+            selectWithOptions(api, 2);
+        }
     });
+}
+
+function selectWithOptions(api, colIdx) {
+    const table = $('#filetable').DataTable();
+
+    const cell = $('.filters th').eq(
+        $(api.column(colIdx).header()).index()
+    );
+
+    // Create the select list and search operation
+    const select = $('<select />')
+        .appendTo(cell)
+        .on( 'change', function () {
+            table
+                .column( colIdx )
+                .search( $(this).val() )
+                .draw();
+        } );
     
-    $('<tr><th></th><th></th><th></th><th></th><th></th></tr>').appendTo($('#filetable thead'))
+    select.append( $('<option value="">Show all</option>') );
+
+    // Get the search data for the first column and add to the select list
+    table
+        .column( colIdx )
+        .cache( 'search' )
+        .sort()
+        .unique()
+        .each( function ( d ) {
+            if (!d.includes(',')) {
+                select.append( $('<option value="'+d+'">'+d+'</option>') );
+            }
+        } );
+    
 }

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -7,7 +7,7 @@ import $ from 'jquery';
 import * as common from './app-common.js';
 import * as routes from './routes.js';
 import { makeButton } from './html.js';
-import { formatBytes } from './utils.js';
+import { formatBytes, escapeRegExp } from './utils.js';
 
 $(document).ready(function () {
     common.updateHeader();
@@ -156,7 +156,7 @@ function genericSelect(api, colIdx, anchoredMatch) {
     const select = $('<select />')
         .appendTo(cell)
         .on('change', function () {
-            let re = $(this).val();
+            let re = escapeRegExp($(this).val());
             if (anchoredMatch) {
                 re = '^' + re + '$';
             } else {

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -155,14 +155,14 @@ function genericSelect(api, colIdx) {
     // Create the select list and search operation
     const select = $('<select />')
         .appendTo(cell)
-        .on( 'change', function () {
+        .on('change', function () {
             table
-                .column( colIdx )
-                .search( $(this).val() )
+                .column(colIdx)
+                .search($(this).val())
                 .draw();
-        } );
+        });
     
-    select.append( $('<option value="">Show all</option>') );
+    select.append($('<option value="">Show all</option>'));
     return select;
 }
 
@@ -172,22 +172,22 @@ function selectWithOptions(api, colIdx) {
 
     // Get the search data for the first column and add to the select list
     table
-        .column( colIdx )
-        .cache( 'search' )
+        .column(colIdx)
+        .cache('search')
         .sort()
         .unique()
-        .each( function ( d ) {
+        .each(function (d) {
             if (!d.includes(',')) {
-                select.append( $('<option value="'+d+'">'+d+'</option>') );
+                select.append($('<option value="'+d+'">'+d+'</option>'));
             }
-        } );
+        });
 }
 
 function statusSelect(api, colIdx) {
     const select = genericSelect(api, colIdx);
-    select.append( $('<option value="✓">SUCCESS</option>') );
-    select.append( $('<option value="FAIL">FAIL</option>') );
-    select.append( $('<option value="TIMEOUT">TIMEOUT</option>') );
+    select.append($('<option value="✓">SUCCESS</option>'));
+    select.append($('<option value="FAIL">FAIL</option>'));
+    select.append($('<option value="TIMEOUT">TIMEOUT</option>'));
 }
 
 function minusXDaysDate(x) {
@@ -198,12 +198,12 @@ function minusXDaysDate(x) {
 function dateSelect(api, colIdx) {
     const select = genericSelect(api, colIdx);
     const today = new Date().toLocaleDateString();
-    select.append( $('<option value="' + today + '">Today</option>') );
-    select.append( $('<option value="' + minusXDaysDate(1) + '">Yesterday</option>') );
-    select.append( $('<option value="' + minusXDaysDate(2) + '">2 days ago</option>') );
-    select.append( $('<option value="' + minusXDaysDate(3) + '">3 days ago</option>') );
-    select.append( $('<option value="' + minusXDaysDate(4) + '">4 days ago</option>') );
-    select.append( $('<option value="' + minusXDaysDate(5) + '">5 days ago</option>') );
-    select.append( $('<option value="' + minusXDaysDate(6) + '">6 days ago</option>') );
-    select.append( $('<option value="' + minusXDaysDate(7) + '">7 days ago</option>') );
+    select.append($('<option value="' + today + '">Today</option>'));
+    select.append($('<option value="' + minusXDaysDate(1) + '">Yesterday</option>'));
+    select.append($('<option value="' + minusXDaysDate(2) + '">2 days ago</option>'));
+    select.append($('<option value="' + minusXDaysDate(3) + '">3 days ago</option>'));
+    select.append($('<option value="' + minusXDaysDate(4) + '">4 days ago</option>'));
+    select.append($('<option value="' + minusXDaysDate(5) + '">5 days ago</option>'));
+    select.append($('<option value="' + minusXDaysDate(6) + '">6 days ago</option>'));
+    select.append($('<option value="' + minusXDaysDate(7) + '">7 days ago</option>'));
 }

--- a/cmd/hiveview/assets/lib/utils.js
+++ b/cmd/hiveview/assets/lib/utils.js
@@ -37,3 +37,8 @@ export function formatBytes(loc) {
 export function queryParam(key) {
     return new URLSearchParams(document.location.search).get(key);
 }
+
+// escapeRegExp escapes all regexp special characters in str.
+export function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
This adds more differentiated column filters to `hiveview` for easier selection of a test suite or a client and generally a better overview what is available. This is not meant to replace but complement the existing global search functionality.

<img width="1098" alt="grafik" src="https://github.com/ethereum/hive/assets/931137/aad36a77-4bae-474b-893e-cfa256a91a82">

Following additions:

- `Date` filter: Filters for "Today", "Yesterday", "x days ago"
- `Suite` filter: Collects the different suites for choice
- `Client` filter: Collects the single clients for choice (I have decided to *not* include combined versions for better overview, this can still be done by fulltext search though)
- `Status` filter: Filter for "SUCCESS", "FAIL" and "TIMEOUT"

Side note on the date filter: it would have been nice to also be able to filter by a range of dates, e.g. a period of a whole week. However this is substantially more complex to implement and I have therefore decided to leave out.