### PR TITLE
simulators/eth2/dencun: Fixes to builder tests

### DIFF
--- a/simulators/eth2/common/go.mod
+++ b/simulators/eth2/common/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.0
 require (
 	github.com/ethereum/go-ethereum v1.13.14
 	github.com/ethereum/hive v0.0.0-20231031133732-dcd7ddb75960
-	github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305003323-ebe431380e1c
+	github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20
 	github.com/google/uuid v1.6.0
 	github.com/herumi/bls-eth-go-binary v1.29.1
 	github.com/holiman/uint256 v1.2.4

--- a/simulators/eth2/common/go.sum
+++ b/simulators/eth2/common/go.sum
@@ -126,8 +126,8 @@ github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/hive v0.0.0-20231031133732-dcd7ddb75960 h1:7H9z2o/KImWQ/1PACU3ewsSFNxT/lzwYRnwit2YFqMg=
 github.com/ethereum/hive v0.0.0-20231031133732-dcd7ddb75960/go.mod h1:sV7LrFBlEii71kI9udVbUVj7SXIifZ2VzFjQ8S6rZns=
-github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305003323-ebe431380e1c h1:EBlnoT34Ea4Y7kVmmIoYqtdNvNmabQlir7SIQ0UCS/A=
-github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305003323-ebe431380e1c/go.mod h1:nag0wj4K1/0AEP1VAKwY08N4I9yymrwXsX4+n0YFfdw=
+github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20 h1:Bf9mev5lvesQIIpJtzO+vnGQ3Jv3NuLa2buY2+2pQzg=
+github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20/go.mod h1:nag0wj4K1/0AEP1VAKwY08N4I9yymrwXsX4+n0YFfdw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/ferranbt/fastssz v0.1.3 h1:ZI+z3JH05h4kgmFXdHuR1aWYsgrg7o+Fw7/NCzM16Mo=

--- a/simulators/eth2/dencun/go.mod
+++ b/simulators/eth2/dencun/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ethereum/go-ethereum v1.13.14
 	github.com/ethereum/hive v0.0.0-20231128202301-f931b46287a8
 	github.com/ethereum/hive/simulators/eth2/common v0.0.0-20230316220410-1364352c32a6
-	github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305003323-ebe431380e1c
+	github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20
 	github.com/lithammer/dedent v1.1.0
 	github.com/marioevz/blobber v1.1.1-0.20240228051014-aa5f0f9031a9
 	github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190

--- a/simulators/eth2/dencun/go.sum
+++ b/simulators/eth2/dencun/go.sum
@@ -164,8 +164,8 @@ github.com/ethereum/hive v0.0.0-20231128202301-f931b46287a8 h1:vpOgMOOh8lQHGL8lS
 github.com/ethereum/hive v0.0.0-20231128202301-f931b46287a8/go.mod h1:lT6CsiAFb+HTThYzu3veK2x2/BlazxNQD6KWPDlvjfo=
 github.com/ethereum/hive/simulators/eth2/common v0.0.0-20230316220410-1364352c32a6 h1:LcSUNGwQuJyR/gdPcsif57yKX+3MyhpoAuChzR8k6Yk=
 github.com/ethereum/hive/simulators/eth2/common v0.0.0-20230316220410-1364352c32a6/go.mod h1:FX4oxNyTNw/P+TUWrb7vva7o/rFI0pHO7OYdtG6EtN4=
-github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305003323-ebe431380e1c h1:EBlnoT34Ea4Y7kVmmIoYqtdNvNmabQlir7SIQ0UCS/A=
-github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305003323-ebe431380e1c/go.mod h1:nag0wj4K1/0AEP1VAKwY08N4I9yymrwXsX4+n0YFfdw=
+github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20 h1:Bf9mev5lvesQIIpJtzO+vnGQ3Jv3NuLa2buY2+2pQzg=
+github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20/go.mod h1:nag0wj4K1/0AEP1VAKwY08N4I9yymrwXsX4+n0YFfdw=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=

--- a/simulators/eth2/dencun/suites/base/execution.go
+++ b/simulators/eth2/dencun/suites/base/execution.go
@@ -19,8 +19,8 @@ import (
 var Deneb string = "deneb"
 
 var (
-	normalTxAccounts = globals.TestAccounts[:len(globals.TestAccounts)/2]
-	blobTxAccounts   = globals.TestAccounts[len(globals.TestAccounts)/2:]
+	blobTxAccounts   = globals.TestAccounts[:len(globals.TestAccounts)/2]
+	normalTxAccounts = globals.TestAccounts[len(globals.TestAccounts)/2:]
 )
 
 func WithdrawalAddress(vI beacon.ValidatorIndex) common.Address {

--- a/simulators/eth2/dencun/suites/builder/config.go
+++ b/simulators/eth2/dencun/suites/builder/config.go
@@ -16,6 +16,11 @@ var REQUIRES_FINALIZATION_TO_ACTIVATE_BUILDER = []string{
 	"teku",
 }
 
+var (
+	DEFAULT_FORK_WAIT_EPOCHS                  = int64(2)
+	DEFAULT_FORK_WAIT_FOR_FINALIZATION_EPOCHS = int64(5)
+)
+
 type BuilderTestSpec struct {
 	suite_base.BaseTestSpec
 	VerifyMissedSlotsCount      bool
@@ -31,7 +36,7 @@ func (ts BuilderTestSpec) GetTestnetConfig(
 ) *testnet.Config {
 	tc := ts.BaseTestSpec.GetTestnetConfig(allNodeDefinitions)
 
-	tc.DenebForkEpoch = big.NewInt(1)
+	tc.DenebForkEpoch = big.NewInt(DEFAULT_FORK_WAIT_EPOCHS)
 
 	if len(
 		allNodeDefinitions.FilterByCL(
@@ -40,7 +45,7 @@ func (ts BuilderTestSpec) GetTestnetConfig(
 	) > 0 {
 		// At least one of the CLs require finalization to start requesting
 		// headers from the builder
-		tc.DenebForkEpoch = big.NewInt(5)
+		tc.DenebForkEpoch = big.NewInt(DEFAULT_FORK_WAIT_FOR_FINALIZATION_EPOCHS)
 	}
 
 	// Builders are always enabled for these tests


### PR DESCRIPTION
## Changes included
- Builder tests now wait until all clients' builders have proposed at least one block with blobs, because some tests were erroneously failing during the verification phase.
- Bumped the Dencun fork epoch on the builder tests for clients that do _not_ require finalization, since nimbus was now taking one epoch before starting to request payloads from the builder, which resulted in a test fail.
- Use fix in #1030 to keep track of the blobs in the blob spammer used by all `eth2/dencun` tests, which resulted in the blob KZG cache not being used due to the blob IDs being too high