### PR TITLE
cmd/hivechain: add forkenv output

### DIFF
--- a/cmd/hivechain/README.md
+++ b/cmd/hivechain/README.md
@@ -54,6 +54,10 @@ Creates `accounts.json` containing accounts and corresponding private keys.
 This writes the `genesis.json` file containing a go-ethereum style genesis spec. Note
 this file includes the fork block numbers/timestamps.
 
+### forkenv
+
+This writes `forkenv.json` with fork configuration environment variables for hive tests.
+
 ### headblock
 
 This creates `headblock.json` with a dump of the head header.

--- a/cmd/hivechain/genesis.go
+++ b/cmd/hivechain/genesis.go
@@ -25,9 +25,8 @@ var (
 
 	numberBasedForkNames = []string{
 		"homestead",
-		"eip150",
-		"eip155",
-		"eip158",
+		"tangerinewhistle",
+		"spuriousdragon",
 		"byzantium",
 		"constantinople",
 		"petersburg",
@@ -64,11 +63,10 @@ func (cfg *generatorConfig) createChainConfig() *params.ChainConfig {
 		// number-based forks
 		case "homestead":
 			chaincfg.HomesteadBlock = new(big.Int).SetUint64(b)
-		case "eip150":
+		case "tangerinewhistle":
 			chaincfg.EIP150Block = new(big.Int).SetUint64(b)
-		case "eip155":
+		case "spuriousdragon":
 			chaincfg.EIP155Block = new(big.Int).SetUint64(b)
-		case "eip158":
 			chaincfg.EIP158Block = new(big.Int).SetUint64(b)
 		case "byzantium":
 			chaincfg.ByzantiumBlock = new(big.Int).SetUint64(b)
@@ -98,6 +96,8 @@ func (cfg *generatorConfig) createChainConfig() *params.ChainConfig {
 			chaincfg.CancunTime = &timestamp
 		case "prague":
 			chaincfg.PragueTime = &timestamp
+		default:
+			panic(fmt.Sprintf("unknown fork name %q", fork))
 		}
 	}
 

--- a/cmd/hivechain/output.go
+++ b/cmd/hivechain/output.go
@@ -17,6 +17,7 @@ import (
 
 var outputFunctions = map[string]func(*generator) error{
 	"genesis":    (*generator).writeGenesis,
+	"forkenv":    (*generator).writeForkEnv,
 	"chain":      (*generator).writeChain,
 	"powchain":   (*generator).writePoWChain,
 	"headstate":  (*generator).writeState,

--- a/cmd/hivechain/output_forkenv.go
+++ b/cmd/hivechain/output_forkenv.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// writeForkEnv writes chain fork configuration in the form that hive expects.
+func (g *generator) writeForkEnv() error {
+	cfg := g.genesis.Config
+	env := make(map[string]string)
+	env["HIVE_CHAIN_ID"] = fmt.Sprint(cfg.ChainID)
+
+	setNum := func(hive string, blocknum *big.Int) {
+		if blocknum != nil {
+			env[hive] = blocknum.Text(10)
+		}
+	}
+	setTime := func(hive string, timestamp *uint64) {
+		if timestamp != nil {
+			env[hive] = fmt.Sprintf("%d", *timestamp)
+		}
+	}
+	setNum("HIVE_FORK_HOMESTEAD", cfg.HomesteadBlock)
+	setNum("HIVE_FORK_TANGERINE", cfg.EIP150Block)
+	setNum("HIVE_FORK_SPURIOUS", cfg.EIP155Block)
+	setNum("HIVE_FORK_BYZANTIUM", cfg.ByzantiumBlock)
+	setNum("HIVE_FORK_CONSTANTINOPLE", cfg.ConstantinopleBlock)
+	setNum("HIVE_FORK_PETERSBURG", cfg.PetersburgBlock)
+	setNum("HIVE_FORK_ISTANBUL", cfg.IstanbulBlock)
+	setNum("HIVE_FORK_MUIR_GLACIER", cfg.MuirGlacierBlock)
+	setNum("HIVE_FORK_ARROW_GLACIER", cfg.ArrowGlacierBlock)
+	setNum("HIVE_FORK_GRAY_GLACIER", cfg.GrayGlacierBlock)
+	setNum("HIVE_FORK_BERLIN", cfg.BerlinBlock)
+	setNum("HIVE_FORK_LONDON", cfg.LondonBlock)
+	setNum("HIVE_MERGE_BLOCK_ID", cfg.MergeNetsplitBlock)
+	setNum("HIVE_TERMINAL_TOTAL_DIFFICULTY", cfg.TerminalTotalDifficulty)
+	setTime("HIVE_SHANGHAI_TIMESTAMP", cfg.ShanghaiTime)
+	setTime("HIVE_CANCUN_TIMESTAMP", cfg.CancunTime)
+	setTime("HIVE_PRAGUE_TIMESTAMP", cfg.PragueTime)
+
+	return g.writeJSON("forkenv.json", env)
+}


### PR DESCRIPTION
Adds a new output mode "forkenv" that has the hive fork configuration variables.