### PR TITLE
simulators/ethereum/engine: Add incorrect engine versions tests

### DIFF
--- a/simulators/ethereum/engine/client/engine.go
+++ b/simulators/ethereum/engine/client/engine.go
@@ -37,6 +37,7 @@ type Engine interface {
 	GetPayloadV1(ctx context.Context, payloadId *api.PayloadID) (typ.ExecutableData, error)
 	GetPayloadV2(ctx context.Context, payloadId *api.PayloadID) (typ.ExecutableData, *big.Int, error)
 	GetPayloadV3(ctx context.Context, payloadId *api.PayloadID) (typ.ExecutableData, *big.Int, *typ.BlobsBundle, *bool, error)
+	GetPayload(ctx context.Context, version int, payloadId *api.PayloadID) (typ.ExecutableData, *big.Int, *typ.BlobsBundle, *bool, error)
 
 	NewPayload(ctx context.Context, version int, payload interface{}, versionedHashes *[]common.Hash, beaconRoot *common.Hash) (api.PayloadStatusV1, error)
 	NewPayloadV1(ctx context.Context, payload *typ.ExecutableDataV1) (api.PayloadStatusV1, error)
@@ -85,6 +86,6 @@ var (
 	Pending                        = big.NewInt(-2)
 	Finalized                      = big.NewInt(-3)
 	Safe                           = big.NewInt(-4)
-	LatestForkchoiceUpdatedVersion = 2
+	LatestForkchoiceUpdatedVersion = 3
 	LatestNewPayloadVersion        = 3
 )

--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -569,6 +569,16 @@ func (n *GethNode) GetPayloadV3(ctx context.Context, payloadId *beacon.PayloadID
 	return ed, p.BlockValue, nil, &p.Override, err
 }
 
+func (n *GethNode) GetPayload(ctx context.Context, version int, payloadId *beacon.PayloadID) (typ.ExecutableData, *big.Int, *typ.BlobsBundle, *bool, error) {
+	p, err := n.api.GetPayloadV3(*payloadId)
+	if p == nil || err != nil {
+		return typ.ExecutableData{}, nil, nil, nil, err
+	}
+	ed, err := typ.FromBeaconExecutableData(p.ExecutionPayload)
+	// TODO: Convert and return the blobs bundle
+	return ed, p.BlockValue, nil, &p.Override, err
+}
+
 func (n *GethNode) GetPayloadBodiesByRangeV1(ctx context.Context, start uint64, count uint64) ([]*typ.ExecutionPayloadBodyV1, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/simulators/ethereum/engine/globals/globals.go
+++ b/simulators/ethereum/engine/globals/globals.go
@@ -181,7 +181,14 @@ func (f *ForkConfig) IsCancun(blockTimestamp uint64) bool {
 	return f.CancunTimestamp != nil && new(big.Int).SetUint64(blockTimestamp).Cmp(f.CancunTimestamp) >= 0
 }
 
-func (f *ForkConfig) ForkchoiceUpdatedVersion(timestamp uint64) int {
+func (f *ForkConfig) ForkchoiceUpdatedVersion(headTimestamp uint64, payloadAttributesTimestamp *uint64) int {
+	// If the payload attributes timestamp is nil, use the head timestamp
+	// to calculate the FcU version.
+	timestamp := headTimestamp
+	if payloadAttributesTimestamp != nil {
+		timestamp = *payloadAttributesTimestamp
+	}
+
 	if f.IsCancun(timestamp) {
 		return 3
 	} else if f.IsShanghai(timestamp) {

--- a/simulators/ethereum/engine/helper/customizer.go
+++ b/simulators/ethereum/engine/helper/customizer.go
@@ -134,6 +134,22 @@ func (customData *BasePayloadAttributesCustomizer) GetPayloadAttributes(basePayl
 	return customPayloadAttributes, nil
 }
 
+type TimestampDeltaPayloadAttributesCustomizer struct {
+	PayloadAttributesCustomizer
+	TimestampDelta int64
+}
+
+var _ PayloadAttributesCustomizer = (*TimestampDeltaPayloadAttributesCustomizer)(nil)
+
+func (customData *TimestampDeltaPayloadAttributesCustomizer) GetPayloadAttributes(basePayloadAttributes *typ.PayloadAttributes) (*typ.PayloadAttributes, error) {
+	customPayloadAttributes, err := customData.PayloadAttributesCustomizer.GetPayloadAttributes(basePayloadAttributes)
+	if err != nil {
+		return nil, err
+	}
+	customPayloadAttributes.Timestamp = uint64(int64(customPayloadAttributes.Timestamp) + customData.TimestampDelta)
+	return customPayloadAttributes, nil
+}
+
 // Customizer that makes no modifications to the forkchoice directive call.
 // Used as base to other customizers.
 type BaseForkchoiceUpdatedCustomizer struct {

--- a/simulators/ethereum/engine/suites/cancun/config.go
+++ b/simulators/ethereum/engine/suites/cancun/config.go
@@ -49,7 +49,10 @@ func (cs *CancunBaseSpec) GetForkConfig() globals.ForkConfig {
 
 // Get the per-block timestamp increments configured for this test
 func (cs *CancunBaseSpec) GetBlockTimeIncrements() uint64 {
-	return 1
+	if cs.TimeIncrements == 0 {
+		return 1
+	}
+	return cs.TimeIncrements
 }
 
 // Timestamp delta between genesis and the withdrawals fork

--- a/simulators/ethereum/engine/suites/cancun/steps.go
+++ b/simulators/ethereum/engine/suites/cancun/steps.go
@@ -438,6 +438,9 @@ func (step NewPayloads) Execute(t *CancunTestContext) error {
 						r.ExpectNoError()
 						r.ExpectPayloadStatus(expectedStatus)
 					}
+					if r.Response.PayloadID != nil {
+						t.CLMock.AddPayloadID(r.Response.PayloadID)
+					}
 				}
 			},
 			OnRequestNextPayload: func() {

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -725,7 +725,7 @@ var Tests = []test.SpecInterface{
 			`,
 		},
 
-		CancunForkHeight: 1,
+		CancunForkHeight: 0,
 
 		TestSequence: TestSequence{
 			SendBlobTransactions{

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -537,6 +537,235 @@ var Tests = []test.SpecInterface{
 		},
 	},
 
+	// ForkchoiceUpdatedV3 before cancun
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "ForkchoiceUpdatedV3 Set Head to Shanghai Payload, Nil Payload Attributes",
+			About: `
+			Test sending ForkchoiceUpdatedV3 to set the head of the chain to a Shanghai payload:
+			- Send NewPayloadV2 with Shanghai payload on block 1
+			- Use ForkchoiceUpdatedV3 to set the head to the payload, with nil payload attributes
+
+			Verify that client returns no error.
+			`,
+		},
+
+		CancunForkHeight: 2,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				FcUOnHeadSet: &helper.UpgradeForkchoiceUpdatedVersion{
+					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{},
+				},
+				ExpectationDescription: `
+				ForkchoiceUpdatedV3 before Cancun returns no error without payload attributes
+				`,
+			},
+		},
+	},
+
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "ForkchoiceUpdatedV3 To Request Shanghai Payload, Nil Beacon Root",
+			About: `
+			Test sending ForkchoiceUpdatedV3 to request a Shanghai payload:
+			- Payload Attributes uses Shanghai timestamp
+			- Payload Attributes' Beacon Root is nil
+
+			Verify that client returns INVALID_PARAMS_ERROR.
+			`,
+		},
+
+		CancunForkHeight: 2,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				FcUOnPayloadRequest: &helper.UpgradeForkchoiceUpdatedVersion{
+					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
+				},
+				ExpectationDescription: fmt.Sprintf(`
+				ForkchoiceUpdatedV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
+				`, *INVALID_PARAMS_ERROR),
+			},
+		},
+	},
+
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "ForkchoiceUpdatedV3 To Request Shanghai Payload, Zero Beacon Root",
+			About: `
+			Test sending ForkchoiceUpdatedV3 to request a Shanghai payload:
+			- Payload Attributes uses Shanghai timestamp
+			- Payload Attributes' Beacon Root zero
+
+			Verify that client returns UNSUPPORTED_FORK_ERROR.
+			`,
+		},
+
+		CancunForkHeight: 2,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				FcUOnPayloadRequest: &helper.UpgradeForkchoiceUpdatedVersion{
+					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
+						PayloadAttributesCustomizer: &helper.BasePayloadAttributesCustomizer{
+							BeaconRoot: &(common.Hash{}),
+						},
+						ExpectedError: UNSUPPORTED_FORK_ERROR,
+					},
+				},
+				ExpectationDescription: fmt.Sprintf(`
+				ForkchoiceUpdatedV3 before Cancun with beacon root must return UNSUPPORTED_FORK_ERROR (code %d)
+				`, *UNSUPPORTED_FORK_ERROR),
+			},
+		},
+	},
+
+	// ForkchoiceUpdatedV2 before cancun with beacon root
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root",
+			About: `
+			Test sending ForkchoiceUpdatedV2 to request a Cancun payload:
+			- Payload Attributes uses Shanghai timestamp
+			- Payload Attributes' Beacon Root zero
+
+			Verify that client returns INVALID_PARAMS_ERROR.
+			`,
+		},
+
+		CancunForkHeight: 1,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				FcUOnPayloadRequest: &helper.DowngradeForkchoiceUpdatedVersion{
+					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
+						PayloadAttributesCustomizer: &helper.BasePayloadAttributesCustomizer{
+							BeaconRoot: &(common.Hash{}),
+						},
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
+				},
+				ExpectationDescription: fmt.Sprintf(`
+				ForkchoiceUpdatedV2 before Cancun with beacon root field must return INVALID_PARAMS_ERROR (code %d)
+				`, *INVALID_PARAMS_ERROR),
+			},
+		},
+	},
+
+	// ForkchoiceUpdatedV2 after cancun
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "ForkchoiceUpdatedV2 To Request Cancun Payload, Zero Beacon Root",
+			About: `
+			Test sending ForkchoiceUpdatedV2 to request a Cancun payload:
+			- Payload Attributes uses Cancun timestamp
+			- Payload Attributes' Beacon Root zero
+
+			Verify that client returns INVALID_PARAMS_ERROR.
+			`,
+		},
+
+		CancunForkHeight: 1,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				FcUOnPayloadRequest: &helper.DowngradeForkchoiceUpdatedVersion{
+					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
+				},
+				ExpectationDescription: fmt.Sprintf(`
+				ForkchoiceUpdatedV2 after Cancun with beacon root field must return INVALID_PARAMS_ERROR (code %d)
+				`, *INVALID_PARAMS_ERROR),
+			},
+		},
+	},
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "ForkchoiceUpdatedV2 To Request Cancun Payload, Nil Beacon Root",
+			About: `
+			Test sending ForkchoiceUpdatedV2 to request a Cancun payload:
+			- Payload Attributes uses Cancun timestamp
+			- Payload Attributes' Beacon Root nil (not provided)
+
+			Verify that client returns UNSUPPORTED_FORK_ERROR.
+			`,
+		},
+
+		CancunForkHeight: 1,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				FcUOnPayloadRequest: &helper.DowngradeForkchoiceUpdatedVersion{
+					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
+						PayloadAttributesCustomizer: &helper.BasePayloadAttributesCustomizer{
+							RemoveBeaconRoot: true,
+						},
+						ExpectedError: UNSUPPORTED_FORK_ERROR,
+					},
+				},
+				ExpectationDescription: fmt.Sprintf(`
+				ForkchoiceUpdatedV2 after Cancun must return UNSUPPORTED_FORK_ERROR (code %d)
+				`, *UNSUPPORTED_FORK_ERROR),
+			},
+		},
+	},
+
+	// GetPayloadV3 Before Cancun, Negative Tests
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "GetPayloadV3 To Request Shanghai Payload",
+			About: `
+			Test requesting a Shanghai PayloadID using GetPayloadV3.
+			Verify that client returns UNSUPPORTED_FORK_ERROR.
+			`,
+		},
+
+		CancunForkHeight: 2,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				GetPayloadCustomizer: &helper.UpgradeGetPayloadVersion{
+					GetPayloadCustomizer: &helper.BaseGetPayloadCustomizer{
+						ExpectedError: UNSUPPORTED_FORK_ERROR,
+					},
+				},
+				ExpectationDescription: fmt.Sprintf(`
+				GetPayloadV3 To Request Shanghai Payload must return UNSUPPORTED_FORK_ERROR (code %d)
+				`, *UNSUPPORTED_FORK_ERROR),
+			},
+		},
+	},
+
+	// GetPayloadV2 After Cancun, Negative Tests
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "GetPayloadV2 To Request Cancun Payload",
+			About: `
+			Test requesting a Cancun PayloadID using GetPayloadV2.
+			Verify that client returns UNSUPPORTED_FORK_ERROR.
+			`,
+		},
+
+		CancunForkHeight: 1,
+
+		TestSequence: TestSequence{
+			NewPayloads{
+				GetPayloadCustomizer: &helper.DowngradeGetPayloadVersion{
+					GetPayloadCustomizer: &helper.BaseGetPayloadCustomizer{
+						ExpectedError: UNSUPPORTED_FORK_ERROR,
+					},
+				},
+				ExpectationDescription: fmt.Sprintf(`
+				GetPayloadV2 To Request Cancun Payload must return UNSUPPORTED_FORK_ERROR (code %d)
+				`, *UNSUPPORTED_FORK_ERROR),
+			},
+		},
+	},
+
 	// NewPayloadV3 Before Cancun, Negative Tests
 	&CancunBaseSpec{
 		Spec: test.Spec{
@@ -556,7 +785,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
 					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 						VersionedHashesCustomizer: &VersionedHashes{
@@ -567,7 +795,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -587,7 +815,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
 					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 						PayloadCustomizer: &helper.CustomPayloadData{
@@ -598,7 +825,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -618,7 +845,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
 					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 						PayloadCustomizer: &helper.CustomPayloadData{
@@ -629,7 +855,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -649,7 +875,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
 					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 						VersionedHashesCustomizer: &VersionedHashes{
@@ -660,7 +885,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -680,7 +905,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
 					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 						PayloadCustomizer: &helper.CustomPayloadData{
@@ -691,7 +915,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -711,7 +935,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
 					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 						PayloadCustomizer: &helper.CustomPayloadData{
@@ -727,7 +950,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with no nil fields must return UNSUPPORTED_FORK_ERROR (code %d)
-				`, UNSUPPORTED_FORK_ERROR),
+				`, *UNSUPPORTED_FORK_ERROR),
 			},
 		},
 	},
@@ -749,7 +972,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 					PayloadCustomizer: &helper.CustomPayloadData{
 						RemoveExcessBlobGas: true,
@@ -758,7 +980,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 after Cancun with nil ExcessBlobGas must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -777,7 +999,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 					PayloadCustomizer: &helper.CustomPayloadData{
 						RemoveBlobGasUsed: true,
@@ -786,7 +1007,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 after Cancun with nil BlobGasUsed must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -805,7 +1026,6 @@ var Tests = []test.SpecInterface{
 
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 					PayloadCustomizer: &helper.CustomPayloadData{
 						RemoveParentBeaconRoot: true,
@@ -814,7 +1034,7 @@ var Tests = []test.SpecInterface{
 				},
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 after Cancun with nil parentBeaconBlockRoot must return INVALID_PARAMS_ERROR (code %d)
-				`, INVALID_PARAMS_ERROR),
+				`, *INVALID_PARAMS_ERROR),
 			},
 		},
 	},
@@ -1065,8 +1285,7 @@ var Tests = []test.SpecInterface{
 		},
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
-				ExpectedBlobs:             []helper.BlobID{},
+				ExpectedBlobs: []helper.BlobID{},
 				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 					VersionedHashesCustomizer: &VersionedHashes{
 						Blobs: []helper.BlobID{0},
@@ -1382,8 +1601,7 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{}, // Send new payload so the parent is unknown to the secondary client
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
-				ExpectedBlobs:             []helper.BlobID{},
+				ExpectedBlobs: []helper.BlobID{},
 			},
 
 			LaunchClients{
@@ -1416,7 +1634,6 @@ var Tests = []test.SpecInterface{
 		},
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 					PayloadCustomizer: &helper.CustomPayloadData{
 						BlobGasUsed: pUint64(1),
@@ -1436,7 +1653,6 @@ var Tests = []test.SpecInterface{
 		},
 		TestSequence: TestSequence{
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
 				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
 					PayloadCustomizer: &helper.CustomPayloadData{
 						BlobGasUsed: pUint64(GAS_PER_BLOB),
@@ -1584,7 +1800,7 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			// Get past the genesis
 			NewPayloads{
-				ExpectedIncludedBlobCount: 0,
+				PayloadCount: 1,
 			},
 			// Send multiple transactions with multiple blobs each
 			SendBlobTransactions{

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -714,6 +714,49 @@ var Tests = []test.SpecInterface{
 		},
 	},
 
+	// ForkchoiceUpdatedV3 with modified BeaconRoot Attribute
+	&CancunBaseSpec{
+		Spec: test.Spec{
+			Name: "ForkchoiceUpdatedV3 Modifies Payload ID on Different Beacon Root",
+			About: `
+			Test requesting a Cancun Payload using ForkchoiceUpdatedV3 twice with the beacon root
+			payload attribute as the only change between requests and verify that the payload ID is
+			different.
+			`,
+		},
+
+		CancunForkHeight: 1,
+
+		TestSequence: TestSequence{
+			SendBlobTransactions{
+				TransactionCount:              1,
+				BlobsPerTransaction:           MAX_BLOBS_PER_BLOCK,
+				BlobTransactionMaxBlobGasCost: big.NewInt(100),
+			},
+			NewPayloads{
+				ExpectedIncludedBlobCount: MAX_BLOBS_PER_BLOCK,
+				FcUOnPayloadRequest: &helper.BaseForkchoiceUpdatedCustomizer{
+					PayloadAttributesCustomizer: &helper.BasePayloadAttributesCustomizer{
+						BeaconRoot: &(common.Hash{}),
+					},
+				},
+			},
+			SendBlobTransactions{
+				TransactionCount:              1,
+				BlobsPerTransaction:           MAX_BLOBS_PER_BLOCK,
+				BlobTransactionMaxBlobGasCost: big.NewInt(100),
+			},
+			NewPayloads{
+				ExpectedIncludedBlobCount: MAX_BLOBS_PER_BLOCK,
+				FcUOnPayloadRequest: &helper.BaseForkchoiceUpdatedCustomizer{
+					PayloadAttributesCustomizer: &helper.BasePayloadAttributesCustomizer{
+						BeaconRoot: &(common.Hash{1}),
+					},
+				},
+			},
+		},
+	},
+
 	// GetPayloadV3 Before Cancun, Negative Tests
 	&CancunBaseSpec{
 		Spec: test.Spec{

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -557,11 +557,14 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				VersionedHashes: &VersionedHashes{
-					Blobs: nil,
+				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
+					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+						VersionedHashesCustomizer: &VersionedHashes{
+							Blobs: nil,
+						},
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -585,11 +588,14 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					BlobGasUsed: pUint64(0),
+				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
+					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+						PayloadCustomizer: &helper.CustomPayloadData{
+							BlobGasUsed: pUint64(0),
+						},
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -613,11 +619,14 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					ExcessBlobGas: pUint64(0),
+				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
+					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+						PayloadCustomizer: &helper.CustomPayloadData{
+							ExcessBlobGas: pUint64(0),
+						},
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -641,11 +650,14 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				VersionedHashes: &VersionedHashes{
-					Blobs: []helper.BlobID{},
+				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
+					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+						VersionedHashesCustomizer: &VersionedHashes{
+							Blobs: []helper.BlobID{},
+						},
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -669,11 +681,14 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					ParentBeaconRoot: &(common.Hash{}),
+				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
+					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+						PayloadCustomizer: &helper.CustomPayloadData{
+							ParentBeaconRoot: &(common.Hash{}),
+						},
+						ExpectedError: INVALID_PARAMS_ERROR,
+					},
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -697,16 +712,19 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				VersionedHashes: &VersionedHashes{
-					Blobs: []helper.BlobID{},
+				NewPayloadCustomizer: &helper.UpgradeNewPayloadVersion{
+					NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+						PayloadCustomizer: &helper.CustomPayloadData{
+							ExcessBlobGas:    pUint64(0),
+							BlobGasUsed:      pUint64(0),
+							ParentBeaconRoot: &(common.Hash{}),
+						},
+						VersionedHashesCustomizer: &VersionedHashes{
+							Blobs: []helper.BlobID{},
+						},
+						ExpectedError: UNSUPPORTED_FORK_ERROR,
+					},
 				},
-				PayloadCustomizer: &helper.CustomPayloadData{
-					ExcessBlobGas:    pUint64(0),
-					BlobGasUsed:      pUint64(0),
-					ParentBeaconRoot: &(common.Hash{}),
-				},
-				ExpectedError: UNSUPPORTED_FORK_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 before Cancun with no nil fields must return UNSUPPORTED_FORK_ERROR (code %d)
 				`, UNSUPPORTED_FORK_ERROR),
@@ -732,11 +750,12 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					RemoveExcessBlobGas: true,
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					PayloadCustomizer: &helper.CustomPayloadData{
+						RemoveExcessBlobGas: true,
+					},
+					ExpectedError: INVALID_PARAMS_ERROR,
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 after Cancun with nil ExcessBlobGas must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -759,11 +778,12 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					RemoveBlobGasUsed: true,
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					PayloadCustomizer: &helper.CustomPayloadData{
+						RemoveBlobGasUsed: true,
+					},
+					ExpectedError: INVALID_PARAMS_ERROR,
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 after Cancun with nil BlobGasUsed must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -786,11 +806,12 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				Version:                   3,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					RemoveParentBeaconRoot: true,
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					PayloadCustomizer: &helper.CustomPayloadData{
+						RemoveParentBeaconRoot: true,
+					},
+					ExpectedError: INVALID_PARAMS_ERROR,
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: fmt.Sprintf(`
 				NewPayloadV3 after Cancun with nil parentBeaconBlockRoot must return INVALID_PARAMS_ERROR (code %d)
 				`, INVALID_PARAMS_ERROR),
@@ -816,10 +837,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect list of versioned hashes must return INVALID status
 				`,
@@ -845,10 +868,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK+1),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK+1),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect list of versioned hashes must return INVALID status
 				`,
@@ -872,10 +897,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs: helper.GetBlobListByIndex(helper.BlobID(TARGET_BLOBS_PER_BLOCK-1), 0),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: helper.GetBlobListByIndex(helper.BlobID(TARGET_BLOBS_PER_BLOCK-1), 0),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect list of versioned hashes must return INVALID status
 				`,
@@ -899,10 +926,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK), helper.BlobID(TARGET_BLOBS_PER_BLOCK-1)),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK), helper.BlobID(TARGET_BLOBS_PER_BLOCK-1)),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect list of versioned hashes must return INVALID status
 				`,
@@ -926,10 +955,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1), helper.BlobID(TARGET_BLOBS_PER_BLOCK)),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1), helper.BlobID(TARGET_BLOBS_PER_BLOCK)),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect hash in list of versioned hashes must return INVALID status
 				`,
@@ -952,11 +983,13 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs:        helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-					HashVersions: []byte{BLOB_COMMITMENT_VERSION_KZG, BLOB_COMMITMENT_VERSION_KZG + 1},
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs:        helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
+						HashVersions: []byte{BLOB_COMMITMENT_VERSION_KZG, BLOB_COMMITMENT_VERSION_KZG + 1},
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect version in list of versioned hashes must return INVALID status
 				`,
@@ -980,10 +1013,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs: nil,
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: nil,
+					},
+					ExpectedError: INVALID_PARAMS_ERROR,
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 				ExpectationDescription: `
 				NewPayloadV3 after Cancun with nil VersionedHashes must return INVALID_PARAMS_ERROR (code -32602)
 				`,
@@ -1007,10 +1042,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: TARGET_BLOBS_PER_BLOCK,
 				ExpectedBlobs:             helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-				VersionedHashes: &VersionedHashes{
-					Blobs: []helper.BlobID{},
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: []helper.BlobID{},
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect list of versioned hashes must return INVALID status
 				`,
@@ -1030,10 +1067,12 @@ var Tests = []test.SpecInterface{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
 				ExpectedBlobs:             []helper.BlobID{},
-				VersionedHashes: &VersionedHashes{
-					Blobs: []helper.BlobID{0},
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: []helper.BlobID{0},
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 				ExpectationDescription: `
 				NewPayloadV3 with incorrect list of versioned hashes must return INVALID status
 				`,
@@ -1069,10 +1108,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1105,10 +1146,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK+1),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK+1),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1138,10 +1181,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: helper.GetBlobListByIndex(helper.BlobID(TARGET_BLOBS_PER_BLOCK-1), 0),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: helper.GetBlobListByIndex(helper.BlobID(TARGET_BLOBS_PER_BLOCK-1), 0),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1172,10 +1217,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK), helper.BlobID(TARGET_BLOBS_PER_BLOCK-1)),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK), helper.BlobID(TARGET_BLOBS_PER_BLOCK-1)),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1206,10 +1253,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1), helper.BlobID(TARGET_BLOBS_PER_BLOCK)),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: append(helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK-1), helper.BlobID(TARGET_BLOBS_PER_BLOCK)),
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1239,11 +1288,13 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs:        helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
-					HashVersions: []byte{BLOB_COMMITMENT_VERSION_KZG, BLOB_COMMITMENT_VERSION_KZG + 1},
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs:        helper.GetBlobList(0, TARGET_BLOBS_PER_BLOCK),
+						HashVersions: []byte{BLOB_COMMITMENT_VERSION_KZG, BLOB_COMMITMENT_VERSION_KZG + 1},
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1274,10 +1325,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: nil,
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: nil,
+					},
+					ExpectedError: INVALID_PARAMS_ERROR,
 				},
-				ExpectedError: INVALID_PARAMS_ERROR,
 			},
 		},
 	},
@@ -1308,10 +1361,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: []helper.BlobID{},
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: []helper.BlobID{},
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1338,10 +1393,12 @@ var Tests = []test.SpecInterface{
 			},
 			SendModifiedLatestPayload{
 				ClientID: 1,
-				VersionedHashes: &VersionedHashes{
-					Blobs: []helper.BlobID{0},
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					VersionedHashesCustomizer: &VersionedHashes{
+						Blobs: []helper.BlobID{0},
+					},
+					ExpectInvalidStatus: true,
 				},
-				ExpectedStatus: test.Invalid,
 			},
 		},
 	},
@@ -1360,8 +1417,11 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					BlobGasUsed: pUint64(1),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					PayloadCustomizer: &helper.CustomPayloadData{
+						BlobGasUsed: pUint64(1),
+					},
+					ExpectInvalidStatus: true,
 				},
 			},
 		},
@@ -1377,8 +1437,11 @@ var Tests = []test.SpecInterface{
 		TestSequence: TestSequence{
 			NewPayloads{
 				ExpectedIncludedBlobCount: 0,
-				PayloadCustomizer: &helper.CustomPayloadData{
-					BlobGasUsed: pUint64(GAS_PER_BLOB),
+				NewPayloadCustomizer: &helper.BaseNewPayloadVersionCustomizer{
+					PayloadCustomizer: &helper.CustomPayloadData{
+						BlobGasUsed: pUint64(GAS_PER_BLOB),
+					},
+					ExpectInvalidStatus: true,
 				},
 			},
 		},


### PR DESCRIPTION
Addresses missing GetPayloadV2/V3 and ForkchoiceUpdatedV2/V3 tests at fork time, described in comment: https://github.com/ethereum/hive/issues/810#issuecomment-1672182427