### PR TITLE
simulators/ethereum/engine,pyspec: Use `golang:1.20-alpine`

### DIFF
--- a/simulators/ethereum/engine/Dockerfile
+++ b/simulators/ethereum/engine/Dockerfile
@@ -1,5 +1,5 @@
 # This simulation runs Engine API tests.
-FROM golang:1-alpine as builder
+FROM golang:1.20-alpine as builder
 RUN apk add --update gcc musl-dev linux-headers
 
 # Build the simulator executable.

--- a/simulators/ethereum/pyspec/Dockerfile
+++ b/simulators/ethereum/pyspec/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------#
 
 # 1) Create pyspec builder container.
-FROM golang:1-alpine as builder
+FROM golang:1.20-alpine as builder
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Build the pyspec simulator executable.


### PR DESCRIPTION
## Changes Included:
- Use `golang:1.20-alpine` instead of `golang:1-alpine` as base image to build the simulators, since `golang:1-alpine` now points to `golang:1.21-alpine` and compilation fails in this newer version.