### PR TITLE
clients/nethermind: upgrade to .NET 8

### DIFF
--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -1,7 +1,7 @@
 ### Build Nethermind From Git:
 
 ## Builder stage: Compiles nethermind from a git repository
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 ARG github=nethermindeth/nethermind
 ARG tag=master
@@ -12,10 +12,10 @@ RUN echo "Cloning: $github - $tag" && \
     dotnet build -c release
 
 ## Final stage: Sets up the environment for running nethermind
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
 # Copy compiled binary from builder
-COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+COPY --from=build /nethermind/src/Nethermind/artifacts/bin/Nethermind.Runner/release /nethermind
 WORKDIR /nethermind
 
 RUN apt-get update && apt-get install -y jq libsnappy-dev libc6-dev libc6 && \

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -2,7 +2,7 @@
 ### Requires a copy of nethermind/ -> hive/clients/nethermind/
 
 ## Builder stage: Compiles nethermind from a local directory
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Default local client path: clients/nethermind/<nethermind>
 ARG local_path=nethermind
@@ -11,10 +11,10 @@ ADD $local_path /nethermind
 RUN cd /nethermind/src/Nethermind/Nethermind.Runner && dotnet build -c release
 
 ## Final stage: Sets up the environment for running nethermind
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
 # Copy compiled binary from builder
-COPY --from=build /nethermind/src/Nethermind/Nethermind.Runner/bin/release/net7.0 /nethermind
+COPY --from=build /nethermind/src/Nethermind/artifacts/bin/Nethermind.Runner/release /nethermind
 WORKDIR /nethermind
 
 RUN apt-get update && apt-get install -y jq libsnappy-dev libc6-dev libc6 && \


### PR DESCRIPTION
- Upgrade Nethermind Dockerfiles to .NET 8, because the client has been already upgraded on master
- May help to bring the client back to the cancun hive tests