### PR TITLE
simulators/ethereum/engine: Expect error code for invalid payload attributes tests

### DIFF
--- a/simulators/ethereum/engine/suites/engine/payload_attributes.go
+++ b/simulators/ethereum/engine/suites/engine/payload_attributes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/hive/simulators/ethereum/engine/clmock"
 	"github.com/ethereum/hive/simulators/ethereum/engine/config"
+	"github.com/ethereum/hive/simulators/ethereum/engine/globals"
 	"github.com/ethereum/hive/simulators/ethereum/engine/helper"
 	"github.com/ethereum/hive/simulators/ethereum/engine/test"
 )
@@ -72,7 +73,7 @@ func (tc InvalidPayloadAttributesTest) Execute(t *test.Env) {
 				r.ExpectPayloadID(nil)
 			} else {
 				r := t.TestEngine.TestEngineForkchoiceUpdated(&fcu, attr, t.CLMock.LatestPayloadBuilt.Timestamp)
-				r.ExpectError()
+				r.ExpectErrorCode(*globals.INVALID_PAYLOAD_ATTRIBUTES)
 
 				// Check that the forkchoice was applied, regardless of the error
 				s := t.TestEngine.TestHeaderByNumber(Head)


### PR DESCRIPTION
## Description

Following this PR: https://github.com/ethereum/hive/pull/974

Some clients are passing: `"Invalid PayloadAttributes, Missing BeaconRoot, Syncing=False"` returning the invalid parameters error code -32602, this should be -38003. Although the purpose of the test is to check that the fcu head is updated, the following change adds further verification by additionally expecting the correct error code response.