### PR TITLE
circleci: Use default ubuntu machine

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -29,7 +29,7 @@ jobs:
   # hive needs to be able to talk to the docker containers it creates.
   smoke-tests:
     machine:
-      image: ubuntu-2004:202201-02
+      image: default
     steps:
       - checkout
       - attach_workspace: {at: "/tmp/build"}

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: {at: "/tmp/build"}
-      - setup_remote_docker: {version: 20.10.14}
+      - setup_remote_docker
       - run:
           command: "/tmp/build/hive --sim=smoke/genesis --client=go-ethereum --loglevel 5"
       - run:


### PR DESCRIPTION
Circleci smoke-test begun failing on march 4th as part of their brownout schedule of deprecated images.

This PR changes the machine to the default one as recommended in their post: https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177/9