### PR TITLE
clients/go-ethereum,nethermind: Add logging of git branch to Dockerfile.git

### DIFF
--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -5,8 +5,9 @@ ARG github=ethereum/go-ethereum
 ARG tag=master
 
 RUN \
-  apk add --update bash curl jq git make gcc musl-dev              \
-        ca-certificates linux-headers                              && \
+  apk add --update bash curl jq git make gcc musl-dev                 \
+  ca-certificates linux-headers                                    && \
+  echo "Cloning: $github - $tag"                                   && \
   git clone --depth 1 --branch $tag https://github.com/$github     && \
   cd go-ethereum                                                   && \
   make geth                                                        && \

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG github=nethermindeth/nethermind
 ARG tag=master
 
-RUN echo "Cloning: $user/$repo - $branch" && \
+RUN echo "Cloning: $github - $tag" && \
     git clone -b $tag https://github.com/$github && \
     cd /nethermind/src/Nethermind/Nethermind.Runner && \
     dotnet build -c release


### PR DESCRIPTION
When building clients from the `Dockerfile.git` files it doesn't show the what branch is being used for geth and nethermind within the build log.

This PR addresses the latter for easier debugging.