### PR TITLE
clients/go-ethereum: Remove miner gasprice flag

### DIFF
--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -140,7 +140,6 @@ fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then
     FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"
 fi
-FLAGS="$FLAGS --miner.gasprice 16000000000"
 
 # Configure LES.
 if [ "$HIVE_LES_SERVER" == "1" ]; then


### PR DESCRIPTION
## Description

Removes the miner gasprice flag for go-ethereum in alignment with the following PR:
https://github.com/ethereum/go-ethereum/pull/28933

Fixes additional test failures on [hivecancun](https://hivecancun.ethdevops.io/#client=go-ethereum_cancun-git).