### PR TITLE
simulators/ethereum/pyspec: update execution-spec-tests

### DIFF
--- a/simulators/ethereum/pyspec/Dockerfile
+++ b/simulators/ethereum/pyspec/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=builder /source/pyspec/pyspec .
 # To run locally generated fixtures, comment the following RUN lines and
 # uncomment the ADD line.
 # Download the latest fixture release.
-RUN wget https://github.com/ethereum/execution-spec-tests/releases/download/v1.0.2/fixtures.tar.gz
+RUN wget https://github.com/ethereum/execution-spec-tests/releases/download/v1.0.3/fixtures.tar.gz
 RUN tar -xzvf fixtures.tar.gz
 RUN mv fixtures /fixtures
 


### PR DESCRIPTION
Updates execution-spec-tests version, which includes the same beacon root contract address as the existing engine-api tests