### PR TITLE
simulators/eth2: Fix Docker golang version

### DIFF
--- a/simulators/eth2/engine/Dockerfile
+++ b/simulators/eth2/engine/Dockerfile
@@ -1,5 +1,5 @@
 # Build the simulator binary
-FROM golang:1-alpine AS builder
+FROM golang:1.20-alpine AS builder
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/eth2/testnet/Dockerfile
+++ b/simulators/eth2/testnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1-alpine AS builder
+FROM golang:1.20-alpine AS builder
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/eth2/withdrawals/Dockerfile
+++ b/simulators/eth2/withdrawals/Dockerfile
@@ -1,5 +1,5 @@
 # Build the simulator binary
-FROM golang:1-alpine AS builder
+FROM golang:1.20-alpine AS builder
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.


### PR DESCRIPTION
Fixes the golang docker image version to `golang:1.20-alpine` instead of `golang:1-alpine`, since the former now redirects to `golang:1.21-alpine` which breaks compilation.