### PR TITLE
simulators/ethereum/pyspec: Fixes for Cancun Devnet 8

### DIFF
--- a/configs/cancun.yaml
+++ b/configs/cancun.yaml
@@ -5,6 +5,13 @@
       github: hyperledger/besu
       tag: main
 
+- client: erigon
+  nametag: cancun-git
+  dockerfile: git
+  build_args:
+      github: ledgerwatch/erigon
+      tag: devel
+
 - client: ethereumjs
   nametag: cancun-git
   build_args:
@@ -24,10 +31,3 @@
   build_args:
       github: NethermindEth/nethermind
       tag: cancun
-
-- client: erigon
-  nametag: cancun-git
-  dockerfile: git
-  build_args:
-      github: ledgerwatch/erigon
-      tag: devel

--- a/go.sum
+++ b/go.sum
@@ -82,7 +82,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
@@ -146,7 +145,6 @@ github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoG
 github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811/go.mod h1:Nb5lgvnQ2+oGlE/EyZy4+2/CxRh9KfvCXnag1vtpxVM=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
@@ -273,7 +271,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
 github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
@@ -321,8 +318,6 @@ github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHj
 github.com/ethereum/go-ethereum v1.11.4 h1:KG81SnUHXWk8LJB3mBcHg/E2yLvXoiPmRMCIRxgx3cE=
 github.com/ethereum/go-ethereum v1.11.4/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanw/esbuild v0.17.6 h1:4TFYbndxF6+KQwLTyZ4PGIal5Pc6g6AK6jp0IU4Elf0=
-github.com/evanw/esbuild v0.17.6/go.mod h1:iINY06rn799hi48UqEnaQvVfZWe6W9bET78LbvN8VWk=
 github.com/evanw/esbuild v0.18.11 h1:Mb0qb9KyJQraob0Y7LA0DOdD8ijJs2TxhqgqrDeGq4w=
 github.com/evanw/esbuild v0.18.11/go.mod h1:iINY06rn799hi48UqEnaQvVfZWe6W9bET78LbvN8VWk=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
@@ -357,7 +352,6 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
@@ -526,17 +520,14 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=
@@ -628,7 +619,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -636,7 +626,6 @@ github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
@@ -889,7 +878,6 @@ go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
@@ -145,6 +146,7 @@ github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoG
 github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811/go.mod h1:Nb5lgvnQ2+oGlE/EyZy4+2/CxRh9KfvCXnag1vtpxVM=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
+github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
@@ -271,6 +273,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
 github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
@@ -318,6 +321,8 @@ github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHj
 github.com/ethereum/go-ethereum v1.11.4 h1:KG81SnUHXWk8LJB3mBcHg/E2yLvXoiPmRMCIRxgx3cE=
 github.com/ethereum/go-ethereum v1.11.4/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanw/esbuild v0.17.6 h1:4TFYbndxF6+KQwLTyZ4PGIal5Pc6g6AK6jp0IU4Elf0=
+github.com/evanw/esbuild v0.17.6/go.mod h1:iINY06rn799hi48UqEnaQvVfZWe6W9bET78LbvN8VWk=
 github.com/evanw/esbuild v0.18.11 h1:Mb0qb9KyJQraob0Y7LA0DOdD8ijJs2TxhqgqrDeGq4w=
 github.com/evanw/esbuild v0.18.11/go.mod h1:iINY06rn799hi48UqEnaQvVfZWe6W9bET78LbvN8VWk=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
@@ -352,6 +357,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
@@ -520,14 +526,17 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=
@@ -619,6 +628,7 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -626,6 +636,7 @@ github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
@@ -878,6 +889,7 @@ go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/simulators/ethereum/go.work.sum
+++ b/simulators/ethereum/go.work.sum
@@ -352,7 +352,10 @@ github.com/ethereum/c-kzg-4844 v0.2.0/go.mod h1:WI2Nd82DMZAAZI1wV2neKGost9EKjvbp
 github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
 github.com/ethereum/go-ethereum v1.12.1-0.20230724161334-2274a03e339f h1:b/1ztbo5mQzQuuyO8A3mVAHOjgiIf7wE8B9/r1Ul4OQ=
 github.com/ethereum/go-ethereum v1.12.1-0.20230724161334-2274a03e339f/go.mod h1:WII7EML+9n033+WEChHAzFzZOVFB+md+oaonHFG8XQQ=
+github.com/ethereum/hive v0.0.0-20230616141546-33068992107d h1:LHq8wfx+J+YqdTJ6e6dgIoqiXG4WIysuhSZ1jig1LIk=
+github.com/ethereum/hive v0.0.0-20230616141546-33068992107d/go.mod h1:2RR3SFHSGGSh7UTvIsw4fDDqjkkr7HrWPyDaMoe6Ehw=
 github.com/ethereum/hive/hiveproxy v0.0.0-20230313101845-c7dfe88c8138/go.mod h1:1LWNU6/EYsIOXZGa2KdklD1ET77gLTeEyhq+WTZ+37o=
+github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20230616141546-33068992107d/go.mod h1:egwoyl8No2k5UBtqXj5iS+7TZXVCtLDLfBlyhjkORaQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanw/esbuild v0.17.6/go.mod h1:iINY06rn799hi48UqEnaQvVfZWe6W9bET78LbvN8VWk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -426,6 +429,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -495,6 +500,13 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/holiman/billy v0.0.0-20230616073924-97ff6efa2b93/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
+github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
+github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
+github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150 h1:vlNjIqmUZ9CMAWsbURYl3a6wZbw7q5RHVvlXTNS/Bs8=
+github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91 h1:KyZDvZ/GGn+r+Y3DKZ7UOQ/TP4xV6HNkrwiVMB1GnNY=
+github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -789,6 +801,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/simulators/ethereum/pyspec/Dockerfile
+++ b/simulators/ethereum/pyspec/Dockerfile
@@ -21,8 +21,8 @@ COPY --from=builder /source/pyspec/pyspec .
 # To run locally generated fixtures, comment the following RUN lines and
 # uncomment the ADD line.
 # Download the latest fixture release.
-RUN wget https://github.com/spencer-tb/execution-spec-tests/releases/latest/download/fixtures-cancun.tar.gz
-RUN tar -xzvf fixtures-cancun.tar.gz
+RUN wget https://github.com/ethereum/execution-spec-tests/releases/download/v1.0.1/fixtures.tar.gz
+RUN tar -xzvf fixtures.tar.gz
 RUN mv fixtures /fixtures
 
 # ADD ./pyspec/fixtures /fixtures

--- a/simulators/ethereum/pyspec/gen_bh.go
+++ b/simulators/ethereum/pyspec/gen_bh.go
@@ -17,29 +17,32 @@ var _ = (*blockHeaderUnmarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (b blockHeader) MarshalJSON() ([]byte, error) {
 	type blockHeader struct {
-		ParentHash      common.Hash           `json:"parentHash"`
-		UncleHash       common.Hash           `json:"sha3Uncles"`
-		UncleHashAlt    common.Hash           `json:"uncleHash"`
-		Coinbase        common.Address        `json:"coinbase"`
-		CoinbaseAlt     common.Address        `json:"author"`
-		CoinbaseAlt2    common.Address        `json:"miner"`
-		StateRoot       common.Hash           `json:"stateRoot"`
-		ReceiptTrie     common.Hash           `json:"receiptsRoot"`
-		ReceiptTrieAlt  common.Hash           `json:"receiptTrie"`
-		Bloom           types.Bloom           `json:"bloom"`
-		Difficulty      *math.HexOrDecimal256 `json:"difficulty"`
-		Number          *math.HexOrDecimal256 `json:"number"`
-		GasLimit        math.HexOrDecimal64   `json:"gasLimit"`
-		GasUsed         math.HexOrDecimal64   `json:"gasUsed"`
-		Timestamp       *math.HexOrDecimal256 `json:"timestamp"`
-		ExtraData       hexutil.Bytes         `json:"extraData"`
-		MixHash         common.Hash           `json:"mixHash"`
-		Nonce           types.BlockNonce      `json:"nonce"`
-		BaseFee         *math.HexOrDecimal256 `json:"baseFeePerGas"`
-		Hash            common.Hash           `json:"hash"`
-		WithdrawalsRoot common.Hash           `json:"withdrawalsRoot"`
-		BlobGasUsed     *math.HexOrDecimal64  `json:"dataGasUsed"`
-		ExcessBlobGas   *math.HexOrDecimal64  `json:"excessDataGas"`
+		ParentHash         common.Hash           `json:"parentHash"`
+		UncleHash          common.Hash           `json:"sha3Uncles"`
+		UncleHashAlt       common.Hash           `json:"uncleHash"`
+		Coinbase           common.Address        `json:"coinbase"`
+		CoinbaseAlt        common.Address        `json:"author"`
+		CoinbaseAlt2       common.Address        `json:"miner"`
+		StateRoot          common.Hash           `json:"stateRoot"`
+		TransactionTrie    common.Hash           `json:"transactionRoot"`
+		TransactionTrieAlt common.Hash           `json:"transactionTrie"`
+		ReceiptTrie        common.Hash           `json:"receiptsRoot"`
+		ReceiptTrieAlt     common.Hash           `json:"receiptTrie"`
+		Bloom              types.Bloom           `json:"bloom"`
+		Difficulty         *math.HexOrDecimal256 `json:"difficulty"`
+		Number             *math.HexOrDecimal256 `json:"number"`
+		GasLimit           math.HexOrDecimal64   `json:"gasLimit"`
+		GasUsed            math.HexOrDecimal64   `json:"gasUsed"`
+		Timestamp          *math.HexOrDecimal256 `json:"timestamp"`
+		ExtraData          hexutil.Bytes         `json:"extraData"`
+		MixHash            common.Hash           `json:"mixHash"`
+		Nonce              types.BlockNonce      `json:"nonce"`
+		BaseFee            *math.HexOrDecimal256 `json:"baseFeePerGas"`
+		Hash               common.Hash           `json:"hash"`
+		WithdrawalsRoot    common.Hash           `json:"withdrawalsRoot"`
+		BlobGasUsed        *math.HexOrDecimal64  `json:"blobGasUsed"`
+		ExcessBlobGas      *math.HexOrDecimal64  `json:"excessBlobGas"`
+		BeaconRoot         *common.Hash          `json:"parentBeaconBlockRoot"`
 	}
 	var enc blockHeader
 	enc.ParentHash = b.ParentHash
@@ -49,6 +52,8 @@ func (b blockHeader) MarshalJSON() ([]byte, error) {
 	enc.CoinbaseAlt = b.CoinbaseAlt
 	enc.CoinbaseAlt2 = b.CoinbaseAlt2
 	enc.StateRoot = b.StateRoot
+	enc.TransactionTrie = b.TransactionTrie
+	enc.TransactionTrieAlt = b.TransactionTrieAlt
 	enc.ReceiptTrie = b.ReceiptTrie
 	enc.ReceiptTrieAlt = b.ReceiptTrieAlt
 	enc.Bloom = b.Bloom
@@ -65,35 +70,39 @@ func (b blockHeader) MarshalJSON() ([]byte, error) {
 	enc.WithdrawalsRoot = b.WithdrawalsRoot
 	enc.BlobGasUsed = (*math.HexOrDecimal64)(b.BlobGasUsed)
 	enc.ExcessBlobGas = (*math.HexOrDecimal64)(b.ExcessBlobGas)
+	enc.BeaconRoot = b.BeaconRoot
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (b *blockHeader) UnmarshalJSON(input []byte) error {
 	type blockHeader struct {
-		ParentHash      *common.Hash          `json:"parentHash"`
-		UncleHash       *common.Hash          `json:"sha3Uncles"`
-		UncleHashAlt    *common.Hash          `json:"uncleHash"`
-		Coinbase        *common.Address       `json:"coinbase"`
-		CoinbaseAlt     *common.Address       `json:"author"`
-		CoinbaseAlt2    *common.Address       `json:"miner"`
-		StateRoot       *common.Hash          `json:"stateRoot"`
-		ReceiptTrie     *common.Hash          `json:"receiptsRoot"`
-		ReceiptTrieAlt  *common.Hash          `json:"receiptTrie"`
-		Bloom           *types.Bloom          `json:"bloom"`
-		Difficulty      *math.HexOrDecimal256 `json:"difficulty"`
-		Number          *math.HexOrDecimal256 `json:"number"`
-		GasLimit        *math.HexOrDecimal64  `json:"gasLimit"`
-		GasUsed         *math.HexOrDecimal64  `json:"gasUsed"`
-		Timestamp       *math.HexOrDecimal256 `json:"timestamp"`
-		ExtraData       *hexutil.Bytes        `json:"extraData"`
-		MixHash         *common.Hash          `json:"mixHash"`
-		Nonce           *types.BlockNonce     `json:"nonce"`
-		BaseFee         *math.HexOrDecimal256 `json:"baseFeePerGas"`
-		Hash            *common.Hash          `json:"hash"`
-		WithdrawalsRoot *common.Hash          `json:"withdrawalsRoot"`
-		BlobGasUsed     *math.HexOrDecimal64  `json:"dataGasUsed"`
-		ExcessBlobGas   *math.HexOrDecimal64  `json:"excessDataGas"`
+		ParentHash         *common.Hash          `json:"parentHash"`
+		UncleHash          *common.Hash          `json:"sha3Uncles"`
+		UncleHashAlt       *common.Hash          `json:"uncleHash"`
+		Coinbase           *common.Address       `json:"coinbase"`
+		CoinbaseAlt        *common.Address       `json:"author"`
+		CoinbaseAlt2       *common.Address       `json:"miner"`
+		StateRoot          *common.Hash          `json:"stateRoot"`
+		TransactionTrie    *common.Hash          `json:"transactionRoot"`
+		TransactionTrieAlt *common.Hash          `json:"transactionTrie"`
+		ReceiptTrie        *common.Hash          `json:"receiptsRoot"`
+		ReceiptTrieAlt     *common.Hash          `json:"receiptTrie"`
+		Bloom              *types.Bloom          `json:"bloom"`
+		Difficulty         *math.HexOrDecimal256 `json:"difficulty"`
+		Number             *math.HexOrDecimal256 `json:"number"`
+		GasLimit           *math.HexOrDecimal64  `json:"gasLimit"`
+		GasUsed            *math.HexOrDecimal64  `json:"gasUsed"`
+		Timestamp          *math.HexOrDecimal256 `json:"timestamp"`
+		ExtraData          *hexutil.Bytes        `json:"extraData"`
+		MixHash            *common.Hash          `json:"mixHash"`
+		Nonce              *types.BlockNonce     `json:"nonce"`
+		BaseFee            *math.HexOrDecimal256 `json:"baseFeePerGas"`
+		Hash               *common.Hash          `json:"hash"`
+		WithdrawalsRoot    *common.Hash          `json:"withdrawalsRoot"`
+		BlobGasUsed        *math.HexOrDecimal64  `json:"blobGasUsed"`
+		ExcessBlobGas      *math.HexOrDecimal64  `json:"excessBlobGas"`
+		BeaconRoot         *common.Hash          `json:"parentBeaconBlockRoot"`
 	}
 	var dec blockHeader
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -119,6 +128,12 @@ func (b *blockHeader) UnmarshalJSON(input []byte) error {
 	}
 	if dec.StateRoot != nil {
 		b.StateRoot = *dec.StateRoot
+	}
+	if dec.TransactionTrie != nil {
+		b.TransactionTrie = *dec.TransactionTrie
+	}
+	if dec.TransactionTrieAlt != nil {
+		b.TransactionTrieAlt = *dec.TransactionTrieAlt
 	}
 	if dec.ReceiptTrie != nil {
 		b.ReceiptTrie = *dec.ReceiptTrie
@@ -167,6 +182,9 @@ func (b *blockHeader) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ExcessBlobGas != nil {
 		b.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.BeaconRoot != nil {
+		b.BeaconRoot = dec.BeaconRoot
 	}
 	return nil
 }

--- a/simulators/ethereum/pyspec/gen_enp.go
+++ b/simulators/ethereum/pyspec/gen_enp.go
@@ -15,23 +15,26 @@ var _ = (*engineNewPayloadUnmarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (e engineNewPayload) MarshalJSON() ([]byte, error) {
 	type engineNewPayload struct {
-		Payload             *engine.ExecutableData `json:"payload"`
-		Version             math.HexOrDecimal64    `json:"version"`
-		BlobVersionedHashes []common.Hash          `json:"blobVersionedHashes"`
+		Payload               *engine.ExecutableData `json:"executionPayload"`
+		BlobVersionedHashes   []common.Hash          `json:"expectedBlobVersionedHashes"`
+		ParentBeaconBlockRoot *common.Hash           `json:"parentBeaconBlockRoot"`
+		Version               math.HexOrDecimal64    `json:"version"`
 	}
 	var enc engineNewPayload
 	enc.Payload = e.Payload
-	enc.Version = math.HexOrDecimal64(e.Version)
 	enc.BlobVersionedHashes = e.BlobVersionedHashes
+	enc.ParentBeaconBlockRoot = e.ParentBeaconBlockRoot
+	enc.Version = math.HexOrDecimal64(e.Version)
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (e *engineNewPayload) UnmarshalJSON(input []byte) error {
 	type engineNewPayload struct {
-		Payload             *engine.ExecutableData `json:"payload"`
-		Version             *math.HexOrDecimal64   `json:"version"`
-		BlobVersionedHashes []common.Hash          `json:"blobVersionedHashes"`
+		Payload               *engine.ExecutableData `json:"executionPayload"`
+		BlobVersionedHashes   []common.Hash          `json:"expectedBlobVersionedHashes"`
+		ParentBeaconBlockRoot *common.Hash           `json:"parentBeaconBlockRoot"`
+		Version               *math.HexOrDecimal64   `json:"version"`
 	}
 	var dec engineNewPayload
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -40,11 +43,14 @@ func (e *engineNewPayload) UnmarshalJSON(input []byte) error {
 	if dec.Payload != nil {
 		e.Payload = dec.Payload
 	}
-	if dec.Version != nil {
-		e.Version = uint64(*dec.Version)
-	}
 	if dec.BlobVersionedHashes != nil {
 		e.BlobVersionedHashes = dec.BlobVersionedHashes
+	}
+	if dec.ParentBeaconBlockRoot != nil {
+		e.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
+	}
+	if dec.Version != nil {
+		e.Version = uint64(*dec.Version)
 	}
 	return nil
 }

--- a/simulators/ethereum/pyspec/go.mod
+++ b/simulators/ethereum/pyspec/go.mod
@@ -3,7 +3,7 @@ module github.com/ethereum/hive/simulators/ethereum/pyspec
 go 1.20
 
 require (
-	github.com/ethereum/go-ethereum v1.12.1-0.20230715212736-b058cf454b3b
+	github.com/ethereum/go-ethereum v1.12.1-0.20230728070838-8f2ae29b8f77
 	github.com/ethereum/hive v0.0.0-20230616141546-33068992107d
 	github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20230616141546-33068992107d
 )
@@ -35,7 +35,7 @@ require (
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
-	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c // indirect
+	github.com/holiman/uint256 v1.2.3 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -65,3 +65,5 @@ require (
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/ethereum/go-ethereum => github.com/marioevz/go-ethereum v1.10.14-0.20230802180057-7bd535142c42

--- a/simulators/ethereum/pyspec/go.sum
+++ b/simulators/ethereum/pyspec/go.sum
@@ -74,8 +74,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum/c-kzg-4844 v0.3.0 h1:3Y3hD6l5i0dEYsBL50C+Om644kve3pNqoAcvE26o9zI=
 github.com/ethereum/c-kzg-4844 v0.3.0/go.mod h1:WI2Nd82DMZAAZI1wV2neKGost9EKjvbpQR9OqE5Qqa8=
-github.com/ethereum/go-ethereum v1.12.1-0.20230715212736-b058cf454b3b h1:LD8/hHcIsC0mlIaJkIQqe214fNzbXDZYkL3Grzhxc0U=
-github.com/ethereum/go-ethereum v1.12.1-0.20230715212736-b058cf454b3b/go.mod h1:WII7EML+9n033+WEChHAzFzZOVFB+md+oaonHFG8XQQ=
 github.com/ethereum/hive v0.0.0-20230616141546-33068992107d h1:LHq8wfx+J+YqdTJ6e6dgIoqiXG4WIysuhSZ1jig1LIk=
 github.com/ethereum/hive v0.0.0-20230616141546-33068992107d/go.mod h1:2RR3SFHSGGSh7UTvIsw4fDDqjkkr7HrWPyDaMoe6Ehw=
 github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20230616141546-33068992107d h1:akwfB80JUROiS8dqEcf/Umgewizy68P/P2YQceEAhzw=
@@ -158,10 +156,11 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/hashicorp/go-bexpr v0.1.11 h1:6DqdA/KBjurGby9yTY0bmkathya0lfwF2SeuubCI7dY=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7 h1:3JQNjnMRil1yD0IfZKHF9GxxWKDJGj8I0IqOUol//sw=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
-github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c h1:DZfsyhDK1hnSS5lH8l+JggqzEleHteTYfutAiVlSUM8=
-github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
+github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o=
+github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
@@ -203,6 +202,8 @@ github.com/labstack/echo/v4 v4.5.0/go.mod h1:czIriw4a0C1dFun+ObrXp7ok03xON0N1awS
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/marioevz/go-ethereum v1.10.14-0.20230802180057-7bd535142c42 h1:YRJHuf5fXz/YMqsKjF8hRX99k2uZ7GQLQjtTKJKgcQY=
+github.com/marioevz/go-ethereum v1.10.14-0.20230802180057-7bd535142c42/go.mod h1:zKetLweqBR8ZS+1O9iJWI8DvmmD2NzD19apjEWDCsnw=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -319,7 +320,7 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
-github.com/urfave/cli/v2 v2.23.7 h1:YHDQ46s3VghFHFf1DdF+Sh7H4RqhcM+t0TmZRJx4oJY=
+github.com/urfave/cli/v2 v2.24.1 h1:/QYYr7g0EhwXEML8jO+8OYt5trPnLHS0p3mrgExJ5NU=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=

--- a/simulators/ethereum/pyspec/runner.go
+++ b/simulators/ethereum/pyspec/runner.go
@@ -134,7 +134,7 @@ func (tc *testcase) run(t *hivesim.T) {
 			int(engineNewPayload.Version),
 			engineNewPayload.Payload,
 			&engineNewPayload.BlobVersionedHashes,
-			nil, // TODO: Fix in pyspec PR
+			engineNewPayload.ParentBeaconBlockRoot,
 		)
 		if plErr != nil {
 			if plException == plErr.Error() {
@@ -149,6 +149,7 @@ func (tc *testcase) run(t *hivesim.T) {
 		if plStatus.Status == "VALID" {
 			latestValidHash = *plStatus.LatestValidHash
 		}
+
 		// check payload status is expected from fixture
 		if expectedStatus != plStatus.Status {
 			tc.failedErr = errors.New("payload status mismatch")
@@ -272,6 +273,7 @@ func extractGenesis(fixture fixtureJSON) *core.Genesis {
 		BaseFee:       fixture.Genesis.BaseFee,
 		BlobGasUsed:   fixture.Genesis.BlobGasUsed,
 		ExcessBlobGas: fixture.Genesis.ExcessBlobGas,
+		BeaconRoot:    fixture.Genesis.BeaconRoot,
 		Alloc:         fixture.Pre,
 	}
 	return genesis

--- a/simulators/ethereum/pyspec/types.go
+++ b/simulators/ethereum/pyspec/types.go
@@ -68,8 +68,8 @@ type blockHeader struct {
 	CoinbaseAlt        common.Address   `json:"author"` // nethermind name
 	CoinbaseAlt2       common.Address   `json:"miner"`  // geth/besu name
 	StateRoot          common.Hash      `json:"stateRoot"`
-	transactionTrie    common.Hash      `json:"transactionRoot"`
-	transactionTrieAlt common.Hash      `json:"transactionTrie"` // name in fixtures
+	TransactionTrie    common.Hash      `json:"transactionRoot"`
+	TransactionTrieAlt common.Hash      `json:"transactionTrie"` // name in fixtures
 	ReceiptTrie        common.Hash      `json:"receiptsRoot"`
 	ReceiptTrieAlt     common.Hash      `json:"receiptTrie"` // name in fixtures
 	Bloom              types.Bloom      `json:"bloom"`
@@ -84,8 +84,9 @@ type blockHeader struct {
 	BaseFee            *big.Int         `json:"baseFeePerGas"`
 	Hash               common.Hash      `json:"hash"`
 	WithdrawalsRoot    common.Hash      `json:"withdrawalsRoot"`
-	BlobGasUsed        *uint64          `json:"dataGasUsed"`
-	ExcessBlobGas      *uint64          `json:"excessDataGas"`
+	BlobGasUsed        *uint64          `json:"blobGasUsed"`
+	ExcessBlobGas      *uint64          `json:"excessBlobGas"`
+	BeaconRoot         *common.Hash     `json:"parentBeaconBlockRoot"`
 }
 
 type blockHeaderUnmarshaling struct {
@@ -151,9 +152,10 @@ type withdrawalsUnmarshaling struct {
 }
 
 type engineNewPayload struct {
-	Payload             *api.ExecutableData `json:"payload"`
-	Version             uint64              `json:"version"`
-	BlobVersionedHashes []common.Hash       `json:"blobVersionedHashes"`
+	Payload               *api.ExecutableData `json:"executionPayload"`
+	BlobVersionedHashes   []common.Hash       `json:"expectedBlobVersionedHashes"`
+	ParentBeaconBlockRoot *common.Hash        `json:"parentBeaconBlockRoot"`
+	Version               uint64              `json:"version"`
 }
 
 type engineNewPayloadUnmarshaling struct {


### PR DESCRIPTION
This PR contains a few small tweaks for the pyspec simulator such that it runs the current execution-spec-tests fixtures correctly.