### PR TITLE
clients/lodestar-bn: Add optional flag to disable peer scoring

### DIFF
--- a/clients/lodestar-bn/lodestar_bn.sh
+++ b/clients/lodestar-bn/lodestar_bn.sh
@@ -38,6 +38,7 @@ bootnodes_option=$([[ "$HIVE_ETH2_BOOTNODE_ENRS" == "" ]] && echo "" || echo "--
 metrics_option=$([[ "$HIVE_ETH2_METRICS_PORT" == "" ]] && echo "" || echo "--metrics --metrics.address=$CONTAINER_IP --metrics.port=$HIVE_ETH2_METRICS_PORT")
 builder_option=$([[ "$HIVE_ETH2_BUILDER_ENDPOINT" == "" ]] && echo "" || echo "--builder --builder.urls $HIVE_ETH2_BUILDER_ENDPOINT")
 echo BUILDER=$builder_option
+peer_score_option=$([[ "$HIVE_ETH2_DISABLE_PEER_SCORING" == "" ]] && echo "" || echo "--disablePeerScoring")
 
 echo "bootnodes option : ${bootnodes_option}"
 
@@ -64,6 +65,7 @@ node /usr/app/node_modules/.bin/lodestar \
     $metrics_option \
     $bootnodes_option \
     $builder_option \
+    $peer_score_option \
     --enr.ip="${CONTAINER_IP}" \
     --enr.tcp="${HIVE_ETH2_P2P_TCP_PORT:-9000}" \
     --enr.udp="${HIVE_ETH2_P2P_UDP_PORT:-9000}" \


### PR DESCRIPTION
Adds a flag that can be enabled on a per-simulator basis to disable peer scoring (e.g. p2p blob gossiping tests).

@g11tech