### PR TITLE
clients/teku-bn: Add presets to config

### DIFF
--- a/clients/teku-bn/teku_bn.sh
+++ b/clients/teku-bn/teku_bn.sh
@@ -14,6 +14,8 @@ mkdir -p /data/testnet_setup
 
 cp /hive/input/genesis.ssz /data/testnet_setup/genesis.ssz
 cp /hive/input/config.yaml /data/testnet_setup
+cp /hive/input/preset*.yaml /data/testnet_setup
+cat /hive/input/preset*.yaml >> /data/testnet_setup/config.yaml
 
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     sed -i '/TERMINAL_TOTAL_DIFFICULTY/d' /data/testnet_setup/config.yaml


### PR DESCRIPTION
This was necessary for Teku to correctly start after `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT` was added to Deneb.

I'm not sure if this is the correct approach or this could be a real issue.

cc @zilm13