### PR TITLE
simulators/ethereum/engine: Minor fix to re-org tests

### DIFF
--- a/simulators/ethereum/engine/suites/engine/reorg.go
+++ b/simulators/ethereum/engine/suites/engine/reorg.go
@@ -529,12 +529,16 @@ func (spec ReOrgBackToCanonicalTest) Execute(t *test.Env) {
 				// Send a fcU with the HeadBlockHash pointing back to the previous block
 				forkchoiceUpdatedBack := api.ForkchoiceStateV1{
 					HeadBlockHash:      previousHash,
-					SafeBlockHash:      previousHash,
-					FinalizedBlockHash: previousHash,
+					SafeBlockHash:      t.CLMock.LatestForkchoice.SafeBlockHash,
+					FinalizedBlockHash: t.CLMock.LatestForkchoice.FinalizedBlockHash,
 				}
 
 				// It is only expected that the client does not produce an error and the CL Mocker is able to progress after the re-org
 				r := t.TestEngine.TestEngineForkchoiceUpdated(&forkchoiceUpdatedBack, nil, previousTimestamp)
+				r.ExpectNoError()
+
+				// Re-send the ForkchoiceUpdated that the CLMock had sent
+				r = t.TestEngine.TestEngineForkchoiceUpdated(&t.CLMock.LatestForkchoice, nil, t.CLMock.LatestExecutedPayload.Timestamp)
 				r.ExpectNoError()
 			},
 		})


### PR DESCRIPTION
Sends the last known block to the CL Mock to the execution client in order for it to be on the expected head.

Previously, the test sent an FcU which overrode what the CL Mock last instructed, which resulted in some clients ending up on the incorrect head (Some clients ignored the directive because an FcU to an ancestor of the current head is optional according to the spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification-1).

cc @jochem-brouwer 