### PR TITLE
clients/portal: update Dockerfiles to use baseimage/tag arg format

### DIFF
--- a/clients/fluffy/Dockerfile
+++ b/clients/fluffy/Dockerfile
@@ -1,6 +1,7 @@
-ARG branch=amd64-master-latest
+ARG baseimage=statusim/nimbus-fluffy
+ARG tag=amd64-master-latest
 
-FROM statusim/nimbus-fluffy:$branch
+FROM $baseimage:$tag
 
 ADD fluffy.sh /fluffy.sh
 RUN chmod +x /fluffy.sh

--- a/clients/trin-bridge/Dockerfile
+++ b/clients/trin-bridge/Dockerfile
@@ -1,4 +1,7 @@
-FROM portalnetwork/trin:latest-bridge
+ARG baseimage=portalnetwork/trin
+ARG tag=latest-bridge
+
+FROM $baseimage:$tag
 
 ADD https://raw.githubusercontent.com/ethereum/portal-spec-tests/master/tests/mainnet/history/hive/test_data_collection_of_forks_blocks.yaml /test_data_collection_of_forks_blocks.yaml
 ADD trin_bridge.sh /trin_bridge.sh

--- a/clients/trin-bridge/trin_bridge.sh
+++ b/clients/trin-bridge/trin_bridge.sh
@@ -13,4 +13,4 @@ else
     exit 1
 fi
 
-RUST_LOG=debug portal-bridge --node-count 1 $FLAGS --executable-path ./usr/bin/trin --mode test:/test_data_collection_of_forks_blocks.yaml --el-provider test --external-ip $IP_ADDR --epoch-accumulator-path . trin
+RUST_LOG=trace portal-bridge --node-count 1 $FLAGS --executable-path ./usr/bin/trin --mode test:/test_data_collection_of_forks_blocks.yaml --el-provider test --external-ip $IP_ADDR --epoch-accumulator-path . trin

--- a/clients/trin/Dockerfile
+++ b/clients/trin/Dockerfile
@@ -1,6 +1,7 @@
-ARG branch=latest
+ARG baseimage=portalnetwork/trin
+ARG tag=latest
 
-FROM portalnetwork/trin:$branch
+FROM $baseimage:$tag
 
 ADD trin.sh /trin.sh
 RUN chmod +x /trin.sh

--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -16,4 +16,4 @@ else
     FLAGS="$FLAGS --networks history"
 fi
 
-RUST_LOG=debug trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none $FLAGS
+RUST_LOG=trace trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none $FLAGS

--- a/clients/ultralight/Dockerfile
+++ b/clients/ultralight/Dockerfile
@@ -1,4 +1,8 @@
-FROM ghcr.io/ethereumjs/ultralight:latest
+
+ARG baseimage=ghcr.io/ethereumjs/ultralight
+ARG tag=latest
+
+FROM $baseimage:$tag
 
 COPY ultralight.sh /ultralight.sh
 RUN chmod +x /ultralight.sh


### PR DESCRIPTION
portal-hive wasn't pulling the latest docker images I think this was why