### PR TITLE
clients/erigon: Increase allowed blobcount in remote txs

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -129,6 +129,9 @@ fi
 FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3"
 FLAGS="$FLAGS --ws"
 
+# Increase blob slots for tests
+FLAGS="$FLAGS --txpool.blobslots=1000"
+
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
     echo -n $JWT_SECRET > /jwt.secret


### PR DESCRIPTION
Erigon now has a built-in spam protector for blob txs, this flag would increase the count of allowed blobs per account from the default 48 to a 1000