### PR TITLE
clients/reth: fix merge netsplit block in mapper

### DIFF
--- a/clients/reth/mapper.jq
+++ b/clients/reth/mapper.jq
@@ -52,7 +52,7 @@ def to_bool:
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
     "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
-    "parisBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED|to_bool,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,


### PR DESCRIPTION
reth does not deserialize `parisBlock` to anything, so this is incorrect. reth is compatible with the geth genesis format, including `mergeNetsplitBlock`, so this changes the mapper back.

Fixes https://github.com/paradigmxyz/reth/issues/6291