### PR TITLE
configs/cancun: Besu update

### DIFF
--- a/configs/cancun.yaml
+++ b/configs/cancun.yaml
@@ -2,8 +2,8 @@
   nametag: cancun-git
   dockerfile: git
   build_args:
-      github: hyperledger/besu
-      tag: main
+      github: Gabriel-Trintinalia/besu
+      tag: add-decode-type-to-transaction-decoder
 
 - client: erigon
   nametag: cancun-git


### PR DESCRIPTION
Updates besu branch to: [Gabriel-Trintinalia/besu@add-decode-type-to-transaction-decoder](https://github.com/Gabriel-Trintinalia/besu/tree/add-decode-type-to-transaction-decoder)

cc @parithosh @Gabriel-Trintinalia let me know when this should be rolled back