### PR TITLE
simulators/ethereum/engine: rm 0x prefix on 4788 code

### DIFF
--- a/simulators/ethereum/engine/config/cancun/genesis.go
+++ b/simulators/ethereum/engine/config/cancun/genesis.go
@@ -30,7 +30,7 @@ func ConfigGenesis(genesis *core.Genesis, forkTimestamp uint64) error {
 	genesis.Alloc[BEACON_ROOTS_ADDRESS] = core.GenesisAccount{
 		Balance: common.Big0,
 		Nonce:   1,
-		Code:    common.Hex2Bytes("0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"),
+		Code:    common.Hex2Bytes("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"),
 	}
 
 	return nil


### PR DESCRIPTION
Looks like in #884 there was a small issue where `0x` prefix was added to the code. This is not accepted by `common.Hex2Bytes`, which fails silently when the prefix exists.