### PR TITLE
simulators/ethereum/engine: Engine API Test Fixes

### DIFF
--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -1844,13 +1844,21 @@ func init() {
 			invalidDetectedOnSync := (invalidField == helper.InvalidBlobGasUsed ||
 				invalidField == helper.InvalidBlobCountGasUsed ||
 				invalidField == helper.InvalidVersionedHashes ||
-				invalidField == helper.InvalidVersionedHashesVersion)
+				invalidField == helper.InvalidVersionedHashesVersion ||
+				invalidField == helper.IncompleteVersionedHashes ||
+				invalidField == helper.ExtraVersionedHashes)
+
+			nilLatestValidHash := (invalidField == helper.InvalidVersionedHashes ||
+				invalidField == helper.InvalidVersionedHashesVersion ||
+				invalidField == helper.IncompleteVersionedHashes ||
+				invalidField == helper.ExtraVersionedHashes)
 
 			Tests = append(Tests, suite_engine.InvalidPayloadTestCase{
 				BaseSpec:              onlyBlobTxsSpec,
 				InvalidField:          invalidField,
 				Syncing:               syncing,
 				InvalidDetectedOnSync: invalidDetectedOnSync,
+				NilLatestValidHash:    nilLatestValidHash,
 			})
 		}
 	}

--- a/simulators/ethereum/engine/suites/engine/misc.go
+++ b/simulators/ethereum/engine/suites/engine/misc.go
@@ -1,6 +1,8 @@
 package suite_engine
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/hive/simulators/ethereum/engine/clmock"
 	"github.com/ethereum/hive/simulators/ethereum/engine/config"
@@ -28,6 +30,11 @@ func (s NonZeroPreMergeFork) GetForkConfig() *config.ForkConfig {
 		return nil
 	}
 	forkConfig.LondonNumber = common.Big1
+	// All post merge forks must happen at the same time as the latest fork
+	mainFork := s.GetMainFork()
+	if mainFork == config.Cancun {
+		forkConfig.ShanghaiTimestamp = new(big.Int).Set(forkConfig.CancunTimestamp)
+	}
 	return forkConfig
 }
 


### PR DESCRIPTION
## Changes Included
-  Pre-Merge Fork > 0: Post-merge forks are now all happening on block 1 for consistency
- Invalid Versioned Hashes verification fixes