### PR TITLE
EthereumJS: fix client timeout on startup

### DIFF
--- a/clients/ethereumjs/Dockerfile.local
+++ b/clients/ethereumjs/Dockerfile.local
@@ -3,13 +3,13 @@
 
 FROM node:18-alpine
 
+RUN apk update && apk add --no-cache bash git jq curl python3 gcc make g++ \
+    && rm -rf /var/cache/apk/*
+
 # Default local client path: clients/ethereumjs/<ethereumjs-monorepo>
 ARG local_path=ethereumjs-monorepo
 COPY $local_path ethereumjs-monorepo
-
-RUN apk update && apk add --no-cache bash git jq curl python3 gcc make g++ && \
-    && rm -rf /var/cache/apk/* \
-    && cd ethereumjs-monorepo && npm i
+RUN cd ethereumjs-monorepo && npm i
 
 # Create version.txt
 RUN cd ethereumjs-monorepo/packages/client && npm ethereumjs --version > /version.txt

--- a/clients/ethereumjs/ethereumjs.sh
+++ b/clients/ethereumjs/ethereumjs.sh
@@ -49,7 +49,7 @@
 set -e
 
 ethereumjs="node /ethereumjs-monorepo/packages/client/dist/bin/cli.js"
-FLAGS="--gethGenesis ./genesis.json --rpc --rpcEngine --saveReceipts --rpcEnginePort 8551 --ws --logLevel debug --rpcDebug --transports rlpx --isSingleNode"
+FLAGS="--gethGenesis ./genesis.json --rpc --rpcEngine --saveReceipts --rpcAddr 0.0.0.0 --rpcEngineAddr 0.0.0.0 --rpcEnginePort 8551 --ws false --logLevel debug --rpcDebug --transports rlpx --isSingleNode"
 
 
 # Configure the chain.


### PR DESCRIPTION
Hive keeps trying to connect to RPC, but we never get those messages, and need to listen to `0.0.0.0`. 

(This temporarily also disables the websockets, since it throws if we enable them)

Also updates the local dockerfile: syntax fix + better local caching (install all apt stuff once instead of every time).