### PR TITLE
clients/reth: Dockerfile support to build Reth from git or locally

### DIFF
--- a/clients/reth/Dockerfile.git
+++ b/clients/reth/Dockerfile.git
@@ -1,0 +1,40 @@
+
+### Build Reth From Git:
+## Pulls reth from a git repository and builds it from source.
+
+## Builder stage: Compiles reth from a git repository
+FROM rust:latest as builder
+
+ARG github=paradigmxyz/reth
+ARG tag=main
+
+RUN apt-get update && apt-get install -y libclang-dev pkg-config build-essential \
+    && echo "Cloning: $github - $tag" \
+    && git clone --depth 1 --branch $tag https://github.com/$github reth \
+    && cd reth && cargo build --release \
+    && cp target/release/reth /usr/local/bin/reth
+
+## Final stage: Sets up the environment for running reth
+FROM debian:latest
+RUN apt-get update && apt-get install -y bash curl jq \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy compiled binary from builder
+COPY --from=builder /usr/local/bin/reth /usr/local/bin/reth
+
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY reth.sh /reth.sh
+COPY enode.sh /hive-bin/enode.sh
+
+# Set execute permissions for scripts
+RUN chmod +x /reth.sh /hive-bin/enode.sh
+
+# Create version.txt
+RUN /usr/local/bin/reth --version | head -1 > /version.txt
+
+# Export the usual networking ports
+EXPOSE 8545 8546 30303 30303/udp
+
+ENTRYPOINT ["/reth.sh"]

--- a/clients/reth/Dockerfile.local
+++ b/clients/reth/Dockerfile.local
@@ -1,0 +1,38 @@
+### Build Reth Locally:
+## Requires a copy of <reth>/ -> hive/clients/reth/<reth>
+
+## Builder stage: Compiles reth from a git repository
+FROM rust:latest as builder
+
+# Default local client path: clients/reth/<reth>
+ARG local_path=reth
+COPY $local_path reth
+
+RUN apt-get update && apt-get install -y libclang-dev pkg-config build-essential \
+    && cd reth && cargo build --release \
+    && cp target/release/reth /usr/local/bin/reth
+
+## Final stage: Sets up the environment for running reth
+FROM debian:latest
+RUN apt-get update && apt-get install -y bash curl jq \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy compiled binary from builder
+COPY --from=builder /usr/local/bin/reth /usr/local/bin/reth
+
+# Add genesis mapper script, startup script, and enode URL retriever script
+COPY genesis.json /genesis.json
+COPY mapper.jq /mapper.jq
+COPY reth.sh /reth.sh
+COPY enode.sh /hive-bin/enode.sh
+
+# Set execute permissions for scripts
+RUN chmod +x /reth.sh /hive-bin/enode.sh
+
+# Create version.txt
+RUN /usr/local/bin/reth --version | head -1 > /version.txt
+
+# Export the usual networking ports
+EXPOSE 8545 8546 30303 30303/udp
+
+ENTRYPOINT ["/reth.sh"]


### PR DESCRIPTION
Similar to the following PRs: https://github.com/ethereum/hive/pull/782, https://github.com/ethereum/hive/pull/779, https://github.com/ethereum/hive/pull/772 & https://github.com/ethereum/hive/pull/785

We can now build reth from git assuming the following `configs/reth.yaml` file exists: 
```yaml
- client: reth
  nametag: reth-git
  dockerfile: git
  build_args:
      github: paradigmxyz/reth
      tag: main
```

Similarly, it can be built locally assuming a local copy of reth is within `clients/reth/<reth>`:
```yaml
- client: reth
  nametag: reth-local
  dockerfile: local
 ```
 
 Using the following command to assert that the appropriate config file:
 ```bash
 ./hive --sim <simulation> --client-file configs/reth.yaml --client reth
 ```