### PR TITLE
Enable snap serving on nethermind

### DIFF
--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -109,6 +109,9 @@ def base_config:
       "BlocksDir": "/blocks",
       "KeysDir": "/keys"
     },
+    "Sync": {
+      "SnapServingEnabled": true,
+    },
   }
 ;
 


### PR DESCRIPTION
- Add` flag to turn on snap serving on nethermind.
- To test `./hive --client nethermind --sim devp2p --sim.limit "snap/*" --sim.parallelism 32`