### PR TITLE
configs/cancun: Change besu branch

### DIFF
--- a/configs/cancun.yaml
+++ b/configs/cancun.yaml
@@ -2,8 +2,8 @@
   nametag: cancun-git
   dockerfile: git
   build_args:
-      github: hyperledger/besu
-      tag: main
+      github: pinges/besu
+      tag: EIP4788
 
 - client: erigon
   nametag: cancun-git


### PR DESCRIPTION
Changes Besu's branch to the one to be used on devnet-8 runs.