### PR TITLE
clients/lighthouse-bn: Add trusted peers env var

### DIFF
--- a/clients/lighthouse-bn/lighthouse_bn.sh
+++ b/clients/lighthouse-bn/lighthouse_bn.sh
@@ -51,6 +51,10 @@ if [[ "$HIVE_ETH2_BEACON_NODE_INDEX" != "" ]]; then
     fi
 fi
 
+if [[ "$HIVE_ETH2_TRUSTED_PEER_IDS" != "" ]]; then
+    trustedpeers="$trustedpeers,$HIVE_ETH2_TRUSTED_PEER_IDS"
+fi
+
 LOG=info
 case "$HIVE_LOGLEVEL" in
     0|1) LOG=error ;;


### PR DESCRIPTION
Adds reading the `HIVE_ETH2_TRUSTED_PEER_IDS` environment variable which can be set from the simulators in order to add a Peer ID to lighthouse's list of trusted peers.

Required for the devp2p blobs tests.