### PR TITLE
cmd/hivechain: export chain starting after genesis

### DIFF
--- a/cmd/hivechain/output.go
+++ b/cmd/hivechain/output.go
@@ -115,7 +115,7 @@ func (g *generator) writeChain() error {
 	}
 	defer out.Close()
 	lastBlock := g.blockchain.CurrentBlock().Number.Uint64()
-	return exportN(g.blockchain, out, 0, lastBlock)
+	return exportN(g.blockchain, out, 1, lastBlock)
 }
 
 // writePoWChain writes pre-merge RLP blocks to a file.
@@ -130,7 +130,7 @@ func (g *generator) writePoWChain() error {
 	if !ok {
 		lastBlock = g.blockchain.CurrentBlock().Number.Uint64()
 	}
-	return exportN(g.blockchain, out, 0, lastBlock)
+	return exportN(g.blockchain, out, 1, lastBlock)
 }
 
 func (g *generator) mergeBlock() (uint64, bool) {


### PR DESCRIPTION
Previously, `hivechain` would output the chain starting with the block after genesis. This makes sense because when we init a client with the genesis file it constructs the genesis block.

This change would be nice to have since anything that was previously consuming `chain.rlp`s from `hivechain` will need to be updated to skip over the genesis block otherwise.