### PR TITLE
simulators/ethereum/pyspec: Update fixtures version

### DIFF
--- a/simulators/ethereum/pyspec/Dockerfile
+++ b/simulators/ethereum/pyspec/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=builder /source/pyspec/pyspec .
 # To run locally generated fixtures, comment the following RUN lines and
 # uncomment the ADD line.
 # Download the latest fixture release.
-RUN wget https://github.com/ethereum/execution-spec-tests/releases/download/v1.0.1/fixtures.tar.gz
+RUN wget https://github.com/ethereum/execution-spec-tests/releases/download/v1.0.2/fixtures.tar.gz
 RUN tar -xzvf fixtures.tar.gz
 RUN mv fixtures /fixtures
 


### PR DESCRIPTION
Updates github.com/ethereum/execution-spec-tests fixtures version from `v1.0.1` to `v1.0.2`.
Release notes here: https://github.com/ethereum/execution-spec-tests/releases/tag/v1.0.2