### PR TITLE
hivechain: track preimages during generation

### DIFF
--- a/cmd/hivechain/generate.go
+++ b/cmd/hivechain/generate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/triedb/hashdb"
 	"golang.org/x/exp/slices"
 )
 
@@ -98,7 +99,7 @@ func (cfg *generatorConfig) createBlockModifiers() (list []*modifierInstance) {
 // run produces a chain.
 func (g *generator) run() error {
 	db := rawdb.NewMemoryDatabase()
-	triedb := trie.NewDatabase(db, trie.HashDefaults)
+	triedb := trie.NewDatabase(db, &trie.Config{Preimages: true, HashDB: hashdb.Defaults})
 	genesis := g.genesis.MustCommit(db, triedb)
 	config := g.genesis.Config
 


### PR DESCRIPTION
Currently preimages is turned off during chain generation. This causes the state dump to fail to output the genesis accounts:

```
WARN [10-20|17:37:46.743] Dump incomplete due to missing preimages missing=19
```