### PR TITLE
clients/besu: sh - Remove legacy option from startup flags

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -113,7 +113,7 @@ fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then
     FLAGS="$FLAGS --miner-extra-data=$HIVE_MINER_EXTRA"
 fi
-FLAGS="$FLAGS --min-gas-price=1 --tx-pool-price-bump=0 --tx-pool-limit-by-account-percentage=1"
+FLAGS="$FLAGS --min-gas-price=1 --tx-pool-price-bump=0"
 
 # Configure peer-to-peer networking.
 if [ "$HIVE_BOOTNODE" != "" ]; then


### PR DESCRIPTION
Besu has implemented a new txpool format and will not start if any legacy flag is present. 