### PR TITLE
[DRAFT] Add documentation generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/evanw/esbuild v0.18.11
 	github.com/fsouza/go-dockerclient v1.9.8
 	github.com/gorilla/mux v1.8.0
+	github.com/lithammer/dedent v1.1.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/net v0.17.0
 	gopkg.in/inconshreveable/log15.v2 v2.0.0-20200109203555-b30bc20e4fd1

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/labstack/echo/v4 v4.5.0/go.mod h1:czIriw4a0C1dFun+ObrXp7ok03xON0N1awStJ6ArI7Y=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
+github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
+github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/hive.go
+++ b/hive.go
@@ -17,6 +17,10 @@ import (
 )
 
 func main() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fatal(err)
+	}
 	var (
 		testResultsRoot       = flag.String("results-root", "workspace/logs", "Target `directory` for results files and logs.")
 		loglevelFlag          = flag.Int("loglevel", 3, "Log `level` for system events. Supports values 0-5.")
@@ -34,6 +38,7 @@ func main() {
 		simDevMode            = flag.Bool("dev", false, "Only starts the simulator API endpoint (listening at 127.0.0.1:3000 by default) without starting any simulators.")
 		simDevModeAPIEndpoint = flag.String("dev.addr", "127.0.0.1:3000", "Endpoint that the simulator API listens on")
 		simDocsMode           = flag.Bool("docs", false, "Starts the simulator in docs mode, where it will not execute any tests, but will instead generate documentation for the tests.")
+		simDocsOutput         = flag.String("docs.output", cwd, "Base output directory for generated documentation. Defaults to cwd.")
 		useCredHelper         = flag.Bool("docker.cred-helper", false, "configure docker authentication using locally-configured credential helper")
 
 		clientsFile = flag.String("client-file", "", `YAML `+"`file`"+` containing client configurations.`)
@@ -108,14 +113,15 @@ func main() {
 
 	// Run.
 	env := libhive.SimEnv{
-		LogDir:             *testResultsRoot,
-		SimLogLevel:        *simLogLevel,
-		SimTestPattern:     *simTestPattern,
-		SimParallelism:     *simParallelism,
-		SimRandomSeed:      *simRandomSeed,
-		SimDurationLimit:   *simTimeLimit,
-		SimDocsMode:        *simDocsMode,
-		ClientStartTimeout: *clientTimeout,
+		LogDir:               *testResultsRoot,
+		SimLogLevel:          *simLogLevel,
+		SimTestPattern:       *simTestPattern,
+		SimParallelism:       *simParallelism,
+		SimRandomSeed:        *simRandomSeed,
+		SimDurationLimit:     *simTimeLimit,
+		SimDocsMode:          *simDocsMode,
+		SimDocsOutputBaseDir: *simDocsOutput,
+		ClientStartTimeout:   *clientTimeout,
 	}
 	runner := libhive.NewRunner(inv, builder, cb)
 

--- a/hive.go
+++ b/hive.go
@@ -33,6 +33,7 @@ func main() {
 		simLogLevel           = flag.Int("sim.loglevel", 3, "Selects log `level` of client instances. Supports values 0-5.")
 		simDevMode            = flag.Bool("dev", false, "Only starts the simulator API endpoint (listening at 127.0.0.1:3000 by default) without starting any simulators.")
 		simDevModeAPIEndpoint = flag.String("dev.addr", "127.0.0.1:3000", "Endpoint that the simulator API listens on")
+		simDocsMode           = flag.Bool("docs", false, "Starts the simulator in docs mode, where it will not execute any tests, but will instead generate documentation for the tests.")
 		useCredHelper         = flag.Bool("docker.cred-helper", false, "configure docker authentication using locally-configured credential helper")
 
 		clientsFile = flag.String("client-file", "", `YAML `+"`file`"+` containing client configurations.`)
@@ -113,6 +114,7 @@ func main() {
 		SimParallelism:     *simParallelism,
 		SimRandomSeed:      *simRandomSeed,
 		SimDurationLimit:   *simTimeLimit,
+		SimDocsMode:        *simDocsMode,
 		ClientStartTimeout: *clientTimeout,
 	}
 	runner := libhive.NewRunner(inv, builder, cb)

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -21,9 +21,10 @@ import (
 
 // Simulation wraps the simulation HTTP API provided by hive.
 type Simulation struct {
-	url      string
-	m        testMatcher
-	ll int
+	url  string
+	m    testMatcher
+	docs bool
+	ll   int
 }
 
 // New looks up the hive host URI using the HIVE_SIMULATOR environment variable
@@ -47,6 +48,8 @@ func New() *Simulation {
 	if ll := os.Getenv("HIVE_LOGLEVEL"); ll != "" {
 		sim.ll, _ = strconv.Atoi(ll)
 	}
+	cc := os.Getenv("HIVE_DOCS_MODE")
+	sim.docs = (cc == "true")
 	return sim
 }
 

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -88,10 +88,10 @@ func (sim *Simulation) EndTest(testSuite SuiteID, test TestID, testResult TestRe
 }
 
 // StartSuite signals the start of a test suite.
-func (sim *Simulation) StartSuite(name, description, simlog string) (SuiteID, error) {
+func (sim *Simulation) StartSuite(suite *simapi.TestRequest, simlog string) (SuiteID, error) {
 	var (
 		url  = fmt.Sprintf("%s/testsuite", sim.url)
-		req  = &simapi.TestRequest{Name: name, Description: description}
+		req  = suite
 		resp SuiteID
 	)
 	err := post(url, req, &resp)
@@ -105,10 +105,10 @@ func (sim *Simulation) EndSuite(testSuite SuiteID) error {
 }
 
 // StartTest starts a new test case, returning the testcase id as a context identifier.
-func (sim *Simulation) StartTest(testSuite SuiteID, name string, description string) (TestID, error) {
+func (sim *Simulation) StartTest(testSuite SuiteID, test *simapi.TestRequest) (TestID, error) {
 	var (
 		url  = fmt.Sprintf("%s/testsuite/%d/test", sim.url, testSuite)
-		req  = &simapi.TestRequest{Name: name, Description: description}
+		req  = test
 		resp TestID
 	)
 	err := post(url, req, &resp)

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/hive/internal/fakes"
 	"github.com/ethereum/hive/internal/libhive"
+	"github.com/ethereum/hive/internal/simapi"
 )
 
 // This test checks that the API returns configured client names correctly.
@@ -73,11 +74,11 @@ func TestEnodeReplaceIP(t *testing.T) {
 
 	// Start the client.
 	sim := NewAt(srv.URL)
-	suiteID, err := sim.StartSuite("suite", "", "")
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "suite"}, "")
 	if err != nil {
 		t.Fatal("can't start suite:", err)
 	}
-	testID, err := sim.StartTest(suiteID, "test", "")
+	testID, err := sim.StartTest(suiteID, &simapi.TestRequest{Name: "test"})
 	if err != nil {
 		t.Fatal("can't start test:", err)
 	}
@@ -125,11 +126,11 @@ func TestStartClientStartOptions(t *testing.T) {
 
 	// Start the suite and test.
 	sim := NewAt(srv.URL)
-	suiteID, err := sim.StartSuite("suite", "", "")
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "suite"}, "")
 	if err != nil {
 		t.Fatal("can't start suite:", err)
 	}
-	testID, err := sim.StartTest(suiteID, "test", "")
+	testID, err := sim.StartTest(suiteID, &simapi.TestRequest{Name: "test"})
 	if err != nil {
 		t.Fatal("can't start test:", err)
 	}
@@ -262,11 +263,11 @@ func TestRunProgram(t *testing.T) {
 	defer tm.Terminate()
 
 	sim := NewAt(srv.URL)
-	suiteID, err := sim.StartSuite("suite", "", "")
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "suite"}, "")
 	if err != nil {
 		t.Fatal("can't start suite:", err)
 	}
-	testID, err := sim.StartTest(suiteID, "test", "")
+	testID, err := sim.StartTest(suiteID, &simapi.TestRequest{Name: "test"})
 	if err != nil {
 		t.Fatal("can't start test:", err)
 	}
@@ -309,11 +310,11 @@ func TestStartClientErrors(t *testing.T) {
 	defer tm.Terminate()
 
 	sim := NewAt(srv.URL)
-	suiteID, err := sim.StartSuite("suite", "", "")
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "suite"}, "")
 	if err != nil {
 		t.Fatal("can't start suite:", err)
 	}
-	testID, err := sim.StartTest(suiteID, "test", "")
+	testID, err := sim.StartTest(suiteID, &simapi.TestRequest{Name: "test"})
 	if err != nil {
 		t.Fatal("can't start test:", err)
 	}
@@ -365,11 +366,11 @@ func TestStartClientInitialNetworks(t *testing.T) {
 	defer tm.Terminate()
 
 	sim := NewAt(srv.URL)
-	suiteID, err := sim.StartSuite("suite", "", "")
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "suite"}, "")
 	if err != nil {
 		t.Fatal("can't start suite:", err)
 	}
-	testID, err := sim.StartTest(suiteID, "test", "")
+	testID, err := sim.StartTest(suiteID, &simapi.TestRequest{Name: "test"})
 	if err != nil {
 		t.Fatal("can't start test:", err)
 	}

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -9,13 +9,25 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/hive/internal/simapi"
 )
 
 // Suite is the description of a test suite.
 type Suite struct {
 	Name        string
+	DisplayName string
+	Category    string
 	Description string
 	Tests       []AnyTest
+}
+
+func (s *Suite) request() *simapi.TestRequest {
+	return &simapi.TestRequest{
+		Name:        s.Name,
+		DisplayName: s.DisplayName,
+		Category:    s.Category,
+		Description: s.Description,
+	}
 }
 
 // Add adds a test to the suite.
@@ -56,7 +68,7 @@ func RunSuite(host *Simulation, suite Suite) error {
 		return nil
 	}
 
-	suiteID, err := host.StartSuite(suite.Name, suite.Description, "")
+	suiteID, err := host.StartSuite(suite.request(), "")
 	if err != nil {
 		return err
 	}
@@ -93,8 +105,10 @@ func MustRunSuite(host *Simulation, suite Suite) {
 type TestSpec struct {
 	// These fields are displayed in the UI. Be sure to add
 	// a meaningful description here.
-	Name        string
-	Description string
+	Name        string // Name is the unique identifier for the test [Mandatory]
+	DisplayName string // Display name for the test (Name will be used if unset) [Optional]
+	Description string // Description of the test (if empty, test won't appear in documentation) [Optional]
+	Category    string // Category of the test [Optional]
 
 	// If AlwaysRun is true, the test will run even if Name does not match the test
 	// pattern. This option is useful for tests that launch a client instance and
@@ -115,8 +129,10 @@ type TestSpec struct {
 type ClientTestSpec struct {
 	// These fields are displayed in the UI. Be sure to add
 	// a meaningful description here.
-	Name        string
-	Description string
+	Name        string // Name is the unique identifier for the test [Mandatory]
+	DisplayName string // Display name for the test (Name will be used if unset) [Optional]
+	Description string // Description of the test (if empty, test won't appear in documentation) [Optional]
+	Category    string // Category of the test [Optional]
 
 	// If AlwaysRun is true, the test will run even if Name does not match the test
 	// pattern. This option is useful for tests that launch a client instance and
@@ -208,11 +224,13 @@ func (t *T) StartClient(clientType string, option ...StartOption) *Client {
 // It waits for the subtest to complete.
 func (t *T) RunClient(clientType string, spec ClientTestSpec) {
 	test := testSpec{
-		suiteID:   t.SuiteID,
-		suite:     t.suite,
-		name:      clientTestName(spec.Name, clientType),
-		desc:      spec.Description,
-		alwaysRun: spec.AlwaysRun,
+		suiteID:     t.SuiteID,
+		suite:       t.suite,
+		name:        clientTestName(spec.Name, clientType),
+		displayName: spec.DisplayName,
+		category:    spec.Category,
+		desc:        spec.Description,
+		alwaysRun:   spec.AlwaysRun,
 	}
 	runTest(t.Sim, test, func(t *T) {
 		client := t.StartClient(clientType, spec.Parameters, WithStaticFiles(spec.Files))
@@ -298,11 +316,22 @@ func (t *T) FailNow() {
 }
 
 type testSpec struct {
-	suiteID   SuiteID
-	suite     *Suite
-	name      string
-	desc      string
-	alwaysRun bool
+	suiteID     SuiteID
+	suite       *Suite
+	name        string
+	displayName string
+	category    string
+	desc        string
+	alwaysRun   bool
+}
+
+func (spec testSpec) request() *simapi.TestRequest {
+	return &simapi.TestRequest{
+		Name:        spec.name,
+		DisplayName: spec.displayName,
+		Category:    spec.category,
+		Description: spec.desc,
+	}
 }
 
 func runTest(host *Simulation, test testSpec, runit func(t *T)) error {
@@ -319,7 +348,7 @@ func runTest(host *Simulation, test testSpec, runit func(t *T)) error {
 		SuiteID: test.suiteID,
 		suite:   test.suite,
 	}
-	testID, err := host.StartTest(test.suiteID, test.name, test.desc)
+	testID, err := host.StartTest(test.suiteID, test.request())
 	if err != nil {
 		return err
 	}
@@ -361,11 +390,13 @@ func (spec ClientTestSpec) runTest(host *Simulation, suiteID SuiteID, suite *Sui
 			continue
 		}
 		test := testSpec{
-			suiteID:   suiteID,
-			suite:     suite,
-			name:      clientTestName(spec.Name, clientDef.Name),
-			desc:      spec.Description,
-			alwaysRun: spec.AlwaysRun,
+			suiteID:     suiteID,
+			suite:       suite,
+			name:        clientTestName(spec.Name, clientDef.Name),
+			displayName: spec.DisplayName,
+			category:    spec.Category,
+			desc:        spec.Description,
+			alwaysRun:   spec.AlwaysRun,
 		}
 		err := runTest(host, test, func(t *T) {
 			client := t.StartClient(clientDef.Name, spec.Parameters, WithStaticFiles(spec.Files))
@@ -391,11 +422,13 @@ func clientTestName(name, clientType string) string {
 
 func (spec TestSpec) runTest(host *Simulation, suiteID SuiteID, suite *Suite) error {
 	test := testSpec{
-		suiteID:   suiteID,
-		suite:     suite,
-		name:      spec.Name,
-		desc:      spec.Description,
-		alwaysRun: spec.AlwaysRun,
+		suiteID:     suiteID,
+		suite:       suite,
+		name:        spec.Name,
+		displayName: spec.DisplayName,
+		category:    spec.Category,
+		desc:        spec.Description,
+		alwaysRun:   spec.AlwaysRun,
 	}
 	return runTest(host, test, spec.Run)
 }

--- a/hivesim/testapi.go
+++ b/hivesim/testapi.go
@@ -372,6 +372,10 @@ func runTest(host *Simulation, test testSpec, runit func(t *T)) error {
 			}
 			close(done)
 		}()
+		if host.docs && !test.alwaysRun {
+			// Don't run the test if we're just generating docs.
+			return
+		}
 		runit(t)
 	}()
 	<-done

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -75,7 +75,7 @@ func (api *simAPI) startSuite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	suiteID, err := api.tm.StartTestSuite(suite.Name, suite.Description)
+	suiteID, err := api.tm.StartTestSuite(&suite)
 	if err != nil {
 		log15.Error("API: StartTestSuite failed", "error", err)
 		serveError(w, err, http.StatusInternalServerError)
@@ -117,7 +117,7 @@ func (api *simAPI) startTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	testID, err := api.tm.StartTest(suiteID, test.Name, test.Description)
+	testID, err := api.tm.StartTest(suiteID, &test)
 	if err != nil {
 		err := fmt.Errorf("can't start test case: %s", err.Error())
 		serveError(w, err, http.StatusInternalServerError)

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -24,6 +24,8 @@ func (tsID TestID) String() string {
 type TestSuite struct {
 	ID             TestSuiteID          `json:"id"`
 	Name           string               `json:"name"`
+	DisplayName    string               `json:"displayName"`
+	Category       string               `json:"category"`
 	Description    string               `json:"description"`
 	ClientVersions map[string]string    `json:"clientVersions"`
 	TestCases      map[TestID]*TestCase `json:"testCases"`
@@ -38,6 +40,8 @@ type TestSuite struct {
 // TestCase represents a single test case in a test suite.
 type TestCase struct {
 	Name          string                 `json:"name"`        // Test case short name.
+	DisplayName   string                 `json:"displayName"` // Test case display name.
+	Category      string                 `json:"category"`    // Test case category.
 	Description   string                 `json:"description"` // Test case long description in MD.
 	Start         time.Time              `json:"start"`
 	End           time.Time              `json:"end"`

--- a/internal/libhive/docs.go
+++ b/internal/libhive/docs.go
@@ -1,0 +1,266 @@
+package libhive
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lithammer/dedent"
+)
+
+func toMarkdownLink(title string) string {
+	removeChars := []string{":", "#", "'", "\"", "`", "*", "+", ",", ";"}
+	title = strings.ReplaceAll(strings.ToLower(title), " ", "-")
+	for _, invalidChar := range removeChars {
+		title = strings.ReplaceAll(title, invalidChar, "")
+	}
+	return title
+}
+
+func toMarkdownFileName(title string) string {
+	title = strings.ReplaceAll(strings.ToUpper(title), " ", "-")
+	return fmt.Sprintf("TESTS-%s.md", title)
+}
+
+type markdownTestCase TestCase
+
+func (tc *markdownTestCase) commandLine(simName string, suiteName string) string {
+	return fmt.Sprintf("./hive --client <CLIENTS> --sim %s --sim.limit \"%s/%s\"", simName, suiteName, tc.Name)
+}
+
+func (tc *markdownTestCase) toBePrinted() bool {
+	return tc.Description != ""
+}
+
+func (tc *markdownTestCase) displayName() string {
+	if tc.DisplayName != "" {
+		return tc.DisplayName
+	}
+	return tc.Name
+}
+
+func (tc *markdownTestCase) description() string {
+	desc := dedent.Dedent(tc.Description)
+	// Replace single quotes with backticks, since backticks are used for markdown code blocks and
+	// they cannot be escaped in golang.
+	desc = strings.ReplaceAll(desc, "'", "`")
+	return desc
+}
+
+func (tc *markdownTestCase) toMarkdown(simName string, suiteName string, depth int) string {
+	sb := strings.Builder{}
+
+	// Print test case display name
+	sb.WriteString(fmt.Sprintf("%s %s\n\n", strings.Repeat("#", depth), tc.displayName()))
+
+	// Print command-line to run
+	sb.WriteString(fmt.Sprintf("%s Run\n\n", strings.Repeat("#", depth+1)))
+	sb.WriteString("<details>\n")
+	sb.WriteString("<summary>Command-line</summary>\n\n")
+	sb.WriteString(fmt.Sprintf("```bash\n%s\n```\n\n", tc.commandLine(simName, suiteName)))
+	sb.WriteString("</details>\n\n")
+
+	// Print description
+	sb.WriteString(fmt.Sprintf("%s Description\n\n", strings.Repeat("#", depth+1)))
+	sb.WriteString(fmt.Sprintf("%s\n\n", tc.description()))
+
+	return sb.String()
+}
+
+func getCategories(testCases map[TestID]*markdownTestCase) []string {
+	categoryMap := make(map[string]struct{})
+	categories := make([]string, 0)
+	for _, tc := range testCases {
+		if tc.toBePrinted() {
+			if _, ok := categoryMap[tc.Category]; !ok {
+				categories = append(categories, tc.Category)
+				categoryMap[tc.Category] = struct{}{}
+			}
+		}
+	}
+	return categories
+}
+
+type markdownSuite TestSuite
+
+func (s *markdownSuite) displayName() string {
+	if s.DisplayName != "" {
+		return s.DisplayName
+	}
+	return fmt.Sprintf("`%s`", s.Name)
+}
+
+func (s *markdownSuite) mardownFileName() string {
+	return toMarkdownFileName(s.Name)
+}
+
+func (s *markdownSuite) commandLine(simName string) string {
+	return fmt.Sprintf("./hive --client <CLIENTS> --sim %s --sim.limit \"%s/\"", simName, s.Name)
+}
+
+func (s *markdownSuite) description() string {
+	desc := dedent.Dedent(s.Description)
+	// Replace single quotes with backticks, since backticks are used for markdown code blocks and
+	// they cannot be escaped in golang.
+	desc = strings.ReplaceAll(desc, "'", "`")
+	return desc
+}
+
+func (s *markdownSuite) testCases() map[TestID]*markdownTestCase {
+	testCases := make(map[TestID]*markdownTestCase)
+	for testID, tc := range s.TestCases {
+		testCases[testID] = (*markdownTestCase)(tc)
+	}
+	return testCases
+}
+
+func (s *markdownSuite) toMarkdown(simName string) (string, error) {
+	headerBuilder := strings.Builder{}
+	categoryBuilder := map[string]*strings.Builder{}
+	headerBuilder.WriteString(fmt.Sprintf("# %s - Test Cases\n\n", s.displayName()))
+
+	headerBuilder.WriteString(fmt.Sprintf("%s\n\n", s.description()))
+
+	headerBuilder.WriteString("## Run Suite\n\n")
+
+	headerBuilder.WriteString("<details>\n")
+	headerBuilder.WriteString("<summary>Command-line</summary>\n\n")
+	headerBuilder.WriteString(fmt.Sprintf("```bash\n%s\n```\n\n", s.commandLine(simName)))
+	headerBuilder.WriteString("</details>\n\n")
+
+	categories := getCategories(s.testCases())
+
+	tcDepth := 3
+	if len(categories) > 1 {
+		headerBuilder.WriteString("## Test Case Categories\n\n")
+		for _, category := range categories {
+			if category == "" {
+				category = "Other"
+			}
+			headerBuilder.WriteString(fmt.Sprintf("- [%s](#category-%s)\n\n", category, toMarkdownLink(category)))
+		}
+	} else {
+		headerBuilder.WriteString("## Test Cases\n\n")
+	}
+
+	for _, tc := range s.testCases() {
+		if !tc.toBePrinted() {
+			continue
+		}
+		contentBuilder, ok := categoryBuilder[tc.Category]
+		if !ok {
+			contentBuilder = &strings.Builder{}
+			categoryBuilder[tc.Category] = contentBuilder
+		}
+		contentBuilder.WriteString(tc.toMarkdown(simName, s.Name, tcDepth))
+	}
+
+	if len(categoryBuilder) > 1 {
+		for _, category := range categories {
+			if category == "" {
+				category = "Other"
+			}
+			contentBuilder, ok := categoryBuilder[category]
+			if !ok {
+				continue
+			}
+			headerBuilder.WriteString(fmt.Sprintf("## Category: %s\n\n", category))
+			headerBuilder.WriteString(contentBuilder.String())
+		}
+	} else {
+		for _, contentBuilder := range categoryBuilder {
+			headerBuilder.WriteString(contentBuilder.String())
+		}
+	}
+
+	return headerBuilder.String(), nil
+}
+
+func (s *markdownSuite) toMarkdownFile(fw FileWriter, simName string) error {
+	// Create the file.
+	file, err := fw.CreateWriter(s.mardownFileName())
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Write the markdown.
+	markdown, err := s.toMarkdown(simName)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write([]byte(markdown))
+	return err
+}
+
+func toMarkdownSuiteMap(testMap map[TestSuiteID]*TestSuite) map[TestSuiteID]*markdownSuite {
+	markdownMap := make(map[TestSuiteID]*markdownSuite)
+	for testID, suite := range testMap {
+		markdownMap[testID] = (*markdownSuite)(suite)
+	}
+	return markdownMap
+}
+
+func generateIndex(simName string, testMap map[TestSuiteID]*markdownSuite) (string, error) {
+	headerBuilder := strings.Builder{}
+	headerBuilder.WriteString(fmt.Sprintf("# Simulator `%s` Test Cases\n\n", simName))
+	headerBuilder.WriteString("## Test Suites\n\n")
+	for _, s := range testMap {
+		headerBuilder.WriteString(fmt.Sprintf("### - [%s](%s)\n", s.displayName(), s.mardownFileName()))
+		headerBuilder.WriteString(s.Description)
+		headerBuilder.WriteString("\n\n")
+	}
+	return headerBuilder.String() + "\n", nil
+}
+
+func generateIndexFile(fw FileWriter, simName string, testMap map[TestSuiteID]*markdownSuite) error {
+	markdownIndex, err := generateIndex(simName, testMap)
+	if err != nil {
+		return err
+	}
+	file, err := fw.CreateWriter("TESTS.md")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.Write([]byte(markdownIndex))
+	return err
+}
+
+type FileWriter interface {
+	CreateWriter(path string) (io.WriteCloser, error)
+}
+
+type fileWriter struct {
+	path string
+}
+
+var _ FileWriter = (*fileWriter)(nil)
+
+func (fw *fileWriter) CreateWriter(path string) (io.WriteCloser, error) {
+	filePath := filepath.FromSlash(fmt.Sprintf("%s/%s", fw.path, path))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return nil, err
+	}
+	return os.Create(filePath)
+}
+
+func NewFileWriter(path string) FileWriter {
+	return &fileWriter{path}
+}
+
+func GenSimulatorMarkdownFiles(fw FileWriter, simName string, testMap map[TestSuiteID]*TestSuite) error {
+	markdownSuiteMap := toMarkdownSuiteMap(testMap)
+	err := generateIndexFile(fw, simName, markdownSuiteMap)
+	if err != nil {
+		return err
+	}
+	for _, s := range markdownSuiteMap {
+		if err := s.toMarkdownFile(fw, simName); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/libhive/docs_test.go
+++ b/internal/libhive/docs_test.go
@@ -1,0 +1,90 @@
+package libhive
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (c nopCloser) Close() error {
+	// No-op
+	return nil
+}
+
+type testWriter struct {
+	fileMap map[string]*bytes.Buffer
+}
+
+func (tw *testWriter) Contains(file string) bool {
+	for k := range tw.fileMap {
+		if k == file {
+			return true
+		}
+	}
+	return false
+}
+
+func (tw *testWriter) CreateWriter(path string) (io.WriteCloser, error) {
+	if _, ok := tw.fileMap[path]; !ok {
+		tw.fileMap[path] = &bytes.Buffer{}
+	}
+	return nopCloser{tw.fileMap[path]}, nil
+}
+
+func TestSuiteDocsGen(t *testing.T) {
+	suiteMap := map[TestSuiteID]*TestSuite{
+		1: {
+			Name:        "suite1",
+			Description: `This is a description of suite1.`,
+			TestCases: map[TestID]*TestCase{
+				1: {
+					Name:        "test1",
+					Description: `This is a description of test1 in suite1.`,
+				},
+				2: {
+					Name:        "test2",
+					Description: `This is a description of test2 in suite1.`,
+				},
+			},
+		},
+		2: {
+			Name:        "suite2",
+			DisplayName: "Suite 2",
+			Description: `This is a description of suite2.`,
+			TestCases: map[TestID]*TestCase{
+				1: {
+					Name:        "testA",
+					Description: `This is a description of testA in suite2.`,
+				},
+				2: {
+					Name:        "testB",
+					DisplayName: "Test B",
+					Description: `This is a description of testB in suite2.`,
+				},
+			},
+		},
+	}
+	tw := &testWriter{map[string]*bytes.Buffer{}}
+	if err := GenSimulatorMarkdownFiles(tw, "sim", suiteMap); err != nil {
+		t.Fatal(err)
+	}
+	if len(tw.fileMap) != 3 {
+		t.Fatalf("expected 3 files, got %d", len(tw.fileMap))
+	}
+
+	if !tw.Contains("TESTS.md") {
+		t.Fatal("TESTS.md not found")
+	}
+
+	if !tw.Contains("TESTS-SUITE1.md") {
+		t.Fatal("TESTS-SUITE1.md not found")
+	}
+
+	if !tw.Contains("TESTS-SUITE2.md") {
+		t.Fatal("TESTS-SUITE2.md not found")
+	}
+}

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -206,6 +206,7 @@ func (r *Runner) run(ctx context.Context, sim string, env SimEnv) (SimResult, er
 			"HIVE_LOGLEVEL":     strconv.Itoa(env.SimLogLevel),
 			"HIVE_TEST_PATTERN": env.SimTestPattern,
 			"HIVE_RANDOM_SEED":  strconv.Itoa(env.SimRandomSeed),
+			"HIVE_DOCS_MODE":    strconv.FormatBool(env.SimDocsMode),
 		},
 	}
 	containerID, err := r.container.CreateContainer(ctx, r.simImages[sim], opts)

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -273,6 +273,12 @@ func (r *Runner) run(ctx context.Context, sim string, env SimEnv) (SimResult, er
 			}
 		}
 	}
+	if env.SimDocsMode {
+		docsOutputDir := filepath.Join(env.SimDocsOutputBaseDir, "simulators", filepath.FromSlash(sim))
+		if err := GenSimulatorMarkdownFiles(NewFileWriter(docsOutputDir), sim, tm.Results()); err != nil {
+			log15.Error("can't generate markdown files", "err", err)
+		}
+	}
 
 	return result, err
 }

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/hive/internal/simapi"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -371,7 +372,7 @@ func (manager *TestManager) doEndSuite(testSuite TestSuiteID) error {
 }
 
 // StartTestSuite starts a test suite and returns the context id
-func (manager *TestManager) StartTestSuite(name string, description string) (TestSuiteID, error) {
+func (manager *TestManager) StartTestSuite(tr *simapi.TestRequest) (TestSuiteID, error) {
 	manager.testSuiteMutex.Lock()
 	defer manager.testSuiteMutex.Unlock()
 
@@ -397,8 +398,10 @@ func (manager *TestManager) StartTestSuite(name string, description string) (Tes
 
 	manager.runningTestSuites[newSuiteID] = &TestSuite{
 		ID:              newSuiteID,
-		Name:            name,
-		Description:     description,
+		Name:            tr.Name,
+		DisplayName:     tr.DisplayName,
+		Category:        tr.Category,
+		Description:     tr.Description,
 		ClientVersions:  make(map[string]string),
 		TestCases:       make(map[TestID]*TestCase),
 		SimulatorLog:    manager.simLogFile,
@@ -410,7 +413,7 @@ func (manager *TestManager) StartTestSuite(name string, description string) (Tes
 }
 
 // StartTest starts a new test case, returning the testcase id as a context identifier
-func (manager *TestManager) StartTest(testSuiteID TestSuiteID, name string, description string) (TestID, error) {
+func (manager *TestManager) StartTest(testSuiteID TestSuiteID, tr *simapi.TestRequest) (TestID, error) {
 	manager.testCaseMutex.Lock()
 	defer manager.testCaseMutex.Unlock()
 
@@ -424,8 +427,10 @@ func (manager *TestManager) StartTest(testSuiteID TestSuiteID, name string, desc
 	var newCaseID = TestID(manager.testCaseCounter)
 	// create a new test case and add it to the test suite
 	newTestCase := &TestCase{
-		Name:        name,
-		Description: description,
+		Name:        tr.Name,
+		DisplayName: tr.DisplayName,
+		Category:    tr.Category,
+		Description: tr.Description,
 		Start:       time.Now(),
 	}
 	// add the test case to the test suite

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -33,11 +33,12 @@ type SimEnv struct {
 	LogDir string
 
 	// Parameters of simulation.
-	SimLogLevel    int
-	SimParallelism int
-	SimRandomSeed  int
-	SimTestPattern string
-	SimDocsMode    bool
+	SimLogLevel          int
+	SimParallelism       int
+	SimRandomSeed        int
+	SimTestPattern       string
+	SimDocsMode          bool
+	SimDocsOutputBaseDir string
 
 	// This is the time limit for the simulation run.
 	// There is no default limit.

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -36,6 +36,7 @@ type SimEnv struct {
 	SimParallelism int
 	SimRandomSeed  int
 	SimTestPattern string
+	SimDocsMode    bool
 
 	// This is the time limit for the simulation run.
 	// There is no default limit.

--- a/internal/simapi/simapi.go
+++ b/internal/simapi/simapi.go
@@ -3,6 +3,8 @@ package simapi
 
 type TestRequest struct {
 	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Category    string `json:"category"`
 	Description string `json:"description"`
 }
 


### PR DESCRIPTION
Adds the `--docs` flag to the hive binary, which has the following effects:
- Sets the `HIVE_DOCS_MODE` environment variable for the simulator container, which does the following:
  - The flag can be parsed by the `hivesim` library being used by (currently) all simulators and inhibit the execution of test functions that are not marked as `AlwaysRun`
  - The simulator will still send `StartSuite`, `EndSuite`, `StartTest` and `EndTest` requests to the hive server
- Using the `TestManager`, the hive server collects the test suites and test cases and then proceeds to generate a markdown document for each suite containing every single test case into the simulator folder

The following fields are added to many structures, including the `TestRequest`, `TestSuite` and `TestCase`:
- DisplayName: Allows specifying a different title for a test suite or test case to be displayed in the output markdown
- Category: Allows grouping together many different test cases and add sections in the markdown file

In its current state, simulators still execute each test case in full because the `hivesim` dependency that inhibits execution in docs mode needs to be updated once this change makes it into the master branch.

