### PR TITLE
cmd/hiveview: persist column filters in URL

### DIFF
--- a/cmd/hiveview/assets/index.html
+++ b/cmd/hiveview/assets/index.html
@@ -29,7 +29,8 @@
           Recent results
           <div id="loading" class="spinner-border text-secondary" role="status" style="width: 26px; height: 26px; display: none;"></div>
         </h2>
-        <p id="page-text" style="display: none;">These test suites are available, and can be loaded. Click on 'Load' to load a certain suite.</p>
+        <p id="page-text" style="display: none">These test suites are available, and can be loaded. Click on 'Load' to load a certain suite.</p>
+        <p id="filters-notice" style="display: none">Note: column filters are active: <a id="filters-clear" href="">[Clear Filters]</a></p>
         <table id="filetable" class="table table-bordered"></table>
       </div>
     </main>

--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -303,28 +303,28 @@ class ColumnFilter {
 
 // DateFilter is for the date column.
 class DateFilter extends ColumnFilter {
-    key() { return "date"; }
+    key() { return "daysago"; }
 
     build() {
         const select = this.buildSelect();
         select.append($('<option value="0">Today</option>'));
-        select.append($('<option value="-1">Yesterday</option>'));
-        select.append($('<option value="-2">2 days ago</option>'));
-        select.append($('<option value="-3">3 days ago</option>'));
-        select.append($('<option value="-4">4 days ago</option>'));
-        select.append($('<option value="-5">5 days ago</option>'));
-        select.append($('<option value="-6">6 days ago</option>'));
-        select.append($('<option value="-7">7 days ago</option>'));
+        select.append($('<option value="1">Yesterday</option>'));
+        select.append($('<option value="2">2 days ago</option>'));
+        select.append($('<option value="3">3 days ago</option>'));
+        select.append($('<option value="4">4 days ago</option>'));
+        select.append($('<option value="5">5 days ago</option>'));
+        select.append($('<option value="6">6 days ago</option>'));
+        select.append($('<option value="7">7 days ago</option>'));
         return select;
     }
 
-    plusXdays(x) {
+    minusXdays(x) {
         const date = new Date(new Date().setDate(new Date().getDate() - x));
-        return date.toLocaleDateString()
+        return date.toLocaleDateString();
     }
 
     valueToRegExp(x) {
-        const date = this.plusXdays(0 + x);
+        const date = this.minusXdays(0 + x);
         return escapeRegExp(date);
     }
 }
@@ -334,7 +334,7 @@ class ClientFilter extends ColumnFilter {
     key() { return "client"; }
 
     build() {
-        return this.buildSelectWithOptions()
+        return this.buildSelectWithOptions();
     }
 
     valueToRegExp(value) {
@@ -347,7 +347,7 @@ class SuiteFilter extends ColumnFilter {
     key() { return "suite"; }
 
     build() {
-        return this.buildSelectWithOptions()
+        return this.buildSelectWithOptions();
     }
 
     valueToRegExp(value) {


### PR DESCRIPTION
This is an alternative/extension of #862. When selecting a column filter in the table header, it will now be persisted to the URL. So if you want a page that shows only a specific client, you can get it by bookmarking the URL.

![Screenshot_2023-09-14_19-09-12](https://github.com/ethereum/hive/assets/6915/842a7dbe-5dd4-459b-ba47-c7d6693c0050)
