### PR TITLE
simulators/ethereum/engine: Fixes from interop meeting

### DIFF
--- a/simulators/ethereum/engine/helper/customizer.go
+++ b/simulators/ethereum/engine/helper/customizer.go
@@ -732,7 +732,12 @@ func GenerateInvalidPayload(basePayload *typ.ExecutableData, payloadField Invali
 			modifiedSignature.R = modifiedSignature.R.Sub(modifiedSignature.R, common.Big1)
 			customTxData.Signature = &modifiedSignature
 		case InvalidTransactionNonce:
-			customNonce := baseTx.Nonce() - 1
+			customNonce := baseTx.Nonce()
+			if customNonce > 0 {
+				customNonce = customNonce - 1
+			} else {
+				customNonce = 2 << 32
+			}
 			customTxData.Nonce = &customNonce
 		case InvalidTransactionGas:
 			customGas := uint64(0)

--- a/simulators/ethereum/engine/helper/customizer.go
+++ b/simulators/ethereum/engine/helper/customizer.go
@@ -728,7 +728,8 @@ func GenerateInvalidPayload(basePayload *typ.ExecutableData, payloadField Invali
 		var customTxData CustomTransactionData
 		switch payloadField {
 		case InvalidTransactionSignature:
-			modifiedSignature := SignatureValuesFromRaw(baseTx.RawSignatureValues())
+			baseV, baseR, baseS := baseTx.RawSignatureValues()
+			modifiedSignature := SignatureValuesFromRaw(baseV, baseR, baseS)
 			modifiedSignature.R = modifiedSignature.R.Sub(modifiedSignature.R, common.Big1)
 			customTxData.Signature = &modifiedSignature
 		case InvalidTransactionNonce:
@@ -740,10 +741,11 @@ func GenerateInvalidPayload(basePayload *typ.ExecutableData, payloadField Invali
 			}
 			customTxData.Nonce = &customNonce
 		case InvalidTransactionGas:
-			customGas := uint64(0)
+			customGas := uint64(baseTx.Gas() + 1)
 			customTxData.Gas = &customGas
 		case InvalidTransactionGasPrice:
-			customTxData.GasPriceOrGasFeeCap = common.Big0
+			customTxData.GasPriceOrGasFeeCap = new(big.Int).Set(baseTx.GasPrice())
+			customTxData.GasPriceOrGasFeeCap.Div(customTxData.GasPriceOrGasFeeCap, big.NewInt(2))
 		case InvalidTransactionGasTipPrice:
 			invalidGasTip := new(big.Int).Set(globals.GasTipPrice)
 			invalidGasTip.Mul(invalidGasTip, big.NewInt(2))

--- a/simulators/ethereum/engine/helper/customizer.go
+++ b/simulators/ethereum/engine/helper/customizer.go
@@ -730,7 +730,7 @@ func GenerateInvalidPayload(basePayload *typ.ExecutableData, payloadField Invali
 		case InvalidTransactionSignature:
 			baseV, baseR, baseS := baseTx.RawSignatureValues()
 			modifiedSignature := SignatureValuesFromRaw(baseV, baseR, baseS)
-			modifiedSignature.R = modifiedSignature.R.Sub(modifiedSignature.R, common.Big1)
+			modifiedSignature.S = modifiedSignature.S.Sub(modifiedSignature.S, common.Big1)
 			customTxData.Signature = &modifiedSignature
 		case InvalidTransactionNonce:
 			customNonce := baseTx.Nonce()

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -1061,14 +1061,8 @@ var Tests = []test.Spec{
 		},
 
 		TestSequence: TestSequence{
-			// First, we send a couple of blob transactions on genesis,
-			// with enough data gas cost to make sure they are included in the first block.
-			SendBlobTransactions{
-				TransactionCount:              cancun.TARGET_BLOBS_PER_BLOCK,
-				BlobTransactionMaxBlobGasCost: big.NewInt(1),
-			},
 			NewPayloads{
-				ExpectedIncludedBlobCount: cancun.TARGET_BLOBS_PER_BLOCK,
+				ExpectedIncludedBlobCount: 0,
 				// This customizer only simulates requesting a Shanghai payload 1 second before cancun.
 				// CL Mock will still request the Cancun payload afterwards
 				FcUOnPayloadRequest: &helper.BaseForkchoiceUpdatedCustomizer{

--- a/simulators/ethereum/engine/suites/engine/invalid_payload.go
+++ b/simulators/ethereum/engine/suites/engine/invalid_payload.go
@@ -28,7 +28,8 @@ type InvalidPayloadTestCase struct {
 	Syncing bool
 	// EmptyTransactions is true if the payload should not contain any transactions
 	EmptyTransactions bool
-	// If true, the payload can be detected to be invalid even when syncing
+	// If true, the payload can be detected to be invalid even when syncing,
+	// but this check is optional and both `INVALID` and `SYNCING` are valid responses.
 	InvalidDetectedOnSync bool
 	// If true, latest valid hash can be nil for this test.
 	NilLatestValidHash bool
@@ -153,8 +154,11 @@ func (tc InvalidPayloadTestCase) Execute(t *test.Env) {
 				// if the payload extends the canonical chain and requisite data for its validation is missing
 				// (the client can assume the payload extends the canonical because the linking payload could be missing)
 				if invalidDetectedOnSync {
-					// For some fields, the client can detect the invalid payload even when it doesn't have the parent
-					r.ExpectStatusEither(test.Invalid)
+					// For some fields, the client can detect the invalid payload even when it doesn't have the parent.
+					// However this behavior is up to the client, so we can't expect it to happen and syncing is also valid.
+					// `VALID` response is still incorrect though.
+					r.ExpectStatusEither(test.Invalid, test.Accepted, test.Syncing)
+					// TODO: It seems like latestValidHash==nil should always be expected here.
 				} else {
 					r.ExpectStatusEither(test.Accepted, test.Syncing)
 					r.ExpectLatestValidHash(nil)

--- a/simulators/ethereum/engine/suites/engine/tests.go
+++ b/simulators/ethereum/engine/suites/engine/tests.go
@@ -195,6 +195,7 @@ func init() {
 		helper.InvalidTransactionValue,
 		helper.InvalidTransactionChainID,
 	} {
+		invalidDetectedOnSync := invalidField == helper.InvalidTransactionChainID
 		for _, syncing := range []bool{false, true} {
 			if invalidField != helper.InvalidTransactionGasTipPrice {
 				for _, testTxType := range []helper.TestTransactionType{helper.LegacyTxOnly, helper.DynamicFeeTxOnly} {
@@ -202,8 +203,9 @@ func init() {
 						BaseSpec: test.BaseSpec{
 							TestTransactionType: testTxType,
 						},
-						InvalidField: invalidField,
-						Syncing:      syncing,
+						InvalidField:          invalidField,
+						Syncing:               syncing,
+						InvalidDetectedOnSync: invalidDetectedOnSync,
 					})
 				}
 			} else {
@@ -211,8 +213,9 @@ func init() {
 					BaseSpec: test.BaseSpec{
 						TestTransactionType: helper.DynamicFeeTxOnly,
 					},
-					InvalidField: invalidField,
-					Syncing:      syncing,
+					InvalidField:          invalidField,
+					Syncing:               syncing,
+					InvalidDetectedOnSync: invalidDetectedOnSync,
 				})
 			}
 		}


### PR DESCRIPTION
## Changes Included
- Invalid payload fields that can be detected by static check before sync are now optional, therefore `INVALID` and `SYNCING` can be accepted for payloads that can be detected to be invalid even before sync
- Invalid payloads with an invalid transaction now use more plausible values. E.g. `nonce < 2**64-1`, `gasLimit > 0`
- `ForkchoiceUpdatedV2 then ForkchoiceUpdatedV3 Valid Payload Building Requests` now does not send blob transactions before Cancun fork.

@lightclient @g11tech @acolytec3  @MarekM25 @marcindsobczak @yperbasis @jflo 