### PR TITLE
clients/nethermind: Fix Dockerfile.git

### DIFF
--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -1,7 +1,7 @@
 ### Build Nethermind From Git:
 
 ## Builder stage: Compiles nethermind from a git repository
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
 
 ARG github=nethermindeth/nethermind
 ARG tag=master


### PR DESCRIPTION
Small fix to force using the correct dotnet sdk docker image, which was producing a failure when trying to build Nethermind from git.