### PR TITLE
hive,libhive: add `simulatorsVersion` to hive and results JSONs

### DIFF
--- a/cmd/hiveview/assets/lib/app-common.js
+++ b/cmd/hiveview/assets/lib/app-common.js
@@ -32,6 +32,11 @@ function hiveInfoHTML(data) {
         let link = makeLink(url, data.sourceCommit.substring(0, 8));
         txt += '<span>commit: ' + link.outerHTML + '</span>';
     }
+    if (data.simulatorsVersion) {
+        let url = 'https://github.com/ethereum/hive/commits/' + escape(data.simulatorsVersion);
+        let link = makeLink(url, data.simulatorsVersion.substring(0, 8));
+        txt += '<span>simulators: ' + link.outerHTML + '</span>';
+    }
     return txt;
 }
 

--- a/hive.go
+++ b/hive.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"regexp"
 	"strings"
@@ -114,6 +115,7 @@ func main() {
 		SimRandomSeed:      *simRandomSeed,
 		SimDurationLimit:   *simTimeLimit,
 		ClientStartTimeout: *clientTimeout,
+		SimulatorsVersion:  simulatorsVersion(),
 	}
 	runner := libhive.NewRunner(inv, builder, cb)
 
@@ -188,4 +190,14 @@ func flagIsSet(name string) bool {
 		}
 	})
 	return found
+}
+
+func simulatorsVersion() (commit *string) {
+	// Get the current folder's HEAD commit.
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return nil
+	}
+	output := strings.TrimSpace(string(out[:]))
+	return &output
 }

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -22,11 +22,12 @@ func (tsID TestID) String() string {
 
 // TestSuite is a single run of a simulator, a collection of testcases.
 type TestSuite struct {
-	ID             TestSuiteID          `json:"id"`
-	Name           string               `json:"name"`
-	Description    string               `json:"description"`
-	ClientVersions map[string]string    `json:"clientVersions"`
-	TestCases      map[TestID]*TestCase `json:"testCases"`
+	ID                TestSuiteID          `json:"id"`
+	Name              string               `json:"name"`
+	Description       string               `json:"description"`
+	ClientVersions    map[string]string    `json:"clientVersions"`
+	SimulatorsVersion *string              `json:"simulatorsVersion,omitempty"`
+	TestCases         map[TestID]*TestCase `json:"testCases"`
 
 	SimulatorLog   string `json:"simLog"`         // path to simulator log-file simulator. (may be shared with multiple suites)
 	TestDetailsLog string `json:"testDetailsLog"` // the test details output file
@@ -74,9 +75,10 @@ type ClientInfo struct {
 
 // HiveInstance contains information about hive itself.
 type HiveInstance struct {
-	SourceCommit string `json:"sourceCommit"`
-	SourceDate   string `json:"sourceDate"`
-	BuildDate    string `json:"buildDate"`
+	SourceCommit      string  `json:"sourceCommit"`
+	SourceDate        string  `json:"sourceDate"`
+	BuildDate         string  `json:"buildDate"`
+	SimulatorsVersion *string `json:"simulatorsVersion,omitempty"`
 }
 
 // ClientDefinition is served by the /clients API endpoint to list the available clients

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -104,7 +104,7 @@ func (r *Runner) Run(ctx context.Context, sim string, env SimEnv) (SimResult, er
 	if err := createWorkspace(env.LogDir); err != nil {
 		return SimResult{}, err
 	}
-	writeInstanceInfo(env.LogDir)
+	writeInstanceInfo(env.LogDir, env.SimulatorsVersion)
 	return r.run(ctx, sim, env)
 }
 
@@ -303,9 +303,10 @@ func createWorkspace(logdir string) error {
 	return nil
 }
 
-func writeInstanceInfo(logdir string) {
+func writeInstanceInfo(logdir string, simulatorsVersion *string) {
 	var obj HiveInstance
 	obj.SourceCommit, obj.SourceDate = hiveVersion()
+	obj.SimulatorsVersion = simulatorsVersion
 	buildDate := hiveBuildTime()
 	if !buildDate.IsZero() {
 		obj.BuildDate = buildDate.Format("2006-01-02T15:04:05Z")

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -48,6 +48,9 @@ type SimEnv struct {
 	// This configures the amount of time the simulation waits
 	// for the client to open port 8545 after launching the container.
 	ClientStartTimeout time.Duration
+
+	// Information about the simulators to put in the results.
+	SimulatorsVersion *string
 }
 
 // SimResult summarizes the results of a simulation run.
@@ -395,14 +398,15 @@ func (manager *TestManager) StartTestSuite(name string, description string) (Tes
 	}
 
 	manager.runningTestSuites[newSuiteID] = &TestSuite{
-		ID:              newSuiteID,
-		Name:            name,
-		Description:     description,
-		ClientVersions:  make(map[string]string),
-		TestCases:       make(map[TestID]*TestCase),
-		SimulatorLog:    manager.simLogFile,
-		TestDetailsLog:  testLogPath,
-		testDetailsFile: testLogFile,
+		ID:                newSuiteID,
+		Name:              name,
+		Description:       description,
+		ClientVersions:    make(map[string]string),
+		TestCases:         make(map[TestID]*TestCase),
+		SimulatorLog:      manager.simLogFile,
+		SimulatorsVersion: manager.config.SimulatorsVersion,
+		TestDetailsLog:    testLogPath,
+		testDetailsFile:   testLogFile,
 	}
 	manager.testSuiteCounter++
 	return newSuiteID, nil


### PR DESCRIPTION
Use git's command `git rev-parse HEAD` to obtain the current folder's HEAD commit and put it in:
- hive.json
- results json (`1*.json` in the logs folder)

If the git command fails, then the field will simply not show up in any of the json files.

This differs from the build commit since, even if we don't rebuild the hive binary on any given deployment, the simulator's commit will still be updated to the latest version of the folder. 

This will allow to better cross-reference any failing tests to either a newer client commit or a newer simulators commit.