### PR TITLE
all: use golang 1.22 in Dockerfiles

### DIFF
--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -1,7 +1,7 @@
 ### Build Erigon From Git:
 
 ## Builder stage: Compiles erigon from a git repository
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine as builder
 
 ARG github=ledgerwatch/erigon
 ARG tag=devel

--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -1,6 +1,6 @@
 ## Pulls geth from a git repository and builds it from source.
 
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine as builder
 ARG github=ethereum/go-ethereum
 ARG tag=master
 

--- a/simulators/eth2/engine/Dockerfile
+++ b/simulators/eth2/engine/Dockerfile
@@ -1,5 +1,5 @@
 # Build the simulator binary
-FROM golang:1.20-alpine AS builder
+FROM golang:1.22-alpine AS builder
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/eth2/testnet/Dockerfile
+++ b/simulators/eth2/testnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM golang:1.22-alpine AS builder
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/eth2/withdrawals/Dockerfile
+++ b/simulators/eth2/withdrawals/Dockerfile
@@ -1,5 +1,5 @@
 # Build the simulator binary
-FROM golang:1.20-alpine AS builder
+FROM golang:1.22-alpine AS builder
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/ethereum/engine/Dockerfile
+++ b/simulators/ethereum/engine/Dockerfile
@@ -1,5 +1,5 @@
 # This simulation runs Engine API tests.
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine as builder
 RUN apk add --update gcc musl-dev linux-headers
 
 # Build the simulator executable.

--- a/simulators/ethereum/pyspec/Dockerfile
+++ b/simulators/ethereum/pyspec/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------#
 
 # 1) Create pyspec builder container.
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine as builder
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Build the pyspec simulator executable.


### PR DESCRIPTION
Our hive pyspec builds recently broke because the images were using 1.20, and `go.mod` files used go toolchains, which were released in 1.21. This just changes any images using 1.20, to using a 1.22 image.