### PR TITLE
clients/erigon, simulators/ethereum/rpc: patch RPC tests for erigon

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -128,7 +128,7 @@ fi
 
 # Configure RPC.
 FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,web3"
-FLAGS="$FLAGS --ws"
+FLAGS="$FLAGS --ws --ws.port=8546"
 
 # Increase blob slots for tests
 FLAGS="$FLAGS --txpool.blobslots=1000"

--- a/clients/erigon/mapper.jq
+++ b/clients/erigon/mapper.jq
@@ -54,7 +54,7 @@ def to_bool:
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
-    "terminalTotalDifficultyPassed": true,
+    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED == null then 1 else env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED|to_bool end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
   }|remove_empty

--- a/simulators/ethereum/rpc/main.go
+++ b/simulators/ethereum/rpc/main.go
@@ -31,6 +31,7 @@ var clientEnv = hivesim.Params{
 	"HIVE_CLIQUE_PERIOD":     "1",
 	"HIVE_CLIQUE_PRIVATEKEY": "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c",
 	"HIVE_MINER":             "658bdf435d810c91414ec09147daa6db62406379",
+	"HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED": "0",
 }
 
 var files = map[string]string{


### PR DESCRIPTION
- Adding `ws.port` explicitly
- `terminalTotalDifficultyPassed` was hardcoded to `true`, now setting it to env-based, but default to `true`. This is so as to not break existing tests. Later this must be only env-based, and changes to the HIVE env params must be made in specific test suites.