### PR TITLE
clients/geth: fix local dockerfile issue

### DIFF
--- a/clients/go-ethereum/Dockerfile.local
+++ b/clients/go-ethereum/Dockerfile.local
@@ -6,8 +6,8 @@ FROM golang:1-alpine as builder
 ARG local_path=go-ethereum
 COPY $local_path go-ethereum
 
-WORKDIR /go-ethereum
-RUN apk add --update bash curl jq git make
+WORKDIR go-ethereum
+RUN apk add --update bash curl jq git make gcc libc-dev linux-headers
 RUN make geth
 RUN mv ./build/bin/geth /usr/local/bin/geth
 


### PR DESCRIPTION
There are two issues in the `Dockerfile.local` for geth.

1) the `WORKDIR` is set as an absolute path, but it should be relative
2) the container doesn't have the appropriate dependencies to build geth