### PR TITLE
simulators/rpc-compat: allow for any message in error checks

### DIFF
--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -112,11 +112,35 @@ func runTest(t *hivesim.T, c *hivesim.Client, data []byte) error {
 				return fmt.Errorf("invalid test, response before request")
 			}
 			want := []byte(strings.TrimSpace(line)[3:]) // trim leading "<< "
-			// Now compare.
-			d, err := diff.New().Compare(resp, want)
-			if err != nil {
-				return fmt.Errorf("failed to unmarshal value: %s\n", err)
+
+			// Unmarshal to map[string]interface{} to compare.
+			var wantMap map[string]interface{}
+			if err := json.Unmarshal(want, &wantMap); err != nil {
+				return fmt.Errorf("failed to unmarshal value: %s", err)
 			}
+
+			var respMap map[string]interface{}
+			if err := json.Unmarshal(resp, &respMap); err != nil {
+				return fmt.Errorf("failed to unmarshal value: %s", err)
+			}
+
+			if c.Type == "reth" {
+				// If errors exist in both, make them equal.
+				// While error comparison might be desirable, error text across
+				// clients is not standardized, so we should not compare them.
+				if wantMap["error"] != nil && respMap["error"] != nil {
+					respError := respMap["error"].(map[string]interface{})
+					wantError := wantMap["error"].(map[string]interface{})
+					respError["message"] = wantError["message"]
+					respError["data"] = wantError["data"]
+					// cast back into the any type
+					respMap["error"] = respError
+				}
+			}
+
+			// Now compare.
+			d := diff.New().CompareObjects(respMap, wantMap)
+
 			// If there is a discrepancy, return error.
 			if d.Modified() {
 				var got map[string]interface{}


### PR DESCRIPTION
When reth runs the `rpc-compat` tests which expect an error, sometimes the error test vector contains a string like this:
```diff
+    "message": "invalid argument 0: json: cannot unmarshal hex string without 0x prefix into Go value of type common.Hash
```
This is something that reth will never be able to output.

Sometimes we also see the following situation:
```diff
>>  {"jsonrpc":"2.0","id":1,"method":"debug_getRawReceipts","params":["2"]}
<<  {"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"hex string without 0x prefix at line 1 column 3"},"id":1}
response differs from expected (-- client, ++ test):
 {
   "error": {
     "code": -32602,
-    "data": "hex string without 0x prefix at line 1 column 3",
-    "message": "Invalid params"
+    "message": "invalid argument 0: hex string without 0x prefix"
   },
   "id": 1,
   "jsonrpc": "2.0"
 }
```
While this is a different way of displaying the error, it includes the correct error code and "invalid params" plus the `data` field give the right information.

This PR tries to make sure that the deep comparison is still performed for the error object, with the exception of the `message` and `data` fields are not compared.

cc @fjl, I pulled this from our old reth PR