### PR TITLE
simulators/ethereum/engine: use generic error check for missing block

### DIFF
--- a/simulators/ethereum/engine/suites/engine/rpc.go
+++ b/simulators/ethereum/engine/suites/engine/rpc.go
@@ -50,7 +50,7 @@ func (b BlockStatus) Execute(t *test.Env) {
 			number = Finalized
 		}
 		p := t.TestEngine.TestHeaderByNumber(number)
-		p.ExpectErrorCode(-39001)
+		p.ExpectError()
 	}
 
 	// Produce blocks before starting the test


### PR DESCRIPTION
Right now, many of these RPC tests expect clients to return `-39001` if `safe` or `finalized` block is not found. Geth doesn't support custom RPC errors for the `eth` namespace so I really prefer if we just expect an error and be happy if we get either `39001` or `-32000`.

![Screenshot 2023-09-22 at 06 57 23](https://github.com/ethereum/hive/assets/14004106/d9213b70-f64e-4ced-b412-8585c849d208)
