### PR TITLE
clients/erigon: Increase blobpool limit in Erigon

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -131,7 +131,7 @@ FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net,txpool,w
 FLAGS="$FLAGS --ws --ws.port=8546"
 
 # Increase blob slots for tests
-FLAGS="$FLAGS --txpool.blobslots=1000"
+FLAGS="$FLAGS --txpool.blobslots=1000 --txpool.totalblobpoollimit=10000"
 
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"


### PR DESCRIPTION
This became necessary because of this test: `Re-Org Back into Canonical Chain, Depth=10, Execute Side Payload on Re-Org`
That uses about 850 blobs in its peak. It can be noted that the default number of blobs allowed in erigon's txpool at the moment is 480.