### PR TITLE
hivesim: only log test and suite skips at high log levels

### DIFF
--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -20,8 +21,9 @@ import (
 
 // Simulation wraps the simulation HTTP API provided by hive.
 type Simulation struct {
-	url string
-	m   testMatcher
+	url      string
+	m        testMatcher
+	ll int
 }
 
 // New looks up the hive host URI using the HIVE_SIMULATOR environment variable
@@ -41,6 +43,9 @@ func New() *Simulation {
 			fmt.Fprintln(os.Stderr, "Warning: ignoring invalid test pattern regexp: "+err.Error())
 		}
 		sim.m = m
+	}
+	if ll := os.Getenv("HIVE_LOGLEVEL"); ll != "" {
+		sim.ll, _ = strconv.Atoi(ll)
 	}
 	return sim
 }

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -50,7 +50,9 @@ func MustRun(host *Simulation, suites ...Suite) {
 // RunSuite runs all tests in a suite.
 func RunSuite(host *Simulation, suite Suite) error {
 	if !host.m.match(suite.Name, "") {
-		fmt.Fprintf(os.Stderr, "skipping suite %q because it doesn't match test pattern %s\n", suite.Name, host.m.pattern)
+		if host.ll > 3 { // hive log level > 3
+			fmt.Fprintf(os.Stderr, "skipping suite %q because it doesn't match test pattern %s\n", suite.Name, host.m.pattern)
+		}
 		return nil
 	}
 
@@ -82,13 +84,12 @@ func MustRunSuite(host *Simulation, suite Suite) {
 // Using this test type doesn't launch any clients by default. To interact with clients,
 // you can launch them using the t.Client method:
 //
-//    c := t.Client()
-//    c.RPC().Call(...)
+//	c := t.Client()
+//	c.RPC().Call(...)
 //
 // or run a subtest using t.RunClientTest():
 //
-//    t.RunClientTest(hivesim.ClientTestSpec{...})
-//
+//	t.RunClientTest(hivesim.ClientTestSpec{...})
 type TestSpec struct {
 	// These fields are displayed in the UI. Be sure to add
 	// a meaningful description here.
@@ -306,7 +307,9 @@ type testSpec struct {
 
 func runTest(host *Simulation, test testSpec, runit func(t *T)) error {
 	if !test.alwaysRun && !host.m.match(test.suite.Name, test.name) {
-		fmt.Fprintf(os.Stderr, "skipping test %q because it doesn't match test pattern %s\n", test.name, host.m.pattern)
+		if host.ll > 3 { // hive log level > 3
+			fmt.Fprintf(os.Stderr, "skipping test %q because it doesn't match test pattern %s\n", test.name, host.m.pattern)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Description

When debugging a single test,
```bash
... --sim.limit engine-cancun/"ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root" --docker.output
```
more often than not the output is flooded with all the tests that are skipped, for example:
```
[4b993452] skipping test "Invalid VersionedHashes Version NewPayload (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Invalid VersionedHashes Version NewPayload - Syncing (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Invalid Incomplete VersionedHashes NewPayload (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Invalid Incomplete VersionedHashes NewPayload - Syncing (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Invalid Extra VersionedHashes NewPayload (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Invalid Extra VersionedHashes NewPayload - Syncing (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Build Payload with Invalid ChainID Transaction (BlobTransactions) (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Payload Build after New Invalid Payload: Invalid ParentBeaconBlockRoot (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "Suggested Fee Recipient Test (BlobTransactions) (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
[4b993452] skipping test "PrevRandao Opcode Transactions Test (BlobTransactions) (Cancun) (go-ethereum_cancun-git)" because it doesn't match test pattern engine-cancun/ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root
...
```

## Proposed Change
We only log `skipping test` and `skipping suite` statements when the `HIVE_LOGLEVEL > 3` to make intial debugging slightly easier? @marioevz @fjl

## Testing Changes
Add the following to then end of any simulator `go.mod` file:
```
replace github.com/ethereum/hive => github.com/spencer-tb/hive v0.0.0-20231020180640-5d8faae93054
```
