### PR TITLE
simulators/ethereum/engine: Fix bugs for ForkID and Missing Ancenstor Tests

### DIFF
--- a/simulators/ethereum/engine/suites/engine/fork_id.go
+++ b/simulators/ethereum/engine/suites/engine/fork_id.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/hive/simulators/ethereum/engine/clmock"
 	"github.com/ethereum/hive/simulators/ethereum/engine/config"
 	"github.com/ethereum/hive/simulators/ethereum/engine/devp2p"
@@ -32,6 +33,19 @@ func (ft ForkIDSpec) GetName() string {
 		name = append(name, fmt.Sprintf("BlocksBeforePeering=%d", ft.ProduceBlocksBeforePeering))
 	}
 	return strings.Join(name, ", ")
+}
+
+func (s ForkIDSpec) GetForkConfig() *config.ForkConfig {
+	forkConfig := s.BaseSpec.GetForkConfig()
+	if forkConfig == nil {
+		return nil
+	}
+	// Merge fork happen at block 0
+	mainFork := s.GetMainFork()
+	if mainFork == config.Paris {
+		forkConfig.ParisNumber = common.Big0
+	}
+	return forkConfig
 }
 
 func (ft ForkIDSpec) Execute(t *test.Env) {

--- a/simulators/ethereum/engine/suites/engine/invalid_ancestor.go
+++ b/simulators/ethereum/engine/suites/engine/invalid_ancestor.go
@@ -359,6 +359,12 @@ func (tc InvalidMissingAncestorReOrgSyncTest) Execute(t *test.Env) {
 			}
 		},
 	})
+
+	if !tc.ReOrgFromCanonical {
+		// Add back the original client before side chain production
+		t.CLMock.AddEngineClient(t.Engine)
+	}
+
 	t.Log("INFO: Starting side chain production")
 	t.CLMock.ProduceSingleBlock(clmock.BlockProcessCallbacks{
 		// Note: We perform the test in the middle of payload creation by the CL Mock, in order to be able to


### PR DESCRIPTION
## Description

- All Fork ID tests for Paris were failing for each client, due to the addition of this PR: https://github.com/ethereum/hive/pull/901, which added a `mergeNetsplitBlock` to each client mapper.
  - Fixed by overriding this value to 0 within the ForkID tests.
  
- Missing Ancenstor Syncing tests with an invalid state root were failing for the cases that didn't reorg on the canonical chain:
  - `Invalid Missing Ancestor Syncing ReOrg, StateRoot, EmptyTxs=False, CanonicalReOrg=False`
  - `Invalid Missing Ancestor Syncing ReOrg, StateRoot, EmptyTxs=True, CanonicalReOrg=False`
  - Fixed by adding back the engine client before the side chain production.
  
Found by @flcl42 & @asdacap.
