### PR TITLE
clients/reth: make sure `Pruner` doesn't start on tests

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -50,8 +50,9 @@ case "$HIVE_LOGLEVEL" in
 esac
 
 # Create the data directory.
-mkdir /reth-hive-datadir
-FLAGS="$FLAGS --datadir /reth-hive-datadir"
+DATADIR="/reth-hive-datadir"
+mkdir $DATADIR
+FLAGS="$FLAGS --datadir $DATADIR"
 
 # TODO If a specific network ID is requested, use that
 #if [ "$HIVE_NETWORK_ID" != "" ]; then
@@ -79,6 +80,9 @@ echo $FLAGS
 # Initialize the local testchain with the genesis state
 echo "Initializing database with genesis state..."
 $reth init $FLAGS --chain /genesis.json
+
+# Make sure pruner doesn't start
+echo -e "[prune]\\nblock_interval = 500_000" >> $DATADIR/reth.toml
 
 # make sure we use the same genesis each time
 FLAGS="$FLAGS --chain /genesis.json"


### PR DESCRIPTION
Reth has a pruner job that locks the database for writing. If that happens, any FCU is skipped. 

Although it's not that common live (and will be improved on the future), it doesn't go well with hive tests.

 This configuration change makes sure the pruner is not started during tests.