### PR TITLE
simulators/portal: bump version of ethportal-api used

### DIFF
--- a/simulators/portal/beacon/Cargo.toml
+++ b/simulators/portal/beacon/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ognyan Genev <ognian.genev@gmail.com>", "Kolby ML (Moroz Liebl) <kol
 edition = "2021"
 
 [dependencies]
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "1829841efca273844be93adf53ab84c2d1a020ed" }
+ethportal-api = { git = "https://github.com/ethereum/trin", tag = "v0.1.0-alpha.22" }
 hivesim = { git = "https://github.com/ethereum/portal-hive", rev = "8ff1e3d3c941dd00d56dacd777a5dfb71edf402f" }
 futures = "0.3.25"
 serde_json = "1.0.87"

--- a/simulators/portal/beacon/Dockerfile
+++ b/simulators/portal/beacon/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install clang -y
 # copy over manifests and source to build image
 COPY Cargo.toml ./Cargo.toml
 COPY src ./src
+RUN apt-get update && apt-get install clang -y
 
 # build for release
 RUN cargo build --release

--- a/simulators/portal/history/Cargo.toml
+++ b/simulators/portal/history/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ognyan Genev <ognian.genev@gmail.com>", "Kolby ML (Moroz Liebl) <kol
 edition = "2021"
 
 [dependencies]
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "2a32224e3c2b0b80bc37c1b692c33016371f197a" }
+ethportal-api = { git = "https://github.com/ethereum/trin", tag = "v0.1.0-alpha.22" }
 portal-spec-test-utils-rs = { git = "https://github.com/ethereum/portal-spec-tests", rev = "d1e996d0d4dc2136b3cd38d9e25cdc3a6b74dcd9" }
 hivesim = { git = "https://github.com/ethereum/portal-hive", rev = "8ff1e3d3c941dd00d56dacd777a5dfb71edf402f" }
 futures = "0.3.25"

--- a/simulators/portal/history/Dockerfile
+++ b/simulators/portal/history/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /history
 # copy over manifests and source to build image
 COPY Cargo.toml ./Cargo.toml
 COPY src ./src
+RUN apt-get update && apt-get install clang -y
 
 # build for release
 RUN cargo build --release

--- a/simulators/portal/history/src/suites/mesh.rs
+++ b/simulators/portal/history/src/suites/mesh.rs
@@ -1,7 +1,7 @@
 use crate::suites::constants::TRIN_BRIDGE_CLIENT_TYPE;
 use ethportal_api::jsonrpsee::core::__reexports::serde_json;
 use ethportal_api::types::distance::{Metric, XorMetric};
-use ethportal_api::types::portal::ContentInfo;
+use ethportal_api::types::history::ContentInfo;
 use ethportal_api::{
     Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
 };
@@ -145,8 +145,8 @@ dyn_async! {
         match client_a.rpc.find_content(enrs[0].clone(), header_with_proof_key.clone()).await {
             Ok(result) => {
                 match result {
-                    ContentInfo::Content{ content: ethportal_api::PossibleHistoryContentValue::ContentPresent(val), utp_transfer } => {
-                        if val != header_with_proof_value {
+                    ContentInfo::Content{ content, utp_transfer } => {
+                        if content != header_with_proof_value {
                             panic!("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
                         }
 

--- a/simulators/portal/history/src/suites/rpc_compat.rs
+++ b/simulators/portal/history/src/suites/rpc_compat.rs
@@ -1,8 +1,6 @@
 use crate::suites::constants::TRIN_BRIDGE_CLIENT_TYPE;
 use ethportal_api::types::enr::generate_random_remote_enr;
-use ethportal_api::types::portal::ContentInfo;
 use ethportal_api::Discv5ApiClient;
-use ethportal_api::PossibleHistoryContentValue::{ContentAbsent, ContentPresent};
 use ethportal_api::{HistoryContentKey, HistoryNetworkApiClient};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
@@ -222,18 +220,8 @@ dyn_async! {
 
         match content_key {
             Ok(content_key) => {
-                let response = HistoryNetworkApiClient::local_content(&client.rpc, content_key).await;
-
-                match response {
-                    Ok(response) => {
-                        match response {
-                            ContentAbsent => (),
-                            _ => panic!("Expected ContentAbsent, got ContentPresent")
-                        }
-                    },
-                    Err(err) => {
-                        panic!("{}", &err.to_string());
-                    },
+                if let Ok(response)  = HistoryNetworkApiClient::local_content(&client.rpc, content_key).await {
+                    panic!("Expected to recieve an error because content wasn't found {response:?}");
                 }
             }
             Err(err) => {
@@ -311,18 +299,8 @@ dyn_async! {
                 }
 
                 // Here we are calling local_content RPC to test if the content is present
-                let response = HistoryNetworkApiClient::local_content(&client.rpc, content_key).await;
-
-                match response {
-                    Ok(response) => {
-                        match response {
-                            ContentPresent(_) => (),
-                            _ => panic!("Expected ContentPresent, got ContentAbsent")
-                        }
-                    },
-                    Err(err) => {
-                        panic!("{}", &err.to_string());
-                    },
+                if let Err(err) = HistoryNetworkApiClient::local_content(&client.rpc, content_key).await {
+                    panic!("Expected content returned from local_content to be present {}", &err.to_string());
                 }
             }
             Err(err) => {
@@ -576,22 +554,8 @@ dyn_async! {
         };
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
 
-        match HistoryNetworkApiClient::recursive_find_content(&client.rpc, header_with_proof_key).await {
-            Ok(result) => {
-                match result {
-                    ContentInfo::Content{ content: ethportal_api::PossibleHistoryContentValue::ContentAbsent, utp_transfer } => {
-                        if utp_transfer {
-                            panic!("Error: Unexpected RecursiveFindContent response: utp_transfer was supposed to be false");
-                        }
-                    },
-                    other => {
-                        panic!("Error: Unexpected RecursiveFindContent response: {other:?}");
-                    }
-                }
-            },
-            Err(err) => {
-                panic!("Error: Unable to get response from RecursiveFindContent request: {err:?}");
-            }
+        if let Ok(content) = HistoryNetworkApiClient::recursive_find_content(&client.rpc, header_with_proof_key).await {
+            panic!("Error: Unexpected RecursiveFindContent expected to not get the content and instead get an error: {content:?}");
         }
     }
 }

--- a/simulators/portal/history/src/suites/trin_bridge.rs
+++ b/simulators/portal/history/src/suites/trin_bridge.rs
@@ -4,7 +4,6 @@ use super::constants::{
 };
 use ethportal_api::HistoryContentKey;
 use ethportal_api::HistoryContentValue;
-use ethportal_api::PossibleHistoryContentValue;
 use ethportal_api::{Discv5ApiClient, HistoryNetworkApiClient};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
@@ -105,16 +104,9 @@ dyn_async! {
         let mut result = vec![];
         for (index, (content_key, content_value)) in content_vec.into_iter().enumerate() {
             match client.rpc.local_content(content_key.clone()).await {
-                Ok(possible_content) => {
-                   match possible_content {
-                        PossibleHistoryContentValue::ContentPresent(content) => {
-                            if content != content_value {
-                                result.push(format!("Error content received for block {} was different then expected", comments[index]));
-                            }
-                        }
-                        PossibleHistoryContentValue::ContentAbsent => {
-                            result.push(format!("Error content for block {} was absent", comments[index]));
-                        }
+                Ok(content) => {
+                    if content != content_value {
+                        result.push(format!("Error content received for block {} was different then expected", comments[index]));
                     }
                 }
                 Err(err) => {

--- a/simulators/portal/history/src/suites/trin_bridge.rs
+++ b/simulators/portal/history/src/suites/trin_bridge.rs
@@ -106,7 +106,7 @@ dyn_async! {
             match client.rpc.local_content(content_key.clone()).await {
                 Ok(content) => {
                     if content != content_value {
-                        result.push(format!("Error content received for block {} was different then expected", comments[index]));
+                        result.push(format!("Error content received for block {} was different then expected: Provided: {content:?} Expected: {content_value:?}", comments[index]));
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
We were using an older version which had a few bugs and is soon to be out dated with the spec. 