### PR TITLE
clients/erigon: Configure snapshots flag

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -139,6 +139,9 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.jwtsecret=/jwt.secret"
 fi
 
+# Configure snapshots.
+FLAGS="$FLAGS --snapshots=false"
+
 # Launch the main client.
 FLAGS="$FLAGS --nat=none"
 echo "Running erigon with flags $FLAGS"


### PR DESCRIPTION
## Description

Sets the snapshots flag to false when running simulations for erigon.

Fixes the existing test failures on [hivecancun](https://hivecancun.ethdevops.io/#client=erigon_cancun-git).