### PR TITLE
cmd/hivechain: write ttd passed to genesis if merged

### DIFF
--- a/cmd/hivechain/genesis.go
+++ b/cmd/hivechain/genesis.go
@@ -90,6 +90,7 @@ func (cfg *generatorConfig) createChainConfig() *params.ChainConfig {
 			chaincfg.GrayGlacierBlock = new(big.Int).SetUint64(b)
 		case "merge":
 			chaincfg.MergeNetsplitBlock = new(big.Int).SetUint64(b)
+			chaincfg.TerminalTotalDifficultyPassed = true
 		// time-based forks
 		case "shanghai":
 			chaincfg.ShanghaiTime = &timestamp


### PR DESCRIPTION
Geth [no longer supports](https://github.com/ethereum/go-ethereum/blob/cd2953567268777507b1ec29269315324fb5aa9c/eth/ethconfig/config.go#L181-L186) PoW networks, so we need to make sure the genesis lists the `ttd` as passed.