### PR TITLE
simulators/ethereum/pyspec: Add Engine API error code checks for erroneous test cases

### DIFF
--- a/simulators/ethereum/pyspec/gen_enp.go
+++ b/simulators/ethereum/pyspec/gen_enp.go
@@ -19,7 +19,7 @@ func (e engineNewPayload) MarshalJSON() ([]byte, error) {
 		BlobVersionedHashes   []common.Hash          `json:"expectedBlobVersionedHashes"`
 		ParentBeaconBlockRoot *common.Hash           `json:"parentBeaconBlockRoot"`
 		Version               math.HexOrDecimal64    `json:"version"`
-		ErrorCode             string                 `json:"errorCode"`
+		ErrorCode             int64                  `json:"errorCode,string"`
 	}
 	var enc engineNewPayload
 	enc.Payload = e.Payload
@@ -37,7 +37,7 @@ func (e *engineNewPayload) UnmarshalJSON(input []byte) error {
 		BlobVersionedHashes   []common.Hash          `json:"expectedBlobVersionedHashes"`
 		ParentBeaconBlockRoot *common.Hash           `json:"parentBeaconBlockRoot"`
 		Version               *math.HexOrDecimal64   `json:"version"`
-		ErrorCode             *string                `json:"errorCode"`
+		ErrorCode             *int64                 `json:"errorCode,string"`
 	}
 	var dec engineNewPayload
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/simulators/ethereum/pyspec/gen_enp.go
+++ b/simulators/ethereum/pyspec/gen_enp.go
@@ -19,12 +19,14 @@ func (e engineNewPayload) MarshalJSON() ([]byte, error) {
 		BlobVersionedHashes   []common.Hash          `json:"expectedBlobVersionedHashes"`
 		ParentBeaconBlockRoot *common.Hash           `json:"parentBeaconBlockRoot"`
 		Version               math.HexOrDecimal64    `json:"version"`
+		ErrorCode             string                 `json:"errorCode"`
 	}
 	var enc engineNewPayload
 	enc.Payload = e.Payload
 	enc.BlobVersionedHashes = e.BlobVersionedHashes
 	enc.ParentBeaconBlockRoot = e.ParentBeaconBlockRoot
 	enc.Version = math.HexOrDecimal64(e.Version)
+	enc.ErrorCode = e.ErrorCode
 	return json.Marshal(&enc)
 }
 
@@ -35,6 +37,7 @@ func (e *engineNewPayload) UnmarshalJSON(input []byte) error {
 		BlobVersionedHashes   []common.Hash          `json:"expectedBlobVersionedHashes"`
 		ParentBeaconBlockRoot *common.Hash           `json:"parentBeaconBlockRoot"`
 		Version               *math.HexOrDecimal64   `json:"version"`
+		ErrorCode             *string                `json:"errorCode"`
 	}
 	var dec engineNewPayload
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -51,6 +54,9 @@ func (e *engineNewPayload) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Version != nil {
 		e.Version = uint64(*dec.Version)
+	}
+	if dec.ErrorCode != nil {
+		e.ErrorCode = *dec.ErrorCode
 	}
 	return nil
 }

--- a/simulators/ethereum/pyspec/runner.go
+++ b/simulators/ethereum/pyspec/runner.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -133,8 +132,8 @@ func (tc *testcase) run(t *hivesim.T) {
 			engineNewPayload.ParentBeaconBlockRoot,
 		)
 		// check for rpc errors and compare error codes
-		fxErrCode := tc.fixture.json.Blocks[i].EngineNewPayload.ErrorCode
-		if fxErrCode != "" {
+		fxErrCode := int(tc.fixture.json.Blocks[i].EngineNewPayload.ErrorCode)
+		if fxErrCode != 0 {
 			checkRPCErrors(plErr, fxErrCode, t, tc)
 			continue
 		}
@@ -277,10 +276,10 @@ func extractGenesis(fixture fixtureJSON) *core.Genesis {
 }
 
 // checkRPCErrors checks for RPC errors and compares error codes if expected.
-func checkRPCErrors(plErr error, fxErrCode string, t *hivesim.T, tc *testcase) {
+func checkRPCErrors(plErr error, fxErrCode int, t *hivesim.T, tc *testcase) {
 	rpcErr, isRpcErr := plErr.(rpc.Error)
 	if isRpcErr {
-		plErrCode := strconv.Itoa(rpcErr.ErrorCode())
+		plErrCode := rpcErr.ErrorCode()
 		if plErrCode != fxErrCode {
 			tc.failedErr = fmt.Errorf("error code mismatch: client returned %v and fixture expected %v", plErrCode, fxErrCode)
 			t.Fatalf("error code mismatch\n client returned: %v\n fixture expected: %v\n in test %s", plErrCode, fxErrCode, tc.name)

--- a/simulators/ethereum/pyspec/types.go
+++ b/simulators/ethereum/pyspec/types.go
@@ -156,6 +156,7 @@ type engineNewPayload struct {
 	BlobVersionedHashes   []common.Hash       `json:"expectedBlobVersionedHashes"`
 	ParentBeaconBlockRoot *common.Hash        `json:"parentBeaconBlockRoot"`
 	Version               uint64              `json:"version"`
+	ErrorCode             string              `json:"errorCode"`
 }
 
 type engineNewPayloadUnmarshaling struct {

--- a/simulators/ethereum/pyspec/types.go
+++ b/simulators/ethereum/pyspec/types.go
@@ -156,7 +156,7 @@ type engineNewPayload struct {
 	BlobVersionedHashes   []common.Hash       `json:"expectedBlobVersionedHashes"`
 	ParentBeaconBlockRoot *common.Hash        `json:"parentBeaconBlockRoot"`
 	Version               uint64              `json:"version"`
-	ErrorCode             string              `json:"errorCode"`
+	ErrorCode             int64               `json:"errorCode,string"`
 }
 
 type engineNewPayloadUnmarshaling struct {


### PR DESCRIPTION
Fixes current false positive and false negative cases for fork transition tests. 

Engine API error codes have been added to the fixtures such they can be parsed within the simulator:
https://github.com/ethereum/execution-spec-tests/pull/248

If an error code exists within a test case the simulator will now check that it matches the expected response from the Engine API.