### PR TITLE
.circleci: add support for running ci's based off code modified specificed via path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,79 +1,14 @@
 version: 2.1
+
+setup: true
+
 orbs:
-  go: circleci/go@1.5.0
-
-jobs:
-  # This job builds the hive executable and stores it in the workspace.
-  build:
-    docker:
-      - image: cimg/go:1.21
-    steps:
-      # Build it.
-      - checkout
-      - go/load-cache
-      - go/mod-download
-      - go/save-cache
-      - run: {command: 'go build -ldflags="-s -extldflags=-static" -tags "osusergo netgo static_build" .'}
-      # Store the executable.
-      - persist_to_workspace:
-          root: .
-          paths: ["hive"]
-
-  # This job runs the smoke test simulations. This requires a virtual
-  # machine instead of the container-based build environment because
-  # hive needs to be able to talk to the docker containers it creates.
-  smoke-tests:
-    machine:
-      image: ubuntu-2004:202201-02
-    steps:
-      - checkout
-      - attach_workspace: {at: "/tmp/build"}
-      - run:
-          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum"
-      - run:
-          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum"
-
-  # This job also runs the smoke test simulations, but against a remote dockerd.
-  smoke-tests-remote-docker:
-    docker:
-      - image: cimg/base:2022.04
-    steps:
-      - checkout
-      - attach_workspace: {at: "/tmp/build"}
-      - setup_remote_docker: {version: 20.10.14}
-      - run:
-          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum --loglevel 5"
-      - run:
-          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum --loglevel 5"
-
-  # This job runs the go unit tests.
-  go-test:
-    docker:
-      - image: cimg/go:1.21
-    steps:
-      # Get the source.
-      - checkout
-      - go/load-cache
-      - go/mod-download
-      - go/save-cache
-      # Run the tests.
-      - run:
-          name: "hive module tests"
-          command: "go test -cover ./..."
-      - run:
-          name: "hiveproxy module tests"
-          command: "go test -cover ./..."
-          working_directory: "./hiveproxy"
-      - run:
-          name: "Compile Go simulators"
-          command: ".circleci/compile-simulators.sh"
+  path-filtering: circleci/path-filtering@0.0.1
 
 workflows:
-  main:
+  setup-workflow:
     jobs:
-      - go-test
-      - build
-      - smoke-tests:
-          requires: ["build"]
-      - smoke-tests-remote-docker:
-          requires: ["build"]
+      - path-filtering/filter:
+          mapping: |
+            simulators/portal/.* rust-ci true
+          base-revision: origin/master

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,0 +1,84 @@
+version: 2.1
+orbs:
+  go: circleci/go@1.5.0
+
+parameters:
+  rust-ci:
+    type: boolean
+    default: false  
+
+jobs:
+  # This job builds the hive executable and stores it in the workspace.
+  build:
+    docker:
+      - image: cimg/go:1.21
+    steps:
+      # Build it.
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - go/save-cache
+      - run: {command: 'go build -ldflags="-s -extldflags=-static" -tags "osusergo netgo static_build" .'}
+      # Store the executable.
+      - persist_to_workspace:
+          root: .
+          paths: ["hive"]
+
+  # This job runs the smoke test simulations. This requires a virtual
+  # machine instead of the container-based build environment because
+  # hive needs to be able to talk to the docker containers it creates.
+  smoke-tests:
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout
+      - attach_workspace: {at: "/tmp/build"}
+      - run:
+          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum"
+      - run:
+          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum"
+
+  # This job also runs the smoke test simulations, but against a remote dockerd.
+  smoke-tests-remote-docker:
+    docker:
+      - image: cimg/base:2022.04
+    steps:
+      - checkout
+      - attach_workspace: {at: "/tmp/build"}
+      - setup_remote_docker: {version: 20.10.14}
+      - run:
+          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum --loglevel 5"
+      - run:
+          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum --loglevel 5"
+
+  # This job runs the go unit tests.
+  go-test:
+    docker:
+      - image: cimg/go:1.21
+    steps:
+      # Get the source.
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - go/save-cache
+      # Run the tests.
+      - run:
+          name: "hive module tests"
+          command: "go test -cover ./..."
+      - run:
+          name: "hiveproxy module tests"
+          command: "go test -cover ./..."
+          working_directory: "./hiveproxy"
+      - run:
+          name: "Compile Go simulators"
+          command: ".circleci/compile-simulators.sh"
+
+workflows:
+  main:
+    jobs:
+      - go-test
+      - build
+      - smoke-tests:
+          requires: ["build"]
+      - smoke-tests-remote-docker:
+          requires: ["build"]


### PR DESCRIPTION
Here is a PR for allowing for certain CI's to run only when certain CI's are touched. I am proposing this change because when portal-hive code gets merged. We wouldn't want rust ci jobs running for non-rust related code.

@fjl here is my PR which will allow for running rust-ci's only on rust code. Would you be able to ``Use of setup workflows must be enabled in project settings (Project settings > Advanced -> Dynamic config using setup workflows)`` enable this.

I am going to close my current portal-hive -> hive PR since it is out of date. And maybe opened PR's to merge 1 thing at a time if that would be easier?

This pr is based off the instructions here https://github.com/CircleCI-Public/api-preview-docs/blob/path-filtering/docs/path-filtering.md#setup-workflows