### PR TITLE
simulators/ethereum/engine: Fix Cancun fcUV2 tests bugs

### DIFF
--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -594,7 +594,7 @@ var Tests = []test.Spec{
 			Verify that client returns INVALID_PARAMS_ERROR.
 			`,
 			MainFork:   config.Cancun,
-			ForkHeight: 1,
+			ForkHeight: 2,
 		},
 
 		TestSequence: TestSequence{
@@ -633,6 +633,9 @@ var Tests = []test.Spec{
 			NewPayloads{
 				FcUOnPayloadRequest: &helper.DowngradeForkchoiceUpdatedVersion{
 					ForkchoiceUpdatedCustomizer: &helper.BaseForkchoiceUpdatedCustomizer{
+						PayloadAttributesCustomizer: &helper.BasePayloadAttributesCustomizer{
+							BeaconRoot: &(common.Hash{}),
+						},
 						ExpectedError: globals.INVALID_PARAMS_ERROR,
 					},
 				},


### PR DESCRIPTION
1. "ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root"
    - test desc: "Payload Attributes uses Shanghai timestamp"
    - bug: `ForkHeight: 1`, generated timestamp is Cancun.
    - fix: `ForkHeight: 2`, generated timestamp is Shanghai.

2. "ForkchoiceUpdatedV2 To Request Cancun Payload, Zero Beacon Root"
   - test desc: "Payload Attributes' Beacon Root zero"
   - bug: Payload Attributes' Beacon Root is not set/nil.
   - fix: set Payload Attributes's Beacon Root to zero.