### PR TITLE
hiveview: Client URL based filtering

### DIFF
--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -59,6 +59,12 @@ function showFileListing(data) {
         suites.push(suite);
     });
 
+    // Filter based on client before rendering
+    const clientFilter = new URLSearchParams(window.location.search).get('client');
+    if (clientFilter) {
+        suites = suites.filter(suite => suite.clients.some(client => client.split('_')[0] === clientFilter));
+    }
+
     $('#filetable').DataTable({
         data: suites,
         pageLength: 50,


### PR DESCRIPTION
Adds a small change to filter all the simulations within `index.html` based on the client provided within the url.

For example, now `/?client=go-ethereum` will display only simulations by geth. This acknowledges that client names within simulation logs usually include extra metadata such as `go-ethereum_cancun-git`, hence the value specified in the url is matched against the string before the first `_`.