### PR TITLE
clients/nethermind: enable snap serving

### DIFF
--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -109,6 +109,9 @@ def base_config:
       "BlocksDir": "/blocks",
       "KeysDir": "/keys"
     },
+    "Sync": {
+      "SnapServingEnabled": true,
+    },
   }
 ;
 


### PR DESCRIPTION
## Description

Adds the `$HIVE_NODETYPE` env var to the nethermind start up script. Sets the appropriate flags if the node type is set to snap.

Passes the previously failed sync tests: https://hivetests.ethdevops.io/#suite=snap&client=nethermind