### PR TITLE
libhive: Return client types in the order defined in the client-file

### DIFF
--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -400,9 +400,9 @@ func TestStartClientInitialNetworks(t *testing.T) {
 }
 
 func newFakeAPI(hooks *fakes.BackendHooks) (*libhive.TestManager, *httptest.Server) {
-	defs := map[string]*libhive.ClientDefinition{
-		"client-1": {Name: "client-1", Image: "/ignored/in/api", Version: "client-1-version", Meta: libhive.ClientMetadata{Roles: []string{"eth1"}}},
-		"client-2": {Name: "client-2", Image: "/not/exposed/", Version: "client-2-version", Meta: libhive.ClientMetadata{Roles: []string{"beacon"}}},
+	defs := []*libhive.ClientDefinition{
+		{Name: "client-1", Image: "/ignored/in/api", Version: "client-1-version", Meta: libhive.ClientMetadata{Roles: []string{"eth1"}}},
+		{Name: "client-2", Image: "/not/exposed/", Version: "client-2-version", Meta: libhive.ClientMetadata{Roles: []string{"beacon"}}},
 	}
 	env := libhive.SimEnv{}
 	backend := fakes.NewContainerBackend(hooks)

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -61,7 +61,7 @@ type SimResult struct {
 type TestManager struct {
 	config     SimEnv
 	backend    ContainerBackend
-	clientDefs map[string]*ClientDefinition
+	clientDefs []*ClientDefinition
 
 	simContainerID string
 	simLogFile     string
@@ -80,7 +80,7 @@ type TestManager struct {
 	results           map[TestSuiteID]*TestSuite
 }
 
-func NewTestManager(config SimEnv, b ContainerBackend, clients map[string]*ClientDefinition) *TestManager {
+func NewTestManager(config SimEnv, b ContainerBackend, clients []*ClientDefinition) *TestManager {
 	return &TestManager{
 		clientDefs:        clients,
 		config:            config,


### PR DESCRIPTION
## Changes Included
Changes map usages to a list in order to try to preserve the order in which the clients are listed in the client-file.

## Reasoning
In simulator `eth2-dencun` there is a new suite that depends on an specific client being launched first before any other client combination ("evil-teku").