### PR TITLE
simulators/ethereum/pyspec: Use latest EEST fixture release.

### DIFF
--- a/simulators/ethereum/pyspec/Dockerfile
+++ b/simulators/ethereum/pyspec/Dockerfile
@@ -21,9 +21,9 @@ COPY --from=builder /source/pyspec/pyspec .
 # To run locally generated fixtures, comment the following RUN lines and
 # uncomment the ADD line.
 # Download the latest fixture release.
-RUN wget https://github.com/ethereum/execution-spec-tests/releases/latest/download/fixtures_develop_hive.tar.gz
-RUN tar -xzvf fixtures_develop_hive.tar.gz
-RUN mv fixtures /fixtures
+RUN wget https://github.com/ethereum/execution-spec-tests/releases/latest/download/fixtures_develop.tar.gz
+RUN tar -xzvf fixtures_develop.tar.gz
+RUN mv fixtures/blockchain_tests_hive /fixtures
 
 # ADD ./pyspec/fixtures /fixtures
 

--- a/simulators/ethereum/pyspec/runner.go
+++ b/simulators/ethereum/pyspec/runner.go
@@ -138,7 +138,7 @@ func (tc *testcase) run(t *hivesim.T) {
 		}
 		// set expected payload return status
 		expectedStatus := "VALID"
-		if !engineNewPayload.Valid {
+		if engineNewPayload.ValidationError != nil {
 			expectedStatus = "INVALID"
 		}
 		// check payload status matches expected

--- a/simulators/ethereum/pyspec/types.go
+++ b/simulators/ethereum/pyspec/types.go
@@ -78,7 +78,7 @@ type engineNewPayload struct {
 	BlobVersionedHashes   []common.Hash       `json:"expectedBlobVersionedHashes"`
 	ParentBeaconBlockRoot *common.Hash        `json:"parentBeaconBlockRoot"`
 	Version               math.HexOrDecimal64 `json:"version"`
-	Valid                 bool                `json:"valid"`
+	ValidationError       *string             `json:"validationError"`
 	ErrorCode             int64               `json:"errorCode,string"`
 
 	HiveExecutionPayload *typ.ExecutableData


### PR DESCRIPTION
## 🗒️ Description

Updates pyspec to use the latest fixture release, with additional tests and slight format change:
https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.0