### PR TITLE
clients/go-ethereum: disable min free disk check

### DIFF
--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -169,5 +169,7 @@ fi
 
 # Run the go-ethereum implementation with the requested flags.
 FLAGS="$FLAGS --nat=none"
+# Disable disk space free monitor
+FLAGS="$FLAGS --datadir.minfreedisk=0"
 echo "Running go-ethereum with flags $FLAGS"
 $geth $FLAGS


### PR DESCRIPTION
Seems rpc-compat with client go-ethereum can't run in the hive test case, 

<img width="1279" alt="image" src="https://github.com/ethereum/hive/assets/3627395/0f800f79-5404-481e-8e7d-89b0c9810559">




eg: https://hivetests2.ethdevops.io/viewer.html?suiteid=1697716928-571541a564e337a8555705dda14793e8.json&suitename=rpc-compat&testid=1&file=%2Fresults%2Fgo-ethereum%2Fclient-489d013ac2474cdaec4ab95f94647a9c1080e52d4193b2483e8b4a35c310f876.log

<img width="1277" alt="image" src="https://github.com/ethereum/hive/assets/3627395/2c3e7eae-29f4-4da8-bb0f-bd7fc4e42aff">

```
ERROR[10-19|12:02:08.452] Low disk space. Gracefully shutting down Geth to prevent database corruption. available=0.00B path=/root/.ethereum/geth
INFO [10-19|12:02:08.452] Got interrupt, shutting down... 
INFO [10-19|12:02:08.452] HTTP server stopped                      endpoint=[::]:8545
INFO [10-19|12:02:08.452] HTTP server stopped                      endpoint=[::]:8546
INFO [10-19|12:02:08.452] HTTP server stopped                      endpoint=[::]:8551
INFO [10-19|12:02:08.453] IPC endpoint closed                      url=/root/.ethereum/geth.ipc
INFO [10-19|12:02:08.453] Ethereum protocol stopped 
INFO [10-19|12:02:08.453] Transaction pool stopped 
INFO [10-19|12:02:08.522] Writing snapshot state to disk           root=f67fe3..1ed599
INFO [10-19|12:02:08.522] Persisted trie from memory database      nodes=0 size=0.00B time="5.769¬µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
INFO [10-19|12:02:08.522] Blockchain stopped
```



