### PR TITLE
simulators/ethereum/engine: Add London non-zero-number test

### DIFF
--- a/simulators/ethereum/engine/config/fork.go
+++ b/simulators/ethereum/engine/config/fork.go
@@ -27,6 +27,7 @@ func (f Fork) PreviousFork() Fork {
 }
 
 type ForkConfig struct {
+	LondonNumber      *big.Int
 	ShanghaiTimestamp *big.Int
 	CancunTimestamp   *big.Int
 }

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -141,6 +141,9 @@ func makeRunner(tests []test.Spec, nodeType string) func(t *hivesim.T) {
 
 			// Configure Forks
 			newParams := globals.DefaultClientEnv.Set("HIVE_TERMINAL_TOTAL_DIFFICULTY", fmt.Sprintf("%d", ttd))
+			if forkConfig.LondonNumber != nil {
+				newParams = newParams.Set("HIVE_FORK_LONDON", fmt.Sprintf("%d", forkConfig.LondonNumber))
+			}
 			if forkConfig.ShanghaiTimestamp != nil {
 				newParams = newParams.Set("HIVE_SHANGHAI_TIMESTAMP", fmt.Sprintf("%d", forkConfig.ShanghaiTimestamp))
 				// Ensure the merge transition is activated before shanghai.

--- a/simulators/ethereum/engine/suites/engine/misc.go
+++ b/simulators/ethereum/engine/suites/engine/misc.go
@@ -1,0 +1,41 @@
+package suite_engine
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/hive/simulators/ethereum/engine/clmock"
+	"github.com/ethereum/hive/simulators/ethereum/engine/config"
+	"github.com/ethereum/hive/simulators/ethereum/engine/test"
+)
+
+// Runs a sanity test on a post Merge fork where a previous fork's (London) number is not zero
+type NonZeroPreMergeFork struct {
+	test.BaseSpec
+}
+
+func (s NonZeroPreMergeFork) WithMainFork(fork config.Fork) test.Spec {
+	specCopy := s
+	specCopy.MainFork = fork
+	return specCopy
+}
+
+func (b NonZeroPreMergeFork) GetName() string {
+	return "Pre-Merge Fork Number > 0"
+}
+
+func (s NonZeroPreMergeFork) GetForkConfig() *config.ForkConfig {
+	forkConfig := s.BaseSpec.GetForkConfig()
+	if forkConfig == nil {
+		return nil
+	}
+	forkConfig.LondonNumber = common.Big1
+	return forkConfig
+}
+
+func (b NonZeroPreMergeFork) Execute(t *test.Env) {
+	// Wait until TTD is reached by this client
+	t.CLMock.WaitForTTD()
+
+	// Simply produce a couple of blocks without transactions (if London is not active at genesis
+	// we can't send type-2 transactions) and check that the chain progresses without issues
+	t.CLMock.ProduceBlocks(5, clmock.BlockProcessCallbacks{})
+}

--- a/simulators/ethereum/engine/suites/engine/tests.go
+++ b/simulators/ethereum/engine/suites/engine/tests.go
@@ -406,4 +406,13 @@ func init() {
 			}
 		}
 	}
+
+	// Misc Tests
+	Tests = append(Tests,
+		NonZeroPreMergeFork{
+			BaseSpec: test.BaseSpec{
+				ForkHeight: 1,
+			},
+		},
+	)
 }

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/hive/simulators/ethereum/engine/config"
 	"github.com/ethereum/hive/simulators/ethereum/engine/globals"
 	"github.com/ethereum/hive/simulators/ethereum/engine/helper"
+	suite_engine "github.com/ethereum/hive/simulators/ethereum/engine/suites/engine"
 	"github.com/ethereum/hive/simulators/ethereum/engine/test"
 	typ "github.com/ethereum/hive/simulators/ethereum/engine/types"
 )
@@ -812,6 +813,14 @@ var Tests = []test.Spec{
 				Start: 17,
 				End:   17 + 32,
 			},
+		},
+	},
+
+	// TODO: Remove since this will be automatically inherited when this test suite is refactored
+	suite_engine.NonZeroPreMergeFork{
+		BaseSpec: test.BaseSpec{
+			MainFork:   config.Shanghai,
+			ForkHeight: 1,
 		},
 	},
 }


### PR DESCRIPTION
Adds a single test where a pre-merge (by block number) fork is not zero. 

Catches https://github.com/ethereum/go-ethereum/issues/28134 (on v1.13.0) and passes on latest master.