### PR TITLE
clients: only output full genesis file at high log levels

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -63,9 +63,19 @@ esac
 FLAGS="--logging=$LOG --data-storage-format=BONSAI"
 
 # Configure the chain.
-jq -f /mapper.jq /genesis.json > /besugenesis.json
-echo -n "Genesis: "; cat /besugenesis.json
-FLAGS="$FLAGS --genesis-file=/besugenesis.json "
+mv /genesis.json /genesis-input.json
+jq -f /mapper.jq /genesis-input.json > /genesis.json
+FLAGS="$FLAGS --genesis-file=/genesis.json "
+
+# Dump genesis. 
+echo "Supplied genesis state:"
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
+else
+    # Log full genesis only at higher log levels.
+    cat /genesis.json
+fi
+
 
 # Enable experimental 'berlin' hard-fork features if configured.
 #if [ -n "$HIVE_FORK_BERLIN" ]; then

--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -68,11 +68,11 @@ jq -f /mapper.jq /genesis-input.json > /genesis.json
 FLAGS="$FLAGS --genesis-file=/genesis.json "
 
 # Dump genesis. 
-echo "Supplied genesis state:"
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
     jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
 else
-    # Log full genesis only at higher log levels.
+    echo "Supplied genesis state:"
     cat /genesis.json
 fi
 

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -67,9 +67,14 @@ fi
 mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
-# Dump genesis
+# Dump genesis. 
 echo "Supplied genesis state:"
-cat /genesis.json
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
+else
+    # Log full genesis only at higher log levels.
+    cat /genesis.json
+fi
 
 echo "Command flags till now:"
 echo $FLAGS

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -68,11 +68,11 @@ mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
 # Dump genesis. 
-echo "Supplied genesis state:"
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
     jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
 else
-    # Log full genesis only at higher log levels.
+    echo "Supplied genesis state:"
     cat /genesis.json
 fi
 

--- a/clients/ethereumjs/ethereumjs.sh
+++ b/clients/ethereumjs/ethereumjs.sh
@@ -56,11 +56,11 @@ mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
 # Dump genesis. 
-echo "Supplied genesis state:"
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
     jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
 else
-    # Log full genesis only at higher log levels.
+    echo "Supplied genesis state:"
     cat /genesis.json
 fi
 

--- a/clients/ethereumjs/ethereumjs.sh
+++ b/clients/ethereumjs/ethereumjs.sh
@@ -51,14 +51,18 @@ set -e
 ethereumjs="node /ethereumjs-monorepo/packages/client/dist/bin/cli.js"
 FLAGS="--gethGenesis ./genesis.json --rpc --rpcEngine --saveReceipts --rpcAddr 0.0.0.0 --rpcEngineAddr 0.0.0.0 --rpcEnginePort 8551 --ws false --logLevel debug --rpcDebug --isSingleNode"
 
-
 # Configure the chain.
 mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
-# Dump genesis
+# Dump genesis. 
 echo "Supplied genesis state:"
-cat /genesis.json
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
+else
+    # Log full genesis only at higher log levels.
+    cat /genesis.json
+fi
 
 # Import clique signing key.
 if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
@@ -74,7 +78,6 @@ fi
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     FLAGS="$FLAGS --jwt-secret ./jwtsecret"
 fi
-
 
 # Load the test chain if present
 echo "Loading initial blockchain..."

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -93,9 +93,14 @@ fi
 mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
-# Dump genesis
+# Dump genesis. 
 echo "Supplied genesis state:"
-cat /genesis.json
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
+else
+    # Log full genesis only at higher log levels.
+    cat /genesis.json
+fi
 
 # Initialize the local testchain with the genesis state
 echo "Initializing database with genesis state..."

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -94,11 +94,11 @@ mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
 # Dump genesis. 
-echo "Supplied genesis state:"
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
     jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
 else
-    # Log full genesis only at higher log levels.
+    echo "Supplied genesis state:"
     cat /genesis.json
 fi
 

--- a/clients/nethermind/nethermind.sh
+++ b/clients/nethermind/nethermind.sh
@@ -57,9 +57,16 @@ fi
 
 # Generate the genesis and chainspec file.
 mkdir -p /chainspec
-echo "Supplied genesis state:" 
 jq -f /mapper.jq /genesis.json > /chainspec/test.json
-jq . /chainspec/test.json
+
+# Dump genesis. 
+echo "Supplied genesis state:"
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    jq 'del(.accounts[] | select(.balance == "0x123450000000000000000" or has("builtin")))' /chainspec/test.json
+else
+    # Log full genesis only at higher log levels.
+    cat /chainspec/test.json
+fi
 
 # Generate the config file.
 mkdir /configs

--- a/clients/nethermind/nethermind.sh
+++ b/clients/nethermind/nethermind.sh
@@ -60,11 +60,11 @@ mkdir -p /chainspec
 jq -f /mapper.jq /genesis.json > /chainspec/test.json
 
 # Dump genesis. 
-echo "Supplied genesis state:"
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
     jq 'del(.accounts[] | select(.balance == "0x123450000000000000000" or has("builtin")))' /chainspec/test.json
 else
-    # Log full genesis only at higher log levels.
+    echo "Supplied genesis state:"
     cat /chainspec/test.json
 fi
 

--- a/clients/nimbus-el/nimbus.sh
+++ b/clients/nimbus-el/nimbus.sh
@@ -86,12 +86,12 @@ jq -f /mapper.jq /genesis.json > /genesis-start.json
 FLAGS="$FLAGS --custom-network:/genesis-start.json"
 
 # Dump genesis.
-echo "Supplied genesis state:"
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
-    jq 'del(.genesis.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis-start.json
+  echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
+  jq 'del(.genesis.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis-start.json
 else
-    # Log full genesis only at higher log levels.
-    cat /genesis-start.json
+  echo "Supplied genesis state:"
+  cat /genesis-start.json
 fi
 
 # Don't immediately abort, some imports are meant to fail

--- a/clients/nimbus-el/nimbus.sh
+++ b/clients/nimbus-el/nimbus.sh
@@ -81,10 +81,18 @@ if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
   fi
 fi
 
-# Configure the genesis chain and use it as start block and dump it to stdout
-echo "Supplied genesis state:"
-jq -f /mapper.jq /genesis.json | tee /genesis-start.json
+# Configure the chain.
+jq -f /mapper.jq /genesis.json > /genesis-start.json
 FLAGS="$FLAGS --custom-network:/genesis-start.json"
+
+# Dump genesis.
+echo "Supplied genesis state:"
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    jq 'del(.genesis.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis-start.json
+else
+    # Log full genesis only at higher log levels.
+    cat /genesis-start.json
+fi
 
 # Don't immediately abort, some imports are meant to fail
 set +e

--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -67,11 +67,11 @@ mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
 # Dump genesis. 
-echo "Supplied genesis state:"
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
     jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
 else
-    # Log full genesis only at higher log levels.
+    echo "Supplied genesis state:"
     cat /genesis.json
 fi
 

--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -66,9 +66,14 @@ FLAGS="$FLAGS --datadir /reth-hive-datadir"
 mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
 
-# Dump genesis
+# Dump genesis. 
 echo "Supplied genesis state:"
-cat /genesis.json
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
+else
+    # Log full genesis only at higher log levels.
+    cat /genesis.json
+fi
 
 echo "Command flags till now:"
 echo $FLAGS


### PR DESCRIPTION
## Description

Similar to https://github.com/ethereum/hive/pull/923, when debugging more than one test, the genesis config for each test can flood the simulation output making it difficult to debug.

## Proposed Change
We only log the entire `genesis.json` config when the `HIVE_LOGLEVEL > 3`.

