### PR TITLE
clients/erigon: Specify golang versioned image

### DIFF
--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -1,7 +1,7 @@
 ### Build Erigon From Git:
 
 ## Builder stage: Compiles erigon from a git repository
-FROM golang:1-alpine as builder
+FROM golang:1.20-alpine as builder
 
 ARG github=ledgerwatch/erigon
 ARG tag=devel


### PR DESCRIPTION
Fixes an issue with Erigon not building properly in hivecancun host due to usage of the latest go version.