### PR TITLE
configs/cancun: Use go-ethereum master

### DIFF
--- a/configs/cancun.yaml
+++ b/configs/cancun.yaml
@@ -21,9 +21,6 @@
 - client: go-ethereum
   nametag: cancun-git
   dockerfile: git
-  build_args:
-      github: lightclient/go-ethereum
-      tag: devnet-10
 
 - client: nethermind
   nametag: cancun-git


### PR DESCRIPTION
Removes `lightclient/go-ethereum@devnet-10` from cancun's config file and uses `master` instead.