### PR TITLE
simulators/ethereum/engine: Add more ForkID tests

### DIFF
--- a/simulators/ethereum/engine/clmock/clmock.go
+++ b/simulators/ethereum/engine/clmock/clmock.go
@@ -223,7 +223,7 @@ func (cl *CLMocker) IsOptimisticallySyncing() bool {
 }
 
 func (cl *CLMocker) ForkID() forkid.ID {
-	return forkid.NewID(cl.Genesis.Config, cl.GenesisBlock(), cl.LatestHeader.Number.Uint64(), cl.Genesis.Timestamp)
+	return forkid.NewID(cl.Genesis.Config, cl.GenesisBlock(), cl.LatestHeader.Number.Uint64(), cl.LatestHeader.Time)
 }
 
 func (cl *CLMocker) GetHeaders(amount uint64, originHash common.Hash, originNumber uint64, reverse bool, skip uint64) ([]*types.Header, error) {

--- a/simulators/ethereum/engine/suites/cancun/config.go
+++ b/simulators/ethereum/engine/suites/cancun/config.go
@@ -115,7 +115,7 @@ func (cs *CancunBaseSpec) GetGenesis() *core.Genesis {
 	genesis.Alloc[HISTORY_STORAGE_ADDRESS] = core.GenesisAccount{
 		Balance: common.Big0,
 		Nonce:   1,
-		Code:    common.Hex2Bytes("0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b42620180004206555f3562018000420662018000015500"),
+		Code:    common.Hex2Bytes("3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b42620180004206555f3562018000420662018000015500"),
 	}
 
 	return genesis

--- a/simulators/ethereum/engine/suites/cancun/steps.go
+++ b/simulators/ethereum/engine/suites/cancun/steps.go
@@ -652,6 +652,31 @@ func (step SendModifiedLatestPayload) Description() string {
 	return desc
 }
 
+// A step that attempts to peer to the client using devp2p, and checks the forkid of the client
+type DevP2PClientPeering struct {
+	// Client index to peer to
+	ClientIndex uint64
+}
+
+func (step DevP2PClientPeering) Execute(t *CancunTestContext) error {
+	// Get client index's enode
+	if step.ClientIndex >= uint64(len(t.TestEngines)) {
+		return fmt.Errorf("invalid client index %d", step.ClientIndex)
+	}
+	engine := t.Engines[step.ClientIndex]
+	conn, err := devp2p.PeerEngineClient(engine, t.CLMock)
+	if err != nil {
+		return fmt.Errorf("error peering engine client: %v", err)
+	}
+	defer conn.Close()
+	t.Logf("INFO: Connected to client %d, remote public key: %s", step.ClientIndex, conn.RemoteKey())
+	return nil
+}
+
+func (step DevP2PClientPeering) Description() string {
+	return fmt.Sprintf("DevP2PClientPeering: client %d", step.ClientIndex)
+}
+
 // A step that requests a Transaction hash via P2P and expects the correct full blob tx
 type DevP2PRequestPooledTransactionHash struct {
 	// Client index to request the transaction hash from

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -4,7 +4,6 @@ package suite_cancun
 import (
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/hive/simulators/ethereum/engine/client/hive_rpc"
@@ -1385,6 +1384,114 @@ var Tests = []test.SpecInterface{
 		},
 	},
 
+	// ForkID tests
+	&CancunForkSpec{
+		GenesisTimestamp:  0,
+		ShanghaiTimestamp: 0,
+		CancunTimestamp:   0,
+
+		CancunBaseSpec: CancunBaseSpec{
+			Spec: test.Spec{
+				Name: "ForkID, genesis at 0, shanghai at 0, cancun at 0",
+				About: `
+			Attemp to peer client with the following configuration at height 0:
+			- genesis timestamp 0
+			- shanghai fork at timestamp 0
+			- cancun fork at timestamp 0
+			`,
+			},
+		},
+	},
+	&CancunForkSpec{
+		GenesisTimestamp:  0,
+		ShanghaiTimestamp: 0,
+		CancunTimestamp:   1,
+
+		CancunBaseSpec: CancunBaseSpec{
+			Spec: test.Spec{
+				Name: "ForkID, genesis at 0, shanghai at 0, cancun at 1",
+				About: `
+			Attemp to peer client with the following configuration at height 0:
+			- genesis timestamp 0
+			- shanghai fork at timestamp 0
+			- cancun fork at timestamp 1
+			`,
+			},
+		},
+	},
+
+	&CancunForkSpec{
+		GenesisTimestamp:           0,
+		ShanghaiTimestamp:          0,
+		CancunTimestamp:            1,
+		ProduceBlocksBeforePeering: 1,
+
+		CancunBaseSpec: CancunBaseSpec{
+			Spec: test.Spec{
+				Name: "ForkID, genesis at 0, shanghai at 0, cancun at 1, transition",
+				About: `
+			Attemp to peer client with the following configuration at height 1:
+			- genesis timestamp 0
+			- shanghai fork at timestamp 0
+			- cancun fork at timestamp 1
+			`,
+			},
+		},
+	},
+
+	&CancunForkSpec{
+		GenesisTimestamp:  1,
+		ShanghaiTimestamp: 1,
+		CancunTimestamp:   1,
+
+		CancunBaseSpec: CancunBaseSpec{
+			Spec: test.Spec{
+				Name: "ForkID, genesis at 1, shanghai at 1, cancun at 1",
+				About: `
+			Attemp to peer client with the following configuration at height 0:
+			- genesis timestamp 1
+			- shanghai fork at timestamp 1
+			- cancun fork at timestamp 1
+			`,
+			},
+		},
+	},
+	&CancunForkSpec{
+		GenesisTimestamp:  1,
+		ShanghaiTimestamp: 1,
+		CancunTimestamp:   2,
+
+		CancunBaseSpec: CancunBaseSpec{
+			Spec: test.Spec{
+				Name: "ForkID, genesis at 1, shanghai at 1, cancun at 2",
+				About: `
+			Attemp to peer client with the following configuration at height 0:
+			- genesis timestamp 1
+			- shanghai fork at timestamp 1
+			- cancun fork at timestamp 2
+			`,
+			},
+		},
+	},
+	&CancunForkSpec{
+		GenesisTimestamp:           1,
+		ShanghaiTimestamp:          1,
+		CancunTimestamp:            2,
+		ProduceBlocksBeforePeering: 1,
+
+		CancunBaseSpec: CancunBaseSpec{
+			Spec: test.Spec{
+				Name: "ForkID, genesis at 1, shanghai at 1, cancun at 2, transition",
+				About: `
+			Attemp to peer client with the following configuration at height 1:
+			- genesis timestamp 1
+			- shanghai fork at timestamp 1
+			- cancun fork at timestamp 2
+			`,
+			},
+		},
+	},
+
 	// DevP2P tests
 	&CancunBaseSpec{
 		Spec: test.Spec{
@@ -1410,38 +1517,4 @@ var Tests = []test.SpecInterface{
 			},
 		},
 	},
-}
-
-// Contains the base spec for all cancun tests.
-type CancunBaseSpec struct {
-	test.Spec
-	TimeIncrements   uint64 // Timestamp increments per block throughout the test
-	GetPayloadDelay  uint64 // Delay between FcU and GetPayload calls
-	CancunForkHeight uint64 // Withdrawals activation fork height
-	TestSequence
-}
-
-// Base test case execution procedure for blobs tests.
-func (bs *CancunBaseSpec) Execute(t *test.Env) {
-
-	t.CLMock.WaitForTTD()
-
-	blobTestCtx := &CancunTestContext{
-		Env:            t,
-		TestBlobTxPool: new(TestBlobTxPool),
-	}
-
-	blobTestCtx.TestBlobTxPool.HashesByIndex = make(map[uint64]common.Hash)
-
-	if bs.GetPayloadDelay != 0 {
-		t.CLMock.PayloadProductionClientDelay = time.Duration(bs.GetPayloadDelay) * time.Second
-	}
-
-	for stepId, step := range bs.TestSequence {
-		t.Logf("INFO: Executing step %d: %s", stepId+1, step.Description())
-		if err := step.Execute(blobTestCtx); err != nil {
-			t.Fatalf("FAIL: Error executing step %d: %v", stepId+1, err)
-		}
-	}
-
 }


### PR DESCRIPTION
Adds the following ForkID tests:
- Genesis timestamp = 0, Shanghai at 0, Cancun at 0 -> peer at Block 0
- Genesis timestamp = 0, Shanghai at 0, Cancun at 1 -> peer at Block 0
- Genesis timestamp = 0, Shanghai at 0, Cancun at 1 -> peer at Block 1
- Genesis timestamp = 1, Shanghai at 1, Cancun at 1 -> peer at Block 0
- Genesis timestamp = 1, Shanghai at 1, Cancun at 2 -> peer at Block 0
- Genesis timestamp = 1, Shanghai at 1, Cancun at 2 -> peer at Block 1

cc @jochem-brouwer @lightclient @spencer-tb 