### PR TITLE
simulators/ethereum/engine/cancun: Maintain devp2p client peering

### DIFF
--- a/simulators/ethereum/engine/suites/cancun/config.go
+++ b/simulators/ethereum/engine/suites/cancun/config.go
@@ -19,10 +19,8 @@ func (cs *CancunBaseSpec) Execute(t *test.Env) {
 
 	t.CLMock.WaitForTTD()
 
-	blobTestCtx := &CancunTestContext{
-		Env:            t,
-		TestBlobTxPool: new(TestBlobTxPool),
-	}
+	blobTestCtx := NewTestContext(t)
+	defer blobTestCtx.Close()
 
 	blobTestCtx.TestBlobTxPool.HashesByIndex = make(map[uint64]common.Hash)
 

--- a/simulators/ethereum/engine/suites/cancun/steps.go
+++ b/simulators/ethereum/engine/suites/cancun/steps.go
@@ -24,16 +24,37 @@ import (
 	"github.com/pkg/errors"
 )
 
-type CancunTestContext struct {
+type TestContext struct {
 	*test.Env
 	*TestBlobTxPool
 	DevP2PConnections map[uint64]*devp2p.Conn
 }
 
+// Initializes a TestContext
+func NewTestContext(env *test.Env) *TestContext {
+	return &TestContext{
+		Env:               env,
+		TestBlobTxPool:    new(TestBlobTxPool),
+		DevP2PConnections: make(map[uint64]*devp2p.Conn),
+	}
+}
+
+// Performs TestContext clean up
+func (t *TestContext) Close() error {
+	for _, conn := range t.DevP2PConnections {
+		if conn != nil {
+			if err := conn.Close(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Interface to represent a single step in a test vector
 type TestStep interface {
 	// Executes the step
-	Execute(testCtx *CancunTestContext) error
+	Execute(testCtx *TestContext) error
 	Description() string
 }
 
@@ -44,7 +65,7 @@ type ParallelSteps struct {
 	Steps []TestStep
 }
 
-func (step ParallelSteps) Execute(t *CancunTestContext) error {
+func (step ParallelSteps) Execute(t *TestContext) error {
 	// Run the steps in parallel
 	wg := sync.WaitGroup{}
 	errs := make(chan error, len(step.Steps))
@@ -90,7 +111,7 @@ func (step LaunchClients) GetClientCount() uint64 {
 	return clientCount
 }
 
-func (step LaunchClients) Execute(t *CancunTestContext) error {
+func (step LaunchClients) Execute(t *TestContext) error {
 	// Launch a new client
 	var (
 		client client.EngineClient
@@ -393,7 +414,7 @@ func (step NewPayloads) VerifyBlobBundle(blobDataInPayload []*BlobWrapData, payl
 	return nil
 }
 
-func (step NewPayloads) Execute(t *CancunTestContext) error {
+func (step NewPayloads) Execute(t *TestContext) error {
 	// Create a new payload
 	// Produce the payload
 	payloadCount := step.GetPayloadCount()
@@ -635,7 +656,7 @@ func (step SendBlobTransactions) GetBlobsPerTransaction() uint64 {
 	return blobCountPerTx
 }
 
-func (step SendBlobTransactions) Execute(t *CancunTestContext) error {
+func (step SendBlobTransactions) Execute(t *TestContext) error {
 	// Send a blob transaction
 	addr := common.BigToAddress(cancun.DATAHASH_START_ADDRESS)
 	blobCountPerTx := step.GetBlobsPerTransaction()
@@ -696,7 +717,7 @@ type SendModifiedLatestPayload struct {
 	NewPayloadCustomizer helper.NewPayloadCustomizer
 }
 
-func (step SendModifiedLatestPayload) Execute(t *CancunTestContext) error {
+func (step SendModifiedLatestPayload) Execute(t *TestContext) error {
 	// Get the latest payload
 	var (
 		payload                           = &t.CLMock.LatestPayloadBuilt
@@ -758,11 +779,9 @@ func (step SendModifiedLatestPayload) Description() string {
 type DevP2PClientPeering struct {
 	// Client index to peer to
 	ClientIndex uint64
-	// Maintain connection for later steps
-	MaintainConnection bool
 }
 
-func (step DevP2PClientPeering) Execute(t *CancunTestContext) error {
+func (step DevP2PClientPeering) Execute(t *TestContext) error {
 	// Get client index's enode
 	if step.ClientIndex >= uint64(len(t.TestEngines)) {
 		return fmt.Errorf("invalid client index %d", step.ClientIndex)
@@ -773,16 +792,7 @@ func (step DevP2PClientPeering) Execute(t *CancunTestContext) error {
 		return fmt.Errorf("error peering engine client: %v", err)
 	}
 	t.Logf("INFO: Connected to client %d, remote public key: %s", step.ClientIndex, conn.RemoteKey())
-
-	// Config connection closure
-	if !step.MaintainConnection {
-		defer conn.Close()
-	} else {
-		if t.DevP2PConnections == nil {
-			t.DevP2PConnections = make(map[uint64]*devp2p.Conn)
-		}
-		t.DevP2PConnections[step.ClientIndex] = conn
-	}
+	t.DevP2PConnections[step.ClientIndex] = conn
 
 	// Sleep
 	time.Sleep(1 * time.Second)
@@ -814,7 +824,7 @@ func (step DevP2PClientPeering) Execute(t *CancunTestContext) error {
 }
 
 func (step DevP2PClientPeering) Description() string {
-	return fmt.Sprintf("DevP2PClientPeering: client %d, connection maintained: %b ", step.ClientIndex, step.MaintainConnection)
+	return fmt.Sprintf("DevP2PClientPeering: client %d", step.ClientIndex)
 }
 
 // A step that requests a Transaction hash via P2P and expects the correct full blob tx
@@ -823,15 +833,13 @@ type DevP2PRequestPooledTransactionHash struct {
 	ClientIndex uint64
 	// Use existing connection from previous step
 	UseExistingConnection bool
-	// Maintain connection for later steps
-	MaintainConnection bool
 	// Transaction Index to request
 	TransactionIndexes []uint64
 	// Wait for a new pooled transaction message before actually requesting the transaction
 	WaitForNewPooledTransaction bool
 }
 
-func (step DevP2PRequestPooledTransactionHash) Execute(t *CancunTestContext) error {
+func (step DevP2PRequestPooledTransactionHash) Execute(t *TestContext) error {
 	// Get client index's enode
 	if step.ClientIndex >= uint64(len(t.TestEngines)) {
 		return fmt.Errorf("invalid client index %d", step.ClientIndex)
@@ -847,6 +855,7 @@ func (step DevP2PRequestPooledTransactionHash) Execute(t *CancunTestContext) err
 			return fmt.Errorf("error peering engine client: %v", err)
 		}
 		t.Logf("INFO: Connected to client %d, remote public key: %s", step.ClientIndex, conn.RemoteKey())
+		t.DevP2PConnections[step.ClientIndex] = conn
 	} else {
 		var exists bool
 		conn, exists = t.DevP2PConnections[step.ClientIndex]
@@ -854,16 +863,6 @@ func (step DevP2PRequestPooledTransactionHash) Execute(t *CancunTestContext) err
 			return fmt.Errorf("no existing connection found for client index %d", step.ClientIndex)
 		}
 		t.Logf("INFO: Using existing connection to client %d, remote public key: %s", step.ClientIndex, conn.RemoteKey())
-	}
-
-	// Config connection closure
-	if !step.MaintainConnection {
-		defer conn.Close()
-	} else if !step.UseExistingConnection && step.MaintainConnection {
-		if t.DevP2PConnections == nil {
-			t.DevP2PConnections = make(map[uint64]*devp2p.Conn)
-		}
-		t.DevP2PConnections[step.ClientIndex] = conn
 	}
 
 	var (

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -1763,9 +1763,9 @@ var Tests = []test.Spec{
 	// DevP2P tests
 	&CancunBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "Request Blob Pooled Transactions",
+			Name: "Request Blob Pooled Transactions Single",
 			About: `
-			Requests blob pooled transactions and verify correct encoding.
+			Requests a single blob pooled transactions and verifies the correct encoding.
 			`,
 			MainFork: config.Cancun,
 		},
@@ -1774,13 +1774,50 @@ var Tests = []test.Spec{
 			NewPayloads{
 				PayloadCount: 1,
 			},
-			// Send multiple transactions with multiple blobs each
+			// Peer with the client before sending txs
+			DevP2PClientPeering{
+				ClientIndex:        0,
+				MaintainConnection: true,
+			},
+			// Send a single blob transaction
 			SendBlobTransactions{
 				TransactionCount:              1,
 				BlobTransactionMaxBlobGasCost: big.NewInt(1),
 			},
 			DevP2PRequestPooledTransactionHash{
 				ClientIndex:                 0,
+				UseExistingConnection:       true,
+				TransactionIndexes:          []uint64{0},
+				WaitForNewPooledTransaction: true,
+			},
+		},
+	},
+	&CancunBaseSpec{
+		BaseSpec: test.BaseSpec{
+			Name: "Request Blob Pooled Transactions Multiple",
+			About: `
+			Requests multiple blob pooled transactions and verifies the correct encoding.
+			`,
+			MainFork: config.Cancun,
+		},
+		TestSequence: TestSequence{
+			// Get past the genesis
+			NewPayloads{
+				PayloadCount: 1,
+			},
+			// Peer with the client before sending txs
+			DevP2PClientPeering{
+				ClientIndex:        0,
+				MaintainConnection: true,
+			},
+			// Send multiple blob transaction
+			SendBlobTransactions{
+				TransactionCount:              cancun.MAX_BLOBS_PER_BLOCK - 1,
+				BlobTransactionMaxBlobGasCost: big.NewInt(1),
+			},
+			DevP2PRequestPooledTransactionHash{
+				ClientIndex:                 0,
+				UseExistingConnection:       true,
 				TransactionIndexes:          []uint64{0},
 				WaitForNewPooledTransaction: true,
 			},

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -1777,7 +1777,6 @@ var Tests = []test.Spec{
 			// Peer with the client before sending txs
 			DevP2PClientPeering{
 				ClientIndex:        0,
-				MaintainConnection: true,
 			},
 			// Send a single blob transaction
 			SendBlobTransactions{
@@ -1808,7 +1807,6 @@ var Tests = []test.Spec{
 			// Peer with the client before sending txs
 			DevP2PClientPeering{
 				ClientIndex:        0,
-				MaintainConnection: true,
 			},
 			// Send multiple blob transaction
 			SendBlobTransactions{


### PR DESCRIPTION
# Description

- Fixes the engine-cancun devp2p test: `Request Blob Pooled Transactions` for geth.
- After the following PR: https://github.com/ethereum/go-ethereum/pull/29026, to obtain a `NewPooledTransactionHashes` devp2p msg for blob txs, we must now peer first before sending blob txs.
- Adds an additional test where we send multiple blob txs instead of a single blob tx.