### PR TITLE
.circleci: Add CI for rust simulators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,79 +1,14 @@
 version: 2.1
+
+setup: true
+
 orbs:
-  go: circleci/go@1.5.0
-
-jobs:
-  # This job builds the hive executable and stores it in the workspace.
-  build:
-    docker:
-      - image: cimg/go:1.21
-    steps:
-      # Build it.
-      - checkout
-      - go/load-cache
-      - go/mod-download
-      - go/save-cache
-      - run: {command: 'go build -ldflags="-s -extldflags=-static" -tags "osusergo netgo static_build" .'}
-      # Store the executable.
-      - persist_to_workspace:
-          root: .
-          paths: ["hive"]
-
-  # This job runs the smoke test simulations. This requires a virtual
-  # machine instead of the container-based build environment because
-  # hive needs to be able to talk to the docker containers it creates.
-  smoke-tests:
-    machine:
-      image: ubuntu-2004:202201-02
-    steps:
-      - checkout
-      - attach_workspace: {at: "/tmp/build"}
-      - run:
-          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum"
-      - run:
-          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum"
-
-  # This job also runs the smoke test simulations, but against a remote dockerd.
-  smoke-tests-remote-docker:
-    docker:
-      - image: cimg/base:2022.04
-    steps:
-      - checkout
-      - attach_workspace: {at: "/tmp/build"}
-      - setup_remote_docker: {version: 20.10.14}
-      - run:
-          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum --loglevel 5"
-      - run:
-          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum --loglevel 5"
-
-  # This job runs the go unit tests.
-  go-test:
-    docker:
-      - image: cimg/go:1.21
-    steps:
-      # Get the source.
-      - checkout
-      - go/load-cache
-      - go/mod-download
-      - go/save-cache
-      # Run the tests.
-      - run:
-          name: "hive module tests"
-          command: "go test -cover ./..."
-      - run:
-          name: "hiveproxy module tests"
-          command: "go test -cover ./..."
-          working_directory: "./hiveproxy"
-      - run:
-          name: "Compile Go simulators"
-          command: ".circleci/compile-simulators.sh"
+  path-filtering: circleci/path-filtering@0.0.1
 
 workflows:
-  main:
+  setup-workflow:
     jobs:
-      - go-test
-      - build
-      - smoke-tests:
-          requires: ["build"]
-      - smoke-tests-remote-docker:
-          requires: ["build"]
+      - path-filtering/filter:
+          mapping: |
+            simulators/portal/.* rust-ci true
+          base-revision: origin/master

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,0 +1,84 @@
+version: 2.1
+orbs:
+  go: circleci/go@1.5.0
+
+parameters:
+  rust-ci:
+    type: boolean
+    default: false  
+
+jobs:
+  # This job builds the hive executable and stores it in the workspace.
+  build:
+    docker:
+      - image: cimg/go:1.21
+    steps:
+      # Build it.
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - go/save-cache
+      - run: {command: 'go build -ldflags="-s -extldflags=-static" -tags "osusergo netgo static_build" .'}
+      # Store the executable.
+      - persist_to_workspace:
+          root: .
+          paths: ["hive"]
+
+  # This job runs the smoke test simulations. This requires a virtual
+  # machine instead of the container-based build environment because
+  # hive needs to be able to talk to the docker containers it creates.
+  smoke-tests:
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout
+      - attach_workspace: {at: "/tmp/build"}
+      - run:
+          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum"
+      - run:
+          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum"
+
+  # This job also runs the smoke test simulations, but against a remote dockerd.
+  smoke-tests-remote-docker:
+    docker:
+      - image: cimg/base:2022.04
+    steps:
+      - checkout
+      - attach_workspace: {at: "/tmp/build"}
+      - setup_remote_docker: {version: 20.10.14}
+      - run:
+          command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum --loglevel 5"
+      - run:
+          command: "/tmp/build/hive --sim=smoke/network --client=go-ethereum --loglevel 5"
+
+  # This job runs the go unit tests.
+  go-test:
+    docker:
+      - image: cimg/go:1.21
+    steps:
+      # Get the source.
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - go/save-cache
+      # Run the tests.
+      - run:
+          name: "hive module tests"
+          command: "go test -cover ./..."
+      - run:
+          name: "hiveproxy module tests"
+          command: "go test -cover ./..."
+          working_directory: "./hiveproxy"
+      - run:
+          name: "Compile Go simulators"
+          command: ".circleci/compile-simulators.sh"
+
+workflows:
+  main:
+    jobs:
+      - go-test
+      - build
+      - smoke-tests:
+          requires: ["build"]
+      - smoke-tests-remote-docker:
+          requires: ["build"]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -72,6 +72,24 @@ jobs:
       - run:
           name: "Compile Go simulators"
           command: ".circleci/compile-simulators.sh"
+  # this makes sure the rust code is good
+  rust-simulators:
+    docker:
+      - image: cimg/rust:1.71.1
+    steps:
+      - checkout
+      - run:
+          name: Install rustfmt
+          command: rustup component add rustfmt
+      - run:
+          name: Install Clippy
+          command: rustup component add clippy
+      - run:
+          name: Install Clang
+          command: sudo apt update && sudo apt-get install clang -y
+      - run:
+          name: "Lint, build, test Rust simulators"
+          command: ".circleci/rust-simulators.sh"          
 
 workflows:
   main:
@@ -82,3 +100,7 @@ workflows:
           requires: ["build"]
       - smoke-tests-remote-docker:
           requires: ["build"]
+      - rust-jobs:
+          when: << pipeline.parameters.rust-ci >>
+          jobs:
+            - rust-simulators

--- a/.circleci/rust-simulators.sh
+++ b/.circleci/rust-simulators.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This causes the bash script to exit immediately if any commands errors out
+set -e
+
+failed=""
+sims=$(find simulators -name Cargo.toml)
+for d in $sims; do
+    d="$(dirname "$d")"
+    echo "Lint, build, test $d"
+    ( cd "$d" || exit 1;
+    cargo fmt --all -- --check;
+    cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings;
+    cargo test --workspace -- --nocapture;
+    )
+done


### PR DESCRIPTION
https://github.com/ethereum/hive/pull/976 <- this PR should be reviewed first, or this one can up to the reviewer.

This PR adds a CI to test the rust simulators

Because of the last PR this CI will only run if code is modified in the simulators/portal folder