### PR TITLE
all: fix some typos in README.md files

### DIFF
--- a/simulators/ethereum/engine/suites/cancun/README.md
+++ b/simulators/ethereum/engine/suites/cancun/README.md
@@ -1,5 +1,5 @@
 # Cancun Engine API Testing
 
-This test suite verifies behavior of the Engine API on the transtion to and after the Cancun fork:
+This test suite verifies behavior of the Engine API on the transition to and after the Cancun fork:
 https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md
 

--- a/simulators/ethereum/rpc/README.md
+++ b/simulators/ethereum/rpc/README.md
@@ -25,7 +25,7 @@ The genesis block also contains 2 contracts:
 Ethclient runs various tests that use the `ethclient.Client` API. Such as sending
 transactions, retrieving logs and balances.
 
-ABI, interacts with the pre-deployed events contract. It send transactions, executs calls
+ABI, interacts with the pre-deployed events contract. It send transactions, executes calls
 and examines generated logs.
 
 Each test is designed to run in parallel with other tests. In most cases the first step a


### PR DESCRIPTION
Found two little errors while reading some README files. 
Doesn't require testing or changelog entry.
Have a nice evening.