### PR TITLE
simulators/ethereum/engine: Update post-merge forks to activate later in pre-merge test

### DIFF
--- a/clients/erigon/mapper.jq
+++ b/clients/erigon/mapper.jq
@@ -50,6 +50,7 @@ def to_bool:
     "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
     "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,

--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -52,7 +52,7 @@ def to_bool:
     "yolov2Block": env.HIVE_FORK_BERLIN|to_int,
     "yolov3Block": env.HIVE_FORK_BERLIN|to_int,
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
-    "mergeForkBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,

--- a/clients/reth/mapper.jq
+++ b/clients/reth/mapper.jq
@@ -52,6 +52,7 @@ def to_bool:
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
     "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
+    "parisBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED|to_bool,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,

--- a/simulators/ethereum/engine/config/fork.go
+++ b/simulators/ethereum/engine/config/fork.go
@@ -10,6 +10,7 @@ type Fork string
 
 const (
 	NA       Fork = ""
+	London   Fork = "London"
 	Paris    Fork = "Paris"
 	Shanghai Fork = "Shanghai"
 	Cancun   Fork = "Cancun"
@@ -17,6 +18,8 @@ const (
 
 func (f Fork) PreviousFork() Fork {
 	switch f {
+	case Paris:
+		return London
 	case Shanghai:
 		return Paris
 	case Cancun:
@@ -28,6 +31,7 @@ func (f Fork) PreviousFork() Fork {
 
 type ForkConfig struct {
 	LondonNumber      *big.Int
+	ParisNumber       *big.Int
 	ShanghaiTimestamp *big.Int
 	CancunTimestamp   *big.Int
 }

--- a/simulators/ethereum/engine/config/genesis.go
+++ b/simulators/ethereum/engine/config/genesis.go
@@ -9,16 +9,17 @@ import (
 )
 
 func (f *ForkConfig) ConfigGenesis(genesis *core.Genesis) error {
+	if f.ParisNumber != nil {
+		genesis.Config.MergeNetsplitBlock = f.ParisNumber
+		if genesis.Number >= f.ParisNumber.Uint64() {
+			removePoW(genesis)
+		}
+	}
 	if f.ShanghaiTimestamp != nil {
 		shanghaiTime := f.ShanghaiTimestamp.Uint64()
 		genesis.Config.ShanghaiTime = &shanghaiTime
-
 		if genesis.Timestamp >= shanghaiTime {
-			// Remove PoW altogether
-			genesis.Difficulty = common.Big0
-			genesis.Config.TerminalTotalDifficulty = common.Big0
-			genesis.Config.Clique = nil
-			genesis.ExtraData = []byte{}
+			removePoW(genesis)
 		}
 	}
 	if f.CancunTimestamp != nil {
@@ -27,4 +28,11 @@ func (f *ForkConfig) ConfigGenesis(genesis *core.Genesis) error {
 		}
 	}
 	return nil
+}
+
+func removePoW(genesis *core.Genesis) {
+	genesis.Difficulty = common.Big0
+	genesis.Config.TerminalTotalDifficulty = common.Big0
+	genesis.Config.Clique = nil
+	genesis.ExtraData = []byte{}
 }

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -144,10 +144,15 @@ func makeRunner(tests []test.Spec, nodeType string) func(t *hivesim.T) {
 			if forkConfig.LondonNumber != nil {
 				newParams = newParams.Set("HIVE_FORK_LONDON", fmt.Sprintf("%d", forkConfig.LondonNumber))
 			}
+			if forkConfig.ParisNumber != nil {
+				newParams = newParams.Set("HIVE_MERGE_BLOCK_ID", fmt.Sprintf("%d", forkConfig.ParisNumber))
+			}
 			if forkConfig.ShanghaiTimestamp != nil {
 				newParams = newParams.Set("HIVE_SHANGHAI_TIMESTAMP", fmt.Sprintf("%d", forkConfig.ShanghaiTimestamp))
-				// Ensure the merge transition is activated before shanghai.
-				newParams = newParams.Set("HIVE_MERGE_BLOCK_ID", "0")
+				// Ensure merge transition is activated before shanghai if not already
+				if forkConfig.ParisNumber == nil {
+					newParams = newParams.Set("HIVE_MERGE_BLOCK_ID", "0")
+				}
 				if forkConfig.CancunTimestamp != nil {
 					newParams = newParams.Set("HIVE_CANCUN_TIMESTAMP", fmt.Sprintf("%d", forkConfig.CancunTimestamp))
 				}

--- a/simulators/ethereum/engine/suites/engine/misc.go
+++ b/simulators/ethereum/engine/suites/engine/misc.go
@@ -29,8 +29,10 @@ func (s NonZeroPreMergeFork) GetForkConfig() *config.ForkConfig {
 	if forkConfig == nil {
 		return nil
 	}
+	// Merge fork & pre-merge happen at block 1
 	forkConfig.LondonNumber = common.Big1
-	// All post merge forks must happen at the same time as the latest fork
+	forkConfig.ParisNumber = common.Big1
+	// Post-merge fork happens at block 2
 	mainFork := s.GetMainFork()
 	if mainFork == config.Cancun {
 		forkConfig.ShanghaiTimestamp = new(big.Int).Set(forkConfig.CancunTimestamp)

--- a/simulators/ethereum/engine/suites/engine/tests.go
+++ b/simulators/ethereum/engine/suites/engine/tests.go
@@ -411,9 +411,10 @@ func init() {
 
 	// Misc Tests
 	Tests = append(Tests,
+		// Pre-merge & merge fork occur at block 1, post-merge forks occur at block 2
 		NonZeroPreMergeFork{
 			BaseSpec: test.BaseSpec{
-				ForkHeight: 1,
+				ForkHeight: 2,
 			},
 		},
 	)


### PR DESCRIPTION
Adds an update to the test here: https://github.com/ethereum/hive/pull/867, where a pre-merge fork is non-zero.

Previously, this test would start by loading a genesis config where the pre-merge fork (London) occured at the same block (block 1) as the post merge fork under test.

Now the genesis config starts with a pre-merge fork (London) and merge fork (Paris) both occuring on block 1. Then the post merge-fork under test occurs at block 2.

cc @marioevz @flcl42