### PR TITLE
simulators/ethereum/consensus: Fix `excessBlobGas` genesis

### DIFF
--- a/simulators/ethereum/consensus/main.go
+++ b/simulators/ethereum/consensus/main.go
@@ -553,15 +553,16 @@ func (tc *testcase) updateEnv(env hivesim.Params) {
 // toGethGenesis creates the genesis specification from a test block.
 func toGethGenesis(test *btJSON) *core.Genesis {
 	genesis := &core.Genesis{
-		Nonce:      test.Genesis.Nonce.Uint64(),
-		Timestamp:  test.Genesis.Timestamp.Uint64(),
-		ExtraData:  test.Genesis.ExtraData,
-		GasLimit:   test.Genesis.GasLimit,
-		Difficulty: test.Genesis.Difficulty,
-		Mixhash:    test.Genesis.MixHash,
-		Coinbase:   test.Genesis.Coinbase,
-		Alloc:      test.Pre,
-		BaseFee:    test.Genesis.BaseFee,
+		Nonce:         test.Genesis.Nonce.Uint64(),
+		Timestamp:     test.Genesis.Timestamp.Uint64(),
+		ExtraData:     test.Genesis.ExtraData,
+		GasLimit:      test.Genesis.GasLimit,
+		Difficulty:    test.Genesis.Difficulty,
+		Mixhash:       test.Genesis.MixHash,
+		Coinbase:      test.Genesis.Coinbase,
+		Alloc:         test.Pre,
+		BaseFee:       test.Genesis.BaseFee,
+		ExcessBlobGas: test.Genesis.ExcessBlobGas,
 	}
 	return genesis
 }
@@ -651,7 +652,15 @@ func compareGenesis(have string, want btHeader) (string, error) {
 	cmp(haveGenesis.GasUsed, want.GasUsed, "gasUsed")
 	cmp(haveGenesis.Nonce, want.Nonce, "nonce")
 	cmp(haveGenesis.BaseFee, want.BaseFee, "baseFeePerGas")
-	cmp(haveGenesis.ExcessBlobGas, want.ExcessBlobGas, "excessBlobGas")
-	cmp(haveGenesis.BlobGasUsed, want.BlobGasUsed, "blobGasUsed")
+	if haveGenesis.ExcessBlobGas != nil && want.ExcessBlobGas != nil {
+		cmp(*haveGenesis.ExcessBlobGas, *want.ExcessBlobGas, "excessBlobGas")
+	} else {
+		cmp(haveGenesis.ExcessBlobGas, want.ExcessBlobGas, "excessBlobGas")
+	}
+	if haveGenesis.BlobGasUsed != nil && want.BlobGasUsed != nil {
+		cmp(*haveGenesis.BlobGasUsed, *want.BlobGasUsed, "blobGasUsed")
+	} else {
+		cmp(haveGenesis.BlobGasUsed, want.BlobGasUsed, "blobGasUsed")
+	}
 	return output, nil
 }

--- a/simulators/ethereum/consensus/types.go
+++ b/simulators/ethereum/consensus/types.go
@@ -55,8 +55,8 @@ type btHeader struct {
 	GasUsed          uint64           `json:"gasUsed"`
 	Timestamp        *big.Int         `json:"timestamp"`
 	BaseFee          *big.Int         `json:"baseFeePerGas"` // EIP-1559
-	ExcessBlobGas    uint64           `json:"excessBlobGas"` // EIP-4844
-	BlobGasUsed      uint64           `json:"blobGasUsed"`   // EIP-4844
+	ExcessBlobGas    *uint64          `json:"excessBlobGas"` // EIP-4844
+	BlobGasUsed      *uint64          `json:"blobGasUsed"`   // EIP-4844
 }
 
 func (b *btHeader) UnmarshalJSON(input []byte) error {
@@ -152,10 +152,12 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 		b.BaseFee = (*big.Int)(dec.BaseFee)
 	}
 	if dec.ExcessBlobGas != nil {
-		b.ExcessBlobGas = uint64(*dec.ExcessBlobGas)
+		ebg := uint64(*dec.ExcessBlobGas)
+		b.ExcessBlobGas = &ebg
 	}
 	if dec.BlobGasUsed != nil {
-		b.BlobGasUsed = uint64(*dec.BlobGasUsed)
+		bgu := uint64(*dec.BlobGasUsed)
+		b.BlobGasUsed = &bgu
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes passing the correct non-zero `excessBlobGas` to clients' genesis files.