### PR TITLE
clients/nethermind: update TxPool config

### DIFF
--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -73,8 +73,7 @@ def txpool_config:
   if env.HIVE_CANCUN_TIMESTAMP != null then
     {
       "TxPool": {
-        "BlobSupportEnabled": true,
-        "PersistentBlobStorageEnabled": true
+        "BlobsSupport": "StorageWithReorgs"
       }
     }
   else


### PR DESCRIPTION
Nethermind recently refactored blob pool to support blob transaction reorgs, introducing an additional flag. We decided to consolidate three blob pool-related flags into one enum. This PR enables support for blob transactions + persistent blob storage + blob transactions reorgs.