### PR TITLE
simulators/ethereum/engine: Coalesce fork configs

### DIFF
--- a/simulators/ethereum/engine/suites/cancun/config.go
+++ b/simulators/ethereum/engine/suites/cancun/config.go
@@ -68,18 +68,6 @@ func (cs *CancunBaseSpec) GetBlobsForkTime() uint64 {
 func (cs *CancunBaseSpec) GetGenesis() *core.Genesis {
 	genesis := cs.Spec.GetGenesis()
 
-	// Remove PoW altogether
-	genesis.Difficulty = common.Big0
-	genesis.Config.TerminalTotalDifficulty = common.Big0
-	genesis.Config.Clique = nil
-	genesis.ExtraData = []byte{}
-
-	if cs.CancunForkHeight == 0 {
-		genesis.BlobGasUsed = new(uint64)
-		genesis.ExcessBlobGas = new(uint64)
-		genesis.BeaconRoot = new(common.Hash)
-	}
-
 	// Add accounts that use the DATAHASH opcode
 	datahashCode := []byte{
 		0x5F, // PUSH0

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -975,12 +975,6 @@ func AddUnconditionalBytecode(g *core.Genesis, start *big.Int, end *big.Int) {
 func (ws *WithdrawalsBaseSpec) GetGenesis() *core.Genesis {
 	genesis := ws.Spec.GetGenesis()
 
-	// Remove PoW altogether
-	genesis.Difficulty = common.Big0
-	genesis.Config.TerminalTotalDifficulty = common.Big0
-	genesis.Config.Clique = nil
-	genesis.ExtraData = []byte{}
-
 	// Add some accounts to withdraw to with unconditional SSTOREs
 	startAccount := big.NewInt(0x1000)
 	endAccount := big.NewInt(0x1000 + int64(ws.GetWithdrawableAccountCount()) - 1)


### PR DESCRIPTION
Brings together the configuration elements of the different forks into a single method.

Fixes an issue when running `ExchangeCapabilities` tests of an improperly configured genesis.