### PR TITLE
clients/prysm: use `latest` tag instead of `latest-debug`

### DIFF
--- a/clients/prysm-bn/Dockerfile
+++ b/clients/prysm-bn/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=gcr.io/prysmaticlabs/prysm/beacon-chain
-ARG tag=latest-debug
+ARG tag=latest
 
 FROM $baseimage:$tag as upstream
 

--- a/clients/prysm-vc/Dockerfile
+++ b/clients/prysm-vc/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=gcr.io/prysmaticlabs/prysm/validator
-ARG tag=latest-debug
+ARG tag=latest
 
 FROM $baseimage:$tag as upstream
 


### PR DESCRIPTION
Prysm's tag `latest-debug` seems to be outdated by a couple of months.

Tag `latest` seems to be up to date, so use that instead.