### PR TITLE
hive: Add --sim.exactmatch flag

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -26,6 +26,7 @@ func main() {
 		dockerOutput          = flag.Bool("docker.output", false, "Relay all docker output to stderr.")
 		simPattern            = flag.String("sim", "", "Regular `expression` selecting the simulators to run.")
 		simTestPattern        = flag.String("sim.limit", "", "Regular `expression` selecting tests/suites (interpreted by simulators).")
+		simTestExact          = flag.Bool("sim.exactmatch", true, "Exact `expression` match for tests/suites (interpreted by simulators).")
 		simParallelism        = flag.Int("sim.parallelism", 1, "Max `number` of parallel clients/containers (interpreted by simulators).")
 		simRandomSeed         = flag.Int("sim.randomseed", 0, "Randomness seed number (interpreted by simulators).")
 		simTestLimit          = flag.Int("sim.testlimit", 0, "[DEPRECATED] Max `number` of tests to execute per client (interpreted by simulators).")
@@ -72,6 +73,10 @@ func main() {
 	if *simPattern != "" && *simDevMode {
 		log15.Warn("--sim is ignored when using --dev mode")
 		simList = nil
+	}
+	if *simTestExact && *simTestPattern != "" {
+		pattern := regexp.QuoteMeta(*simTestPattern) + "$"
+		simTestPattern = &pattern
 	}
 
 	// Create the docker backends.


### PR DESCRIPTION
## Description

Following this PR: https://github.com/ethereum/hive/pull/929

> On occasion we may use a regex pattern that will run more tests than intended. 
> 
> The intention behind the `sim.limit` below may be to solely run a single test in isolation:
> ```bash
> ... --sim.limit engine-cancun/"InvalidPayloadAttributes: Missing BeaconRoot" --docker.output
> ```
> 
> Due to the increasing number of tests within the engine simulator alongside its programtic naming of tests, the above `sim.limit` will run and additional test using regex matching: 
> ```
> InvalidPayloadAttributes: Missing BeaconRoot
> InvalidPayloadAttributes: Missing BeaconRoot (Syncing)
> ```

## Updated Proposed Change

Adds an additional boolean flag: `--sim.exactmatch`, that can be used to escape and anchor the regex expression specified within `--sim.limit`.
