### PR TITLE
simulators/ethereum/engine: TransactionCreator - Keep track of blobs

### DIFF
--- a/simulators/ethereum/engine/helper/blobs.go
+++ b/simulators/ethereum/engine/helper/blobs.go
@@ -224,6 +224,8 @@ func (blobId BlobID) GenerateBlob() (*typ.Blob, *typ.KZGCommitment, *typ.KZGProo
 	// Use precomputed KZG commitments and proofs if available
 	if preComputedKZGCommitment, preComputedProof := GetPrecomputedKZG(blobId); preComputedKZGCommitment != nil && preComputedProof != nil {
 		return &blob, preComputedKZGCommitment, preComputedProof, nil
+	} else {
+		fmt.Printf("INFO: No precomputed KZG for blob %d\n", blobId)
 	}
 	ctx_4844 := CryptoCtx()
 

--- a/simulators/ethereum/engine/helper/blobs.go
+++ b/simulators/ethereum/engine/helper/blobs.go
@@ -83,7 +83,7 @@ func GetBlobListByIndex(startIndex BlobID, endIndex BlobID) BlobIDs {
 		}
 	} else {
 		for i := uint64(0); i < count; i++ {
-			blobList[i] = endIndex - BlobID(i)
+			blobList[i] = startIndex - BlobID(i)
 		}
 	}
 

--- a/simulators/ethereum/engine/helper/tx.go
+++ b/simulators/ethereum/engine/helper/tx.go
@@ -258,8 +258,6 @@ type TransactionCreator interface {
 	MakeTransaction(sender SenderAccount, nonce uint64, blockTimestamp uint64) (typ.Transaction, error)
 }
 
-const BLOBS_PER_SENDER_ACCOUNT = 10000
-
 type BaseTransactionCreator struct {
 	Recipient  *common.Address
 	GasFee     *big.Int
@@ -267,6 +265,7 @@ type BaseTransactionCreator struct {
 	GasLimit   uint64
 	BlobGasFee *big.Int
 	BlobCount  *big.Int
+	BlobID     BlobID
 	Amount     *big.Int
 	Payload    []byte
 	AccessList types.AccessList
@@ -373,8 +372,8 @@ func (tc *BaseTransactionCreator) MakeTransaction(sender SenderAccount, nonce ui
 		}
 
 		// Need tx wrap data that will pass blob verification
-		blobID := BlobID((nonce * cancun.MAX_BLOBS_PER_BLOCK) + (sender.GetIndex() * BLOBS_PER_SENDER_ACCOUNT))
-		hashes, blobData, err := BlobDataGenerator(blobID, blobCount)
+		hashes, blobData, err := BlobDataGenerator(tc.BlobID, blobCount)
+		tc.BlobID += BlobID(blobCount)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Changes Included
- Modify `BaseTransactionCreator` transaction creator to keep track of blobs instead of jumping 10,000+ unused blob IDs
- Fix `GetBlobListByIndex` since it was returning negative blob IDs

Down to only one failing test in some clients, this issue was causing a panic in the simulator.