### PR TITLE
simulators/eth2/dencun: Builder suite: Poll mock builder to wait for the CL to request payloads

### DIFF
--- a/simulators/eth2/common/go.mod
+++ b/simulators/eth2/common/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34
 	github.com/marioevz/eth-clients v0.0.0-20231123180401-b4230c802498
-	github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190
+	github.com/marioevz/mock-builder v1.2.1-0.20240312201838-ad9ba388e88b
 	github.com/pkg/errors v0.9.1
 	github.com/protolambda/bls12-381-util v0.0.0-20220416220906-d8552aa452c7
 	github.com/protolambda/eth2api v0.0.0-20230316214135-5f8afbd6d05d

--- a/simulators/eth2/common/go.sum
+++ b/simulators/eth2/common/go.sum
@@ -374,6 +374,8 @@ github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033 h1:sn57n+lbJrLS8F
 github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033/go.mod h1:hcwWCT4sF1X7KsMZ535MvDZVk5M20Uyj+x2LARZjQsM=
 github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190 h1:vBXJeLFGRKZid18H4JQ+vhR+AQKU6fkx0Uc8JVMc3OI=
 github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190/go.mod h1:17VX12ir8TOY2Ln2vy3jhjeVIGfrwmcsxY9VI0ZP1Zk=
+github.com/marioevz/mock-builder v1.2.1-0.20240312201838-ad9ba388e88b h1:tQ+fxfY5YHxOimJN1/NJ/ofPGMZA1ZX0OsU2Rm/xfE0=
+github.com/marioevz/mock-builder v1.2.1-0.20240312201838-ad9ba388e88b/go.mod h1:17VX12ir8TOY2Ln2vy3jhjeVIGfrwmcsxY9VI0ZP1Zk=
 github.com/marioevz/zrnt v0.26.2-0.20231109183115-d2098ec1f42c h1:ZwKLkGVKnAq1JZql6SBrQici0la1X7APcbBLwmrSsd4=
 github.com/marioevz/zrnt v0.26.2-0.20231109183115-d2098ec1f42c/go.mod h1:ZctXHBa/2rlF85iao8oqQ8264DbEBBGWr6lwIOW2yv4=
 github.com/marioevz/ztyp v0.0.0-20231106221254-dd6f24f13fd9 h1:e40k7kQLw2jyDg4+Mc+TVSSfm1TO51NxPZo9T7nVCzM=

--- a/simulators/eth2/dencun/go.mod
+++ b/simulators/eth2/dencun/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ethereum/hive/simulators/ethereum/engine v0.0.0-20240305231022-f69df863de20
 	github.com/lithammer/dedent v1.1.0
 	github.com/marioevz/blobber v1.1.1-0.20240306221924-a7e22e59ea34
-	github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190
+	github.com/marioevz/mock-builder v1.2.1-0.20240312201838-ad9ba388e88b
 	github.com/protolambda/eth2api v0.0.0-20230316214135-5f8afbd6d05d
 	github.com/protolambda/zrnt v0.32.3
 )

--- a/simulators/eth2/dencun/go.sum
+++ b/simulators/eth2/dencun/go.sum
@@ -454,6 +454,8 @@ github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033 h1:sn57n+lbJrLS8F
 github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033/go.mod h1:hcwWCT4sF1X7KsMZ535MvDZVk5M20Uyj+x2LARZjQsM=
 github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190 h1:vBXJeLFGRKZid18H4JQ+vhR+AQKU6fkx0Uc8JVMc3OI=
 github.com/marioevz/mock-builder v1.1.1-0.20231123171249-08b59e943190/go.mod h1:17VX12ir8TOY2Ln2vy3jhjeVIGfrwmcsxY9VI0ZP1Zk=
+github.com/marioevz/mock-builder v1.2.1-0.20240312201838-ad9ba388e88b h1:tQ+fxfY5YHxOimJN1/NJ/ofPGMZA1ZX0OsU2Rm/xfE0=
+github.com/marioevz/mock-builder v1.2.1-0.20240312201838-ad9ba388e88b/go.mod h1:17VX12ir8TOY2Ln2vy3jhjeVIGfrwmcsxY9VI0ZP1Zk=
 github.com/marioevz/zrnt v0.26.2-0.20231109183115-d2098ec1f42c h1:ZwKLkGVKnAq1JZql6SBrQici0la1X7APcbBLwmrSsd4=
 github.com/marioevz/zrnt v0.26.2-0.20231109183115-d2098ec1f42c/go.mod h1:ZctXHBa/2rlF85iao8oqQ8264DbEBBGWr6lwIOW2yv4=
 github.com/marioevz/ztyp v0.0.0-20231106221254-dd6f24f13fd9 h1:e40k7kQLw2jyDg4+Mc+TVSSfm1TO51NxPZo9T7nVCzM=

--- a/simulators/eth2/dencun/suites/base/TESTS.md
+++ b/simulators/eth2/dencun/suites/base/TESTS.md
@@ -38,7 +38,8 @@ Sanity test to check the fork transition to deneb.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Capella
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -78,7 +79,8 @@ Sanity test to check the beacon clients can start with deneb genesis.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 

--- a/simulators/eth2/dencun/suites/base/config.go
+++ b/simulators/eth2/dencun/suites/base/config.go
@@ -171,9 +171,9 @@ func (ts BaseTestSpec) GetDescription() *utils.Description {
 		ts.GetValidatorCount()/uint64(ts.GetValidatingNodeCount()),
 	))
 	if ts.DenebGenesis {
-		desc.Add(utils.CategoryTestnetConfiguration, "- Genesis Fork: Deneb")
+		desc.Add(utils.CategoryTestnetConfiguration, "\n- Genesis Fork: Deneb")
 	} else {
-		desc.Add(utils.CategoryTestnetConfiguration, "- Genesis Fork: Capella")
+		desc.Add(utils.CategoryTestnetConfiguration, "\n- Genesis Fork: Capella")
 	}
 	execCredentialCount := ts.GetExecutionWithdrawalCredentialCount()
 	blsCredentialCount := ts.GetValidatorCount() - execCredentialCount

--- a/simulators/eth2/dencun/suites/base/execution.go
+++ b/simulators/eth2/dencun/suites/base/execution.go
@@ -238,6 +238,8 @@ func (ts BaseTestSpec) ExecutePostForkWait(
 					t.Logf("INFO: all clients have produced a block with blobs")
 					break out
 				}
+
+				testnet.BeaconClients().Running().PrintStatus(blobsWaitCtx)
 			}
 		}
 	}

--- a/simulators/eth2/dencun/suites/builder/TESTS.md
+++ b/simulators/eth2/dencun/suites/builder/TESTS.md
@@ -46,13 +46,13 @@ Test canonical chain includes deneb payloads built by the builder api.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 0
 - BLS Withdrawal Credentials Count: 128
-- Deneb/Cancun transition occurs on Epoch 1 or 5
-	- Epoch depends on whether builder workflow activation requires finalization [on the CL client](#clients-that-require-finalization-to-enable-builder).
+- Deneb starts from genesis.
 - Builder is enabled for all nodes
-- Builder action is only enabled after fork
+- Builder action is enabled from genesis
 - Nodes have the mock-builder configured as builder endpoint
 
 #### Verifications (Execution Client)
@@ -65,8 +65,7 @@ Test canonical chain includes deneb payloads built by the builder api.
 
 - For each blob transaction on the execution chain, the blob sidecars are available for the beacon block at the same height
 - The beacon block lists the correct commitments for each blob
-- Verify that the builder, up to before Deneb fork, has been able to produce blocks and they have been included in the canonical chain
-- After Deneb fork, the builder must be able to include blocks with blobs in the canonical chain, which implicitly verifies:
+- The builder must be able to include blocks with blobs in the canonical chain, which implicitly verifies:
 	- Consensus client is able to properly format header requests to the builder
 	- Consensus client is able to properly format blinded signed requests to the builder
 	- No signed block contained an invalid format or signature
@@ -97,13 +96,13 @@ building payloads with invalid parent beacon block root.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
-- Deneb/Cancun transition occurs on Epoch 1 or 5
-	- Epoch depends on whether builder workflow activation requires finalization [on the CL client](#clients-that-require-finalization-to-enable-builder).
+- Deneb starts from genesis.
 - Builder is enabled for all nodes
-- Builder action is only enabled after fork
+- Builder action is enabled from genesis
 - Nodes have the mock-builder configured as builder endpoint
 
 #### Verifications (Execution Client)
@@ -116,8 +115,7 @@ building payloads with invalid parent beacon block root.
 
 - For each blob transaction on the execution chain, the blob sidecars are available for the beacon block at the same height
 - The beacon block lists the correct commitments for each blob
-- Verify that the builder, up to before Deneb fork, has been able to produce blocks and they have been included in the canonical chain
-- After Deneb fork, the builder starts producing invalid payloads, verify that:
+- The builder starts producing invalid payloads, verify that:
 	- None of the produced payloads are included in the canonical chain
 - Since action causes missed slot, verify that the circuit breaker correctly kicks in and disables the builder workflow. Builder starts corrupting payloads after fork, hence a single block in the canonical chain after the fork is enough to verify the circuit breaker
 
@@ -146,13 +144,13 @@ returning error on header request after deneb transition.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
-- Deneb/Cancun transition occurs on Epoch 1 or 5
-	- Epoch depends on whether builder workflow activation requires finalization [on the CL client](#clients-that-require-finalization-to-enable-builder).
+- Deneb starts from genesis.
 - Builder is enabled for all nodes
-- Builder action is only enabled after fork
+- Builder action is enabled from genesis
 - Nodes have the mock-builder configured as builder endpoint
 
 #### Verifications (Execution Client)
@@ -165,8 +163,7 @@ returning error on header request after deneb transition.
 
 - For each blob transaction on the execution chain, the blob sidecars are available for the beacon block at the same height
 - The beacon block lists the correct commitments for each blob
-- Verify that the builder, up to before Deneb fork, has been able to produce blocks and they have been included in the canonical chain
-- After Deneb fork, the builder starts producing invalid payloads, verify that:
+- The builder starts producing invalid payloads, verify that:
 	- None of the produced payloads are included in the canonical chain
 
 ### - Deneb Builder Errors Out on Signed Blinded Beacon Block/Blob Sidecars Submission After Deneb Transition
@@ -194,13 +191,13 @@ returning error on unblinded payload request after deneb transition.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
-- Deneb/Cancun transition occurs on Epoch 1 or 5
-	- Epoch depends on whether builder workflow activation requires finalization [on the CL client](#clients-that-require-finalization-to-enable-builder).
+- Deneb starts from genesis.
 - Builder is enabled for all nodes
-- Builder action is only enabled after fork
+- Builder action is enabled from genesis
 - Nodes have the mock-builder configured as builder endpoint
 
 #### Verifications (Execution Client)
@@ -213,8 +210,7 @@ returning error on unblinded payload request after deneb transition.
 
 - For each blob transaction on the execution chain, the blob sidecars are available for the beacon block at the same height
 - The beacon block lists the correct commitments for each blob
-- Verify that the builder, up to before Deneb fork, has been able to produce blocks and they have been included in the canonical chain
-- After Deneb fork, the builder starts producing invalid payloads, verify that:
+- The builder starts producing invalid payloads, verify that:
 	- None of the produced payloads are included in the canonical chain
 - Since action causes missed slot, verify that the circuit breaker correctly kicks in and disables the builder workflow. Builder starts corrupting payloads after fork, hence a single block in the canonical chain after the fork is enough to verify the circuit breaker
 
@@ -243,13 +239,13 @@ version is outdated (capella instead of deneb).
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
-- Deneb/Cancun transition occurs on Epoch 1 or 5
-	- Epoch depends on whether builder workflow activation requires finalization [on the CL client](#clients-that-require-finalization-to-enable-builder).
+- Deneb starts from genesis.
 - Builder is enabled for all nodes
-- Builder action is only enabled after fork
+- Builder action is enabled from genesis
 - Nodes have the mock-builder configured as builder endpoint
 
 #### Verifications (Execution Client)
@@ -262,8 +258,7 @@ version is outdated (capella instead of deneb).
 
 - For each blob transaction on the execution chain, the blob sidecars are available for the beacon block at the same height
 - The beacon block lists the correct commitments for each blob
-- Verify that the builder, up to before Deneb fork, has been able to produce blocks and they have been included in the canonical chain
-- After Deneb fork, the builder starts producing invalid payloads, verify that:
+- The builder starts producing invalid payloads, verify that:
 	- None of the produced payloads are included in the canonical chain
 
 ### - Deneb Builder Builds Block With Invalid Beacon Root, Incorrect State Root
@@ -296,13 +291,13 @@ produced locally and results in an empty slot.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
-- Deneb/Cancun transition occurs on Epoch 1 or 5
-	- Epoch depends on whether builder workflow activation requires finalization [on the CL client](#clients-that-require-finalization-to-enable-builder).
+- Deneb starts from genesis.
 - Builder is enabled for all nodes
-- Builder action is only enabled after fork
+- Builder action is enabled from genesis
 - Nodes have the mock-builder configured as builder endpoint
 
 #### Verifications (Execution Client)
@@ -315,8 +310,7 @@ produced locally and results in an empty slot.
 
 - For each blob transaction on the execution chain, the blob sidecars are available for the beacon block at the same height
 - The beacon block lists the correct commitments for each blob
-- Verify that the builder, up to before Deneb fork, has been able to produce blocks and they have been included in the canonical chain
-- After Deneb fork, the builder starts producing invalid payloads, verify that:
+- The builder starts producing invalid payloads, verify that:
 	- None of the produced payloads are included in the canonical chain
 - Since action causes missed slot, verify that the circuit breaker correctly kicks in and disables the builder workflow. Builder starts corrupting payloads after fork, hence a single block in the canonical chain after the fork is enough to verify the circuit breaker
 

--- a/simulators/eth2/dencun/suites/builder/tests.go
+++ b/simulators/eth2/dencun/suites/builder/tests.go
@@ -32,6 +32,7 @@ func init() {
 				Test canonical chain includes deneb payloads built by the builder api.`,
 				// All validators start with BLS withdrawal credentials
 				GenesisExecutionWithdrawalCredentialsShares: 0,
+				DenebGenesis: true,
 				WaitForBlobs: true,
 			},
 		},
@@ -44,6 +45,7 @@ func init() {
 				building payloads with invalid parent beacon block root.`,
 				// All validators can withdraw from the start
 				GenesisExecutionWithdrawalCredentialsShares: 1,
+				DenebGenesis: true,
 				WaitForBlobs: true,
 			},
 			InvalidatePayloadAttributes: mock_builder.INVALIDATE_ATTR_BEACON_ROOT,
@@ -57,6 +59,7 @@ func init() {
 				returning error on header request after deneb transition.`,
 				// All validators can withdraw from the start
 				GenesisExecutionWithdrawalCredentialsShares: 1,
+				DenebGenesis: true,
 				WaitForBlobs: true,
 			},
 			ErrorOnHeaderRequest: true,
@@ -70,6 +73,7 @@ func init() {
 				returning error on unblinded payload request after deneb transition.`,
 				// All validators can withdraw from the start
 				GenesisExecutionWithdrawalCredentialsShares: 1,
+				DenebGenesis: true,
 				WaitForBlobs: true,
 			},
 			ErrorOnPayloadReveal: true,
@@ -83,6 +87,7 @@ func init() {
 				version is outdated (capella instead of deneb).`,
 				// All validators can withdraw from the start
 				GenesisExecutionWithdrawalCredentialsShares: 1,
+				DenebGenesis: true,
 				WaitForBlobs: true,
 			},
 			InvalidPayloadVersion: true,
@@ -101,6 +106,7 @@ func init() {
 				produced locally and results in an empty slot.`,
 				// All validators can withdraw from the start
 				GenesisExecutionWithdrawalCredentialsShares: 1,
+				DenebGenesis: true,
 				WaitForBlobs: true,
 			},
 			InvalidatePayload: mock_builder.INVALIDATE_PAYLOAD_BEACON_ROOT,

--- a/simulators/eth2/dencun/suites/p2p/gossip/blobs/TESTS.md
+++ b/simulators/eth2/dencun/suites/p2p/gossip/blobs/TESTS.md
@@ -40,7 +40,8 @@ Sanity test where the blobber is verified to be working correctly
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -88,7 +89,8 @@ Test chain health where the blobs are gossiped before the block
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -136,7 +138,8 @@ Test chain health where the blobs are gossiped after the block with a 500ms dela
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -185,7 +188,8 @@ Test chain health where the blobs are gossiped after the block with a 6s delay
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -241,7 +245,8 @@ delay makes the test more deterministic.
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -290,7 +295,8 @@ Test chain health if a proposer sends equivocating blobs and block to different 
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -339,7 +345,8 @@ Test chain health if a proposer sends equivocating blob sidecars (equivocating b
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -388,7 +395,8 @@ Test chain health if a proposer sends equivocating blob sidecars (equivocating b
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 
@@ -437,7 +445,8 @@ Test chain health if a proposer sends equivocating blob sidecars (equivocating b
 - Node Count: 2
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 128
 - BLS Withdrawal Credentials Count: 0
 

--- a/simulators/eth2/dencun/suites/reorg/TESTS.md
+++ b/simulators/eth2/dencun/suites/reorg/TESTS.md
@@ -41,7 +41,8 @@ Start two clients disconnected from each other, then connect them through a thir
 - Node Count: 5
 - Validating Node Count: 5
 - Validator Key Count: 128
-- Validator Key per Node: 25- Genesis Fork: Capella
+- Validator Key per Node: 25
+- Genesis Fork: Capella
 - Execution Withdrawal Credentials Count: 0
 - BLS Withdrawal Credentials Count: 128
 
@@ -82,7 +83,8 @@ Start two clients disconnected from each other, then connect them through a thir
 - Node Count: 5
 - Validating Node Count: 5
 - Validator Key Count: 128
-- Validator Key per Node: 25- Genesis Fork: Deneb
+- Validator Key per Node: 25
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 0
 - BLS Withdrawal Credentials Count: 128
 

--- a/simulators/eth2/dencun/suites/sync/TESTS.md
+++ b/simulators/eth2/dencun/suites/sync/TESTS.md
@@ -53,7 +53,8 @@ Test syncing of the beacon chain by a secondary non-validating client, sync from
 - Node Count: 3
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Capella
+- Validator Key per Node: 64
+- Genesis Fork: Capella
 - Execution Withdrawal Credentials Count: 0
 - BLS Withdrawal Credentials Count: 128
 
@@ -105,7 +106,8 @@ Test syncing of the beacon chain by a secondary non-validating client, sync from
 - Node Count: 3
 - Validating Node Count: 2
 - Validator Key Count: 128
-- Validator Key per Node: 64- Genesis Fork: Deneb
+- Validator Key per Node: 64
+- Genesis Fork: Deneb
 - Execution Withdrawal Credentials Count: 0
 - BLS Withdrawal Credentials Count: 128
 


### PR DESCRIPTION
## Changes Included
- The simulator now polls the mock builder for the requests it has received at `/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}` from each consensus client, and it immediately proceeds with the test once all clients have started requesting payloads, instead of having a hard-coded delay period for each client depending on whether the client waits for finality or not before requesting the builder for payloads.
- All tests now start from Deneb, and the injected builder faults start from the beginning, so the tests are much faster now (between 2-4 minutes if the client does not require for finalization to start requesting payloads from the builder).