### PR TITLE
clients/reth: add cancun fork in mapper

### DIFF
--- a/clients/reth/mapper.jq
+++ b/clients/reth/mapper.jq
@@ -55,5 +55,6 @@ def to_bool:
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED|to_bool,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
+    "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
   }|remove_empty
 }

--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -21,6 +21,8 @@
 #  - HIVE_FORK_PETERSBURG      block number for ConstantinopleFix/Petersburg transition
 #  - HIVE_FORK_ISTANBUL        block number for Istanbul transition
 #  - HIVE_FORK_MUIR_GLACIER    block number for MuirGlacier transition
+#  - HIVE_SHANGHAI_TIMESTAMP   timestamp for Shanghai transition
+#  - HIVE_CANCUN_TIMESTAMP     timestamp for Cancun transition
 #  - HIVE_LOGLEVEL             client log level
 #
 # These flags are NOT supported by reth


### PR DESCRIPTION
Adds cancun fork in mapper and documents shanghai / cancun timestamps in `reth.sh`