### PR TITLE
simulators/ethereum/engine: update test names for distinction

### DIFF
--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -114,7 +114,7 @@ Send a NewPayload directive to the client including an incorrect BlockHash, shou
    - NewPayload while syncing, on canonical chain
    - NewPayload while syncing, on side chain
 
-- ParentHash==BlockHash on NewPayload:  
+- ParentHash equals BlockHash on NewPayload:  
 Send a NewPayload directive to the client including ParentHash that is equal to the BlockHash (Incorrect hash).
 
 - Invalid Transition Payload:
@@ -176,10 +176,10 @@ Test that performing a re-org back into a previous block of the canonical chain 
 Build an alternative chain of 10 payloads.
 Perform `newPayload(P10')` + `fcU(P10')`, which should result in client `SYNCING`. Verify that the client can re-org back to the canonical chain after sending `newPayload(P11)` + `fcU(P11)`.
 
-- Import and re-org to previously validated payload on a side chain:
+- Re-org to Previously Validated Sidechain Payload:
 Attempt to re-org to one of the sidechain (previously validated) payloads, but not the leaf, and also build a new payload from this sidechain.
 
-- Safe Re-Org to Side Chain
+- Safe Re-Org to Side Chain:
 Perform a re-org of the safe block (and head block) to a valid sidechain.
 
 ### Suggested Fee Recipient in Payload creation

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -158,7 +158,7 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "Blob Transaction Ordering, Single Account",
+			Name: "Blob Transaction Ordering, Single Account, Single Blob",
 			About: `
 			Send N blob transactions with cancun.MAX_BLOBS_PER_BLOCK-1 blobs each,
 			using account A.
@@ -203,7 +203,7 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "Blob Transaction Ordering, Single Account 2",
+			Name: "Blob Transaction Ordering, Single Account, Dual Blob",
 			About: `
 			Send N blob transactions with cancun.MAX_BLOBS_PER_BLOCK-1 blobs each,
 			using account A.
@@ -1084,7 +1084,7 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Missing Hash",
+			Name: "NewPayloadV3 Versioned Hashes, Missing Hash, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is missing one of the hashes.
@@ -1116,7 +1116,7 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Extra Hash",
+			Name: "NewPayloadV3 Versioned Hashes, Extra Hash, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is has an extra hash for a blob that is not in the payload.
@@ -1150,7 +1150,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Out of Order",
+			Name: "NewPayloadV3 Versioned Hashes, Out of Order, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is out of order.
@@ -1182,7 +1182,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Repeated Hash",
+			Name: "NewPayloadV3 Versioned Hashes, Repeated Hash, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			has a blob that is repeated in the array.
@@ -1214,7 +1214,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Incorrect Hash",
+			Name: "NewPayloadV3 Versioned Hashes, Incorrect Hash, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			has a blob hash that does not belong to any blob contained in the payload.
@@ -1245,7 +1245,7 @@ var Tests = []test.Spec{
 	},
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Incorrect Version",
+			Name: "NewPayloadV3 Versioned Hashes, Incorrect Version, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			has a single blob that has an incorrect version.
@@ -1278,7 +1278,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Nil Hashes",
+			Name: "NewPayloadV3 Versioned Hashes, Nil Hashes, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is nil, even though the fork has already happened.
@@ -1310,7 +1310,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Empty Hashes",
+			Name: "NewPayloadV3 Versioned Hashes, Empty Hashes, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is empty, even though there are blobs in the payload.
@@ -1342,7 +1342,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Non-Empty Hashes",
+			Name: "NewPayloadV3 Versioned Hashes, Non-Empty Hashes, Syncing=False",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is contains hashes, even though there are no blobs in the payload.
@@ -1371,7 +1371,7 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Missing Hash (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Missing Hash, Syncing=True",
 			About: `
 				Tests VersionedHashes in Engine API NewPayloadV3 where the array
 				is missing one of the hashes.
@@ -1410,7 +1410,7 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Extra Hash (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Extra Hash, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is has an extra hash for a blob that is not in the payload.
@@ -1451,7 +1451,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Out of Order (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Out of Order, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is out of order.
@@ -1489,7 +1489,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Repeated Hash (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Repeated Hash, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			has a blob that is repeated in the array.
@@ -1528,7 +1528,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Incorrect Hash (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Incorrect Hash, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			has a blob that is repeated in the array.
@@ -1566,7 +1566,7 @@ var Tests = []test.Spec{
 	},
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Incorrect Version (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Incorrect Version, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			has a single blob that has an incorrect version.
@@ -1606,7 +1606,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Nil Hashes (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Nil Hashes, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is nil, even though the fork has already happened.
@@ -1645,7 +1645,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Empty Hashes (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Empty Hashes, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is empty, even though there are blobs in the payload.
@@ -1684,7 +1684,7 @@ var Tests = []test.Spec{
 
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "NewPayloadV3 Versioned Hashes, Non-Empty Hashes (Syncing)",
+			Name: "NewPayloadV3 Versioned Hashes, Non-Empty Hashes, Syncing=True",
 			About: `
 			Tests VersionedHashes in Engine API NewPayloadV3 where the array
 			is contains hashes, even though there are no blobs in the payload.
@@ -1721,7 +1721,7 @@ var Tests = []test.Spec{
 	// and can be executed using `pyspec` simulator.
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "Incorrect BlobGasUsed: Non-Zero on Zero Blobs",
+			Name: "Incorrect BlobGasUsed, Non-Zero on Zero Blobs",
 			About: `
 			Send a payload with zero blobs, but non-zero BlobGasUsed.
 			`,
@@ -1741,7 +1741,7 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "Incorrect BlobGasUsed: GAS_PER_BLOB on Zero Blobs",
+			Name: "Incorrect BlobGasUsed, GAS_PER_BLOB on Zero Blobs",
 			About: `
 			Send a payload with zero blobs, but non-zero BlobGasUsed.
 			`,

--- a/simulators/ethereum/engine/suites/engine/bad_hash.go
+++ b/simulators/ethereum/engine/suites/engine/bad_hash.go
@@ -152,9 +152,11 @@ func (s ParentHashOnNewPayload) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (p ParentHashOnNewPayload) GetName() string {
-	name := "ParentHash==BlockHash on NewPayload"
+	name := "ParentHash equals BlockHash on NewPayload,"
 	if p.Syncing {
-		name += " (Syncing)"
+		name += " Syncing=True"
+	} else {
+		name += " Syncing=False"
 	}
 	return name
 }

--- a/simulators/ethereum/engine/suites/engine/fork_id.go
+++ b/simulators/ethereum/engine/suites/engine/fork_id.go
@@ -2,6 +2,7 @@ package suite_engine
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ethereum/hive/simulators/ethereum/engine/clmock"
@@ -22,14 +23,15 @@ func (s ForkIDSpec) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (ft ForkIDSpec) GetName() string {
-	name := fmt.Sprintf("Fork ID: Genesis at %d, %s at %d", ft.GetGenesisTimestamp(), ft.MainFork, ft.ForkTime)
+	var name []string
+	name = append(name, fmt.Sprintf("Fork ID: Genesis=%d, %s=%d", ft.GetGenesisTimestamp(), ft.MainFork, ft.ForkTime))
 	if ft.PreviousForkTime != 0 {
-		name += fmt.Sprintf(", %s at %d", ft.MainFork.PreviousFork(), ft.PreviousForkTime)
+		name = append(name, fmt.Sprintf("%s=%d", ft.MainFork.PreviousFork(), ft.PreviousForkTime))
 	}
 	if ft.ProduceBlocksBeforePeering > 0 {
-		name += fmt.Sprintf(", Produce %d blocks before peering", ft.ProduceBlocksBeforePeering)
+		name = append(name, fmt.Sprintf("BlocksBeforePeering=%d", ft.ProduceBlocksBeforePeering))
 	}
-	return name
+	return strings.Join(name, ", ")
 }
 
 func (ft ForkIDSpec) Execute(t *test.Env) {

--- a/simulators/ethereum/engine/suites/engine/invalid_ancestor.go
+++ b/simulators/ethereum/engine/suites/engine/invalid_ancestor.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"strings"
 	"time"
 
 	api "github.com/ethereum/go-ethereum/beacon/engine"
@@ -40,16 +39,16 @@ func (s InvalidMissingAncestorReOrgTest) WithMainFork(fork config.Fork) test.Spe
 }
 
 func (tc InvalidMissingAncestorReOrgTest) GetName() string {
-	name := []string{
-		"Invalid Missing Ancestor ReOrg",
-		fmt.Sprintf("Invalid %s", tc.InvalidField),
-	}
+	emptyTxsStatus := "False"
 	if tc.EmptyTransactions {
-		name = append(name, "Empty Txs")
+		emptyTxsStatus = "True"
 	}
-	name = append(name, fmt.Sprintf("Invalid P%d'", tc.InvalidIndex))
-
-	return strings.Join(name, ", ")
+	return fmt.Sprintf(
+		"Invalid Missing Ancestor ReOrg, %s, EmptyTxs=%s, Invalid P%d",
+		tc.InvalidField,
+		emptyTxsStatus,
+		tc.InvalidIndex,
+	)
 }
 
 func (tc InvalidMissingAncestorReOrgTest) Execute(t *test.Env) {
@@ -207,21 +206,21 @@ func (s InvalidMissingAncestorReOrgSyncTest) WithMainFork(fork config.Fork) test
 }
 
 func (tc InvalidMissingAncestorReOrgSyncTest) GetName() string {
-	name := []string{
-		"Invalid Missing Ancestor ReOrg",
-		fmt.Sprintf("Invalid %s", tc.InvalidField),
-	}
+	emptyTxsStatus := "False"
 	if tc.EmptyTransactions {
-		name = append(name, "Empty Txs")
+		emptyTxsStatus = "True"
 	}
-	name = append(name,
-		fmt.Sprintf("Invalid P%d'", tc.InvalidIndex),
-		"Reveal using sync",
-	)
+	canonicalReOrgStatus := "False"
 	if tc.ReOrgFromCanonical {
-		name = append(name, "ReOrg from Canonical")
+		canonicalReOrgStatus = "True"
 	}
-	return strings.Join(name, ", ")
+	return fmt.Sprintf(
+		"Invalid Missing Ancestor Syncing ReOrg, %s, EmptyTxs=%s, CanonicalReOrg=%s, Invalid P%d",
+		tc.InvalidField,
+		emptyTxsStatus,
+		canonicalReOrgStatus,
+		tc.InvalidIndex,
+	)
 }
 
 func (tc InvalidMissingAncestorReOrgSyncTest) Execute(t *test.Env) {

--- a/simulators/ethereum/engine/suites/engine/invalid_payload.go
+++ b/simulators/ethereum/engine/suites/engine/invalid_payload.go
@@ -42,17 +42,25 @@ func (s InvalidPayloadTestCase) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (i InvalidPayloadTestCase) GetName() string {
-	name := fmt.Sprintf("Invalid %s NewPayload", i.InvalidField)
+	syncStatus := "False"
 	if i.Syncing {
-		name += " - Syncing"
+		syncStatus = "True"
 	}
+	emptyTxsStatus := "False"
 	if i.EmptyTransactions {
-		name += " - Empty Transactions"
+		emptyTxsStatus = "True"
 	}
+	dynFeeTxsStatus := "False"
 	if i.BaseSpec.TestTransactionType == helper.DynamicFeeTxOnly {
-		name += fmt.Sprintf(" - %s", i.BaseSpec.TestTransactionType)
+		dynFeeTxsStatus = "True"
 	}
-	return name
+	return fmt.Sprintf(
+		"Invalid NewPayload, %s, Syncing=%s, EmptyTxs=%s, DynFeeTxs=%s",
+		i.InvalidField,
+		syncStatus,
+		emptyTxsStatus,
+		dynFeeTxsStatus,
+	)
 }
 
 func (tc InvalidPayloadTestCase) Execute(t *test.Env) {
@@ -400,7 +408,7 @@ func (s InvalidTxChainIDTest) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (s InvalidTxChainIDTest) GetName() string {
-	name := fmt.Sprintf("Build Payload with Invalid ChainID Transaction (%s)", s.TestTransactionType)
+	name := fmt.Sprintf("Build Payload with Invalid ChainID Transaction, %s", s.TestTransactionType)
 	return name
 }
 

--- a/simulators/ethereum/engine/suites/engine/payload_attributes.go
+++ b/simulators/ethereum/engine/suites/engine/payload_attributes.go
@@ -25,9 +25,11 @@ func (s InvalidPayloadAttributesTest) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (tc InvalidPayloadAttributesTest) GetName() string {
-	name := fmt.Sprintf("Invalid PayloadAttributes: %s", tc.Description)
+	name := fmt.Sprintf("Invalid PayloadAttributes, %s,", tc.Description)
 	if tc.Syncing {
-		name += " (Syncing)"
+		name += " Syncing=True"
+	} else {
+		name += " Syncing=False"
 	}
 	return name
 }

--- a/simulators/ethereum/engine/suites/engine/payload_execution.go
+++ b/simulators/ethereum/engine/suites/engine/payload_execution.go
@@ -222,9 +222,11 @@ func (s MultiplePayloadsExtendingCanonicalChainTest) WithMainFork(fork config.Fo
 }
 
 func (s MultiplePayloadsExtendingCanonicalChainTest) GetName() string {
-	name := "Multiple New Payloads Extending Canonical Chain"
+	name := "Multiple New Payloads Extending Canonical Chain,"
 	if s.SetHeadToFirstPayloadReceived {
-		name += " (FcU to first payload received)"
+		name += " Set Head to First Payload Received"
+	} else {
+		name += " Wait for Canonical Payload"
 	}
 	return name
 }

--- a/simulators/ethereum/engine/suites/engine/payload_id.go
+++ b/simulators/ethereum/engine/suites/engine/payload_id.go
@@ -36,7 +36,7 @@ func (s UniquePayloadIDTest) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (tc UniquePayloadIDTest) GetName() string {
-	return fmt.Sprintf("Unique Payload ID - %s", tc.FieldModification)
+	return fmt.Sprintf("Unique Payload ID, %s", tc.FieldModification)
 }
 
 // Check that the payload id returned on a forkchoiceUpdated call is different

--- a/simulators/ethereum/engine/suites/engine/prev_randao.go
+++ b/simulators/ethereum/engine/suites/engine/prev_randao.go
@@ -25,7 +25,7 @@ func (s PrevRandaoTransactionTest) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (t PrevRandaoTransactionTest) GetName() string {
-	return fmt.Sprintf("PrevRandao Opcode Transactions Test (%s)", t.TestTransactionType)
+	return fmt.Sprintf("PrevRandao Opcode Transactions Test, %s", t.TestTransactionType)
 }
 
 func (tc PrevRandaoTransactionTest) Execute(t *test.Env) {

--- a/simulators/ethereum/engine/suites/engine/reorg.go
+++ b/simulators/ethereum/engine/suites/engine/reorg.go
@@ -130,17 +130,19 @@ func (s TransactionReOrgTest) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (s TransactionReOrgTest) GetName() string {
-	name := "Transaction Re-Org"
-	if s.ReorgOut {
-		name += ", Re-Org Out"
-	}
+	reOrgType := "Out Of Block"
 	if s.ReorgDifferentBlock {
-		name += ", Re-Org to Different Block"
+		reOrgType = "To Different Block"
 	}
+	payloadOnRevertStatus := "False"
 	if s.NewPayloadOnRevert {
-		name += ", New Payload on Revert Back"
+		payloadOnRevertStatus = "True"
 	}
-	return name
+	return fmt.Sprintf(
+		"Transaction ReOrg %s, NewPayloadOnRevert=%s",
+		reOrgType,
+		payloadOnRevertStatus,
+	)
 }
 
 // Test transaction status after a forkchoiceUpdated re-orgs to an alternative hash where a transaction is not present
@@ -323,7 +325,7 @@ func (s ReOrgBackToCanonicalTest) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (s ReOrgBackToCanonicalTest) GetName() string {
-	name := fmt.Sprintf("Re-Org Back into Canonical Chain (Depth: %d)", s.ReOrgDepth)
+	name := fmt.Sprintf("Re-Org Back into Canonical Chain, Depth=%d", s.ReOrgDepth)
 
 	if s.ExecuteSidePayloadOnReOrg {
 		name += ", Execute Side Payload on Re-Org"
@@ -544,7 +546,7 @@ func (s ReOrgPrevValidatedPayloadOnSideChainTest) WithMainFork(fork config.Fork)
 }
 
 func (s ReOrgPrevValidatedPayloadOnSideChainTest) GetName() string {
-	name := "Import and re-org to previously validated payload on a side chain"
+	name := "Re-org to Previously Validated Sidechain Payload"
 	return name
 }
 

--- a/simulators/ethereum/engine/suites/engine/suggested_fee_recipient.go
+++ b/simulators/ethereum/engine/suites/engine/suggested_fee_recipient.go
@@ -26,7 +26,7 @@ func (s SuggestedFeeRecipientTest) WithMainFork(fork config.Fork) test.Spec {
 }
 
 func (t SuggestedFeeRecipientTest) GetName() string {
-	return fmt.Sprintf("Suggested Fee Recipient Test (%s)", t.TestTransactionType)
+	return fmt.Sprintf("Suggested Fee Recipient Test, %s", t.TestTransactionType)
 }
 
 func (tc SuggestedFeeRecipientTest) Execute(t *test.Env) {


### PR DESCRIPTION
Updates existing engine simulator test names such that they are distinct.

This means they can all be ran seperately whilst debugging.