### PR TITLE
Use admin_nodeInfo instead of net_nodeInfo in nimbus enode.sh

### DIFF
--- a/clients/nimbus-el/enode.sh
+++ b/clients/nimbus-el/enode.sh
@@ -9,7 +9,7 @@
 # Immediately abort the script on any error encountered
 set -e
 
-TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"net_nodeInfo","params":[],"id":1}' "localhost:8545" )
+TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}' "localhost:8545" )
 
 TARGET_ENODE=$(echo ${TARGET_RESPONSE}| jq -r '.result.enode')
 echo "$TARGET_ENODE"


### PR DESCRIPTION
Most/all EL clients seem to use admin_nodeInfo so we adjusted this in nimbus-eth1.

See also https://github.com/status-im/nimbus-eth1/pull/1799