### PR TITLE
clients/nimbus-bn,vc: Use ethpandaops prebuilt docker images

### DIFF
--- a/clients/nimbus-bn/Dockerfile
+++ b/clients/nimbus-bn/Dockerfile
@@ -1,36 +1,16 @@
-# Docker container spec for building the unstable branch of nimbus.
-
-FROM debian:buster-slim AS build
-
 ARG tag=unstable
-ARG github=status-im/nimbus-eth2
+ARG baseimage=ethpandaops/nimbus-eth2
 
-RUN apt-get update \
- && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM $baseimage:$tag AS source
 
-RUN git clone --recurse-submodules --depth 1 --branch "$tag" https://github.com/$github
-
-WORKDIR /nimbus-eth2
-
-RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
-
-RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_beacon_node && \
-    mv build/nimbus_beacon_node /usr/bin/
-
-# --------------------------------- #
-# Starting new image to reduce size #
-# --------------------------------- #
-
-FROM debian:buster-slim AS deploy
+FROM debian:bookworm-slim AS deploy
 
 RUN apt-get update \
  && apt-get install -y librocksdb-dev bash curl jq\
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY --from=build /usr/bin/nimbus_beacon_node /usr/bin/nimbus_beacon_node
+COPY --from=source /home/user/nimbus-eth2/build/nimbus_beacon_node /usr/bin/nimbus_beacon_node
 
 RUN usr/bin/nimbus_beacon_node --version > /version.txt
 

--- a/clients/nimbus-bn/Dockerfile.git
+++ b/clients/nimbus-bn/Dockerfile.git
@@ -1,0 +1,46 @@
+# Docker container spec for building the unstable branch of nimbus.
+
+FROM debian:buster-slim AS build
+
+ARG tag=unstable
+ARG github=status-im/nimbus-eth2
+
+RUN apt-get update \
+ && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN git clone --recurse-submodules --depth 1 --branch "$tag" https://github.com/$github
+
+WORKDIR /nimbus-eth2
+
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_beacon_node && \
+    mv build/nimbus_beacon_node /usr/bin/
+
+# --------------------------------- #
+# Starting new image to reduce size #
+# --------------------------------- #
+
+FROM debian:buster-slim AS deploy
+
+RUN apt-get update \
+ && apt-get install -y librocksdb-dev bash curl jq\
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /usr/bin/nimbus_beacon_node /usr/bin/nimbus_beacon_node
+
+RUN usr/bin/nimbus_beacon_node --version > /version.txt
+
+ADD nimbus_bn.sh /nimbus_bn.sh
+RUN chmod +x /nimbus_bn.sh
+ADD nimbus_version.sh /nimbus_version.sh
+RUN chmod +x /nimbus_version.sh
+
+RUN /nimbus_version.sh > /version.txt
+
+EXPOSE 9000 9000/udp 4000 4000/udp
+
+ENTRYPOINT ["/nimbus_bn.sh"]

--- a/clients/nimbus-vc/Dockerfile
+++ b/clients/nimbus-vc/Dockerfile
@@ -1,36 +1,16 @@
-# Docker container spec for building the unstable branch of nimbus.
-
-FROM debian:buster-slim AS build
-
 ARG tag=unstable
-ARG github=status-im/nimbus-eth2
+ARG baseimage=ethpandaops/nimbus-validator-client
 
-RUN apt-get update \
- && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM $baseimage:$tag AS source
 
-RUN git clone --recurse-submodules --depth 1 --branch "$tag" https://github.com/$github
-
-WORKDIR /nimbus-eth2
-
-RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
-
-RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_validator_client && \
-    mv build/nimbus_validator_client /usr/bin/
-
-# --------------------------------- #
-# Starting new image to reduce size #
-# --------------------------------- #
-
-FROM debian:buster-slim AS deploy
+FROM debian:bookworm-slim AS deploy
 
 RUN apt-get update \
  && apt-get install -y librocksdb-dev bash curl jq\
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY --from=build /usr/bin/nimbus_validator_client /usr/bin/nimbus_validator_client
+COPY --from=source /home/user/nimbus-eth2/build/nimbus_validator_client /usr/bin/nimbus_validator_client
 
 # Add the startup script.
 ADD nimbus_vc.sh /nimbus_vc.sh

--- a/clients/nimbus-vc/Dockerfile.git
+++ b/clients/nimbus-vc/Dockerfile.git
@@ -1,0 +1,44 @@
+# Docker container spec for building the unstable branch of nimbus.
+
+FROM debian:buster-slim AS build
+
+ARG tag=unstable
+ARG github=status-im/nimbus-eth2
+
+RUN apt-get update \
+ && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN git clone --recurse-submodules --depth 1 --branch "$tag" https://github.com/$github
+
+WORKDIR /nimbus-eth2
+
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+
+RUN NPROC=$(nproc); make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" nimbus_validator_client && \
+    mv build/nimbus_validator_client /usr/bin/
+
+# --------------------------------- #
+# Starting new image to reduce size #
+# --------------------------------- #
+
+FROM debian:buster-slim AS deploy
+
+RUN apt-get update \
+ && apt-get install -y librocksdb-dev bash curl jq\
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /usr/bin/nimbus_validator_client /usr/bin/nimbus_validator_client
+
+# Add the startup script.
+ADD nimbus_vc.sh /nimbus_vc.sh
+RUN chmod +x /nimbus_vc.sh
+
+ADD nimbus_version.sh /nimbus_version.sh
+RUN chmod +x /nimbus_version.sh
+
+RUN /nimbus_version.sh > /version.txt
+
+ENTRYPOINT ["/nimbus_vc.sh"]


### PR DESCRIPTION
Currently nimbus images take too long to generate and they seem to randomly trigger a full rebuild even when the image was just recently built.

This PR changes the default Dockerfile to use the prebuilt ethpandaops images to speed up test execution while leaving the original file as the optional `Dockerfile.git` to be able to build from source and run hive tests.