### PR TITLE
cmd/hive: Add `--sim.randomseed`

### DIFF
--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -122,6 +122,10 @@ This sets the default value of `HIVE_LOGLEVEL` in client containers.
 interpreted by simulators. It sets the `HIVE_PARALLELISM` environment variable. Defaults
 to 1.
 
+`--sim.randomseed <number>`: Sets a fixed number as the randomness seed to be used by all
+simulators. It sets the `HIVE_RANDOM_SEED` environment variable. Defaults to zero, which
+translates being unset and the simulators decide the source of randomness.
+
 ## Viewing simulation results (hiveview)
 
 The results of hive simulation runs are stored in JSON files containing test results, and

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -95,6 +95,7 @@ This is the list of all environment variables that hive sets when launching simu
 | `HIVE_SIMULATOR`    | URL of the API server                        |                     |
 | `HIVE_TEST_PATTERN` | Regular expression, selects suites/tests     | `--sim.limit`       |
 | `HIVE_PARALLELISM`  | Integer, sets test concurrency               | `--sim.parallelism` |
+| `HIVE_RANDOM_SEED`  | Integer, sets simulator random seed number   | `--sim.randomseed`  |
 | `HIVE_LOGLEVEL`     | Decimal 0-5, configures simulator log levels | `--sim.loglevel`    |
 
 ## Writing Simulators in Go

--- a/hive.go
+++ b/hive.go
@@ -27,6 +27,7 @@ func main() {
 		simPattern            = flag.String("sim", "", "Regular `expression` selecting the simulators to run.")
 		simTestPattern        = flag.String("sim.limit", "", "Regular `expression` selecting tests/suites (interpreted by simulators).")
 		simParallelism        = flag.Int("sim.parallelism", 1, "Max `number` of parallel clients/containers (interpreted by simulators).")
+		simRandomSeed         = flag.Int("sim.randomseed", 0, "Randomness seed number (interpreted by simulators).")
 		simTestLimit          = flag.Int("sim.testlimit", 0, "[DEPRECATED] Max `number` of tests to execute per client (interpreted by simulators).")
 		simTimeLimit          = flag.Duration("sim.timelimit", 0, "Simulation `timeout`. Hive aborts the simulator if it exceeds this time.")
 		simLogLevel           = flag.Int("sim.loglevel", 3, "Selects log `level` of client instances. Supports values 0-5.")
@@ -110,6 +111,7 @@ func main() {
 		SimLogLevel:        *simLogLevel,
 		SimTestPattern:     *simTestPattern,
 		SimParallelism:     *simParallelism,
+		SimRandomSeed:      *simRandomSeed,
 		SimDurationLimit:   *simTimeLimit,
 		ClientStartTimeout: *clientTimeout,
 	}

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -205,6 +205,7 @@ func (r *Runner) run(ctx context.Context, sim string, env SimEnv) (SimResult, er
 			"HIVE_PARALLELISM":  strconv.Itoa(env.SimParallelism),
 			"HIVE_LOGLEVEL":     strconv.Itoa(env.SimLogLevel),
 			"HIVE_TEST_PATTERN": env.SimTestPattern,
+			"HIVE_RANDOM_SEED":  strconv.Itoa(env.SimRandomSeed),
 		},
 	}
 	containerID, err := r.container.CreateContainer(ctx, r.simImages[sim], opts)

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -34,6 +34,7 @@ type SimEnv struct {
 	// Parameters of simulation.
 	SimLogLevel    int
 	SimParallelism int
+	SimRandomSeed  int
 	SimTestPattern string
 
 	// This is the time limit for the simulation run.


### PR DESCRIPTION
Adds flag `--sim.randomseed <number>` to hive command to pass environment variable `HIVE_RANDOM_SEED` to simulators in order for them to parse and generate a deterministic randomness source.