### PR TITLE
simulators/ethereum/engine: Fix several tests

### DIFF
--- a/simulators/ethereum/engine/helper/customizer.go
+++ b/simulators/ethereum/engine/helper/customizer.go
@@ -137,12 +137,14 @@ type TimestampDeltaPayloadAttributesCustomizer struct {
 var _ PayloadAttributesCustomizer = (*TimestampDeltaPayloadAttributesCustomizer)(nil)
 
 func (customData *TimestampDeltaPayloadAttributesCustomizer) GetPayloadAttributes(basePayloadAttributes *typ.PayloadAttributes) (*typ.PayloadAttributes, error) {
-	customPayloadAttributes, err := customData.PayloadAttributesCustomizer.GetPayloadAttributes(basePayloadAttributes)
-	if err != nil {
-		return nil, err
+	if customData.PayloadAttributesCustomizer != nil {
+		var err error
+		if basePayloadAttributes, err = customData.PayloadAttributesCustomizer.GetPayloadAttributes(basePayloadAttributes); err != nil {
+			return nil, err
+		}
 	}
-	customPayloadAttributes.Timestamp = uint64(int64(customPayloadAttributes.Timestamp) + customData.TimestampDelta)
-	return customPayloadAttributes, nil
+	basePayloadAttributes.Timestamp = uint64(int64(basePayloadAttributes.Timestamp) + customData.TimestampDelta)
+	return basePayloadAttributes, nil
 }
 
 // Customizer that makes no modifications to the forkchoice directive call.

--- a/simulators/ethereum/engine/helper/tx.go
+++ b/simulators/ethereum/engine/helper/tx.go
@@ -512,7 +512,11 @@ func (txSender *TransactionSender) GetLastNonce(ctx context.Context, node client
 	if txSender.nonceMap != nil {
 		txSender.nonceMapLock.Lock()
 		defer txSender.nonceMapLock.Unlock()
-		return txSender.nonceMap[sender.GetAddress()], nil
+		nextNonce := txSender.nonceMap[sender.GetAddress()]
+		if nextNonce > 0 {
+			return nextNonce - 1, nil
+		}
+		return 0, fmt.Errorf("no previous nonce found in map for %s", sender.GetAddress().Hex())
 	} else {
 		return node.GetLastAccountNonce(ctx, sender.GetAddress(), header)
 	}

--- a/simulators/ethereum/engine/suites/cancun/steps.go
+++ b/simulators/ethereum/engine/suites/cancun/steps.go
@@ -439,7 +439,7 @@ func (step NewPayloads) Execute(t *CancunTestContext) error {
 						r.ExpectPayloadStatus(expectedStatus)
 					}
 					if r.Response.PayloadID != nil {
-						t.CLMock.AddPayloadID(r.Response.PayloadID)
+						t.CLMock.AddPayloadID(t.Engine, r.Response.PayloadID)
 					}
 				}
 			},

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -1827,6 +1827,23 @@ func init() {
 		Tests = append(Tests, t)
 	}
 
+	// Unique Payload ID Tests
+	for _, t := range []suite_engine.PayloadAttributesFieldChange{
+		suite_engine.PayloadAttributesParentBeaconRoot,
+		// TODO: Remove when withdrawals suite is refactored
+		suite_engine.PayloadAttributesAddWithdrawal,
+		suite_engine.PayloadAttributesModifyWithdrawalAmount,
+		suite_engine.PayloadAttributesModifyWithdrawalIndex,
+		suite_engine.PayloadAttributesModifyWithdrawalValidator,
+		suite_engine.PayloadAttributesModifyWithdrawalAddress,
+		suite_engine.PayloadAttributesRemoveWithdrawal,
+	} {
+		Tests = append(Tests, suite_engine.UniquePayloadIDTest{
+			BaseSpec:          baseSpec,
+			FieldModification: t,
+		})
+	}
+
 	// Invalid Payload Tests
 	for _, invalidField := range []helper.InvalidPayloadBlockField{
 		helper.InvalidParentBeaconBlockRoot,

--- a/simulators/ethereum/engine/suites/engine/payload_id.go
+++ b/simulators/ethereum/engine/suites/engine/payload_id.go
@@ -89,7 +89,7 @@ func (tc UniquePayloadIDTest) Execute(t *test.Env) {
 			r := t.TestEngine.TestEngineForkchoiceUpdated(&t.CLMock.
 				LatestForkchoice, &payloadAttributes, t.CLMock.LatestHeader.Time)
 			r.ExpectNoError()
-			t.CLMock.AddPayloadID(r.Response.PayloadID)
+			t.CLMock.AddPayloadID(t.Engine, r.Response.PayloadID)
 		},
 	})
 }

--- a/simulators/ethereum/engine/suites/engine/payload_id.go
+++ b/simulators/ethereum/engine/suites/engine/payload_id.go
@@ -80,7 +80,12 @@ func (tc UniquePayloadIDTest) Execute(t *test.Env) {
 				}
 				payloadAttributes.Withdrawals = append(types.Withdrawals{&modifiedWithdrawal}, payloadAttributes.Withdrawals[1:]...)
 			case PayloadAttributesParentBeaconRoot:
-				payloadAttributes.BeaconRoot[0] = payloadAttributes.BeaconRoot[0] + 1
+				if payloadAttributes.BeaconRoot == nil {
+					t.Fatalf("Cannot modify parent beacon root when there is no parent beacon root")
+				}
+				newBeaconRoot := *payloadAttributes.BeaconRoot
+				newBeaconRoot[0] = newBeaconRoot[0] + 1
+				payloadAttributes.BeaconRoot = &newBeaconRoot
 			default:
 				t.Fatalf("Unknown field change: %s", tc.FieldModification)
 			}

--- a/simulators/ethereum/engine/suites/engine/tests.go
+++ b/simulators/ethereum/engine/suites/engine/tests.go
@@ -115,30 +115,29 @@ func init() {
 	Tests = append(Tests,
 		ForkchoiceUpdatedOnPayloadRequestTest{
 			BaseSpec: test.BaseSpec{
-				Name:       "Early upgrade",
-				ForkHeight: 2,
+				Name: "Early upgrade",
+				About: `
+				Early upgrade of ForkchoiceUpdated when requesting a payload.
+				The test sets the fork height to 1, and the block timestamp increments to 2
+				seconds each block.
+				CL Mock prepares the payload attributes for the first block, which should contain
+				the attributes of the next fork.
+				The test then reduces the timestamp by 1, but still uses the next forkchoice updated
+				version, which should result in UNSUPPORTED_FORK_ERROR error.
+				`,
+				ForkHeight:              1,
+				BlockTimestampIncrement: 2,
 			},
 			ForkchoiceUpdatedCustomizer: &helper.UpgradeForkchoiceUpdatedVersion{
 				ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
+					PayloadAttributesCustomizer: &helper.TimestampDeltaPayloadAttributesCustomizer{
+						PayloadAttributesCustomizer: &helper.BasePayloadAttributesCustomizer{},
+						TimestampDelta:              -1,
+					},
 					ExpectedError: globals.UNSUPPORTED_FORK_ERROR,
 				},
 			},
 		},
-		/*
-			TODO: This test is failing because the upgraded version of the ForkchoiceUpdated does not contain the
-			      expected fields of the following version.
-			ForkchoiceUpdatedOnHeadBlockUpdateTest{
-				BaseSpec: test.BaseSpec{
-					Name:       "Early upgrade",
-					ForkHeight: 2,
-				},
-				ForkchoiceUpdatedCustomizer: &helper.UpgradeForkchoiceUpdatedVersion{
-					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
-						ExpectedError: globals.UNSUPPORTED_FORK_ERROR,
-					},
-				},
-			},
-		*/
 	)
 
 	// Payload Execution Tests


### PR DESCRIPTION
## Changes Included
- Small fix to the setup of the generic versioning tests
- Fixes the tx replacement that affected one Cancun test
- Fixed the Unique ID test for the beacon root attribute
- Added a per-client map for payload IDs (allows collisions between clients for some clients that use a simple counter e.g. Erigon)