### PR TITLE
simulators/eth2: Update blobber

### DIFF
--- a/simulators/eth2/common/go.mod
+++ b/simulators/eth2/common/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/herumi/bls-eth-go-binary v1.29.1
 	github.com/holiman/uint256 v1.2.4
 	github.com/lithammer/dedent v1.1.0
-	github.com/marioevz/blobber v1.1.1-0.20240228051014-aa5f0f9031a9
+	github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34
 	github.com/marioevz/eth-clients v0.0.0-20231123180401-b4230c802498
 	github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190
 	github.com/pkg/errors v0.9.1

--- a/simulators/eth2/common/go.sum
+++ b/simulators/eth2/common/go.sum
@@ -366,8 +366,8 @@ github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/marioevz/blobber v1.1.1-0.20240228051014-aa5f0f9031a9 h1:0N0luMkryC9Z/UCsPnIdd3a6n1Iv786L8lRpBOp90GE=
-github.com/marioevz/blobber v1.1.1-0.20240228051014-aa5f0f9031a9/go.mod h1:7wGWXnUInWpcluqhusompgjT18fujAK/ibNxsuH4sgM=
+github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34 h1:8Dq4RK6bFDm6GJTU3iEaUCSt2+85GReA7wxfeAfYD0w=
+github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34/go.mod h1:7wGWXnUInWpcluqhusompgjT18fujAK/ibNxsuH4sgM=
 github.com/marioevz/eth-clients v0.0.0-20231123180401-b4230c802498 h1:FHzV7rVAhib6tRhR/e4UTWupqWw3ikIme06O1x96Ynk=
 github.com/marioevz/eth-clients v0.0.0-20231123180401-b4230c802498/go.mod h1:bhR5rKHekIvdWmsWUqRP6X6dLl05ohnH3X/+ZvKs3xg=
 github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033 h1:sn57n+lbJrLS8FKYs08W7TEzraTGOCQGrSC4hni6rYw=

--- a/simulators/eth2/dencun/go.mod
+++ b/simulators/eth2/dencun/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/hive/simulators/eth2/common v0.0.0-20230316220410-1364352c32a6
 	github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20
 	github.com/lithammer/dedent v1.1.0
-	github.com/marioevz/blobber v1.1.1-0.20240228051014-aa5f0f9031a9
+	github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34
 	github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190
 	github.com/protolambda/eth2api v0.0.0-20230316214135-5f8afbd6d05d
 	github.com/protolambda/zrnt v0.32.3

--- a/simulators/eth2/dencun/go.sum
+++ b/simulators/eth2/dencun/go.sum
@@ -446,8 +446,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/marioevz/blobber v1.1.1-0.20240228051014-aa5f0f9031a9 h1:0N0luMkryC9Z/UCsPnIdd3a6n1Iv786L8lRpBOp90GE=
-github.com/marioevz/blobber v1.1.1-0.20240228051014-aa5f0f9031a9/go.mod h1:7wGWXnUInWpcluqhusompgjT18fujAK/ibNxsuH4sgM=
+github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34 h1:8Dq4RK6bFDm6GJTU3iEaUCSt2+85GReA7wxfeAfYD0w=
+github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34/go.mod h1:7wGWXnUInWpcluqhusompgjT18fujAK/ibNxsuH4sgM=
 github.com/marioevz/eth-clients v0.0.0-20231123180401-b4230c802498 h1:FHzV7rVAhib6tRhR/e4UTWupqWw3ikIme06O1x96Ynk=
 github.com/marioevz/eth-clients v0.0.0-20231123180401-b4230c802498/go.mod h1:bhR5rKHekIvdWmsWUqRP6X6dLl05ohnH3X/+ZvKs3xg=
 github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033 h1:sn57n+lbJrLS8FKYs08W7TEzraTGOCQGrSC4hni6rYw=


### PR DESCRIPTION
Updates the blobber to the newest main which contains the following PRs:
https://github.com/marioevz/blobber/pull/39
https://github.com/marioevz/blobber/pull/41

Fixes test failures in lodestar.