### PR TITLE
simulators/ethereum/engine: Trim rpc logs only at low log levels

### DIFF
--- a/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -91,10 +93,12 @@ func (s HiveRPCEngineStarter) StartClient(T *hivesim.T, testContext context.Cont
 	if err := CheckEthEngineLive(c); err != nil {
 		return nil, fmt.Errorf("Engine/Eth ports were never open for client: %v", err)
 	}
+	hiveLogLevel, _ := strconv.Atoi(os.Getenv("HIVE_LOGLEVEL"))
 	ec := NewHiveRPCEngineClient(c, enginePort, ethPort, jwtSecret, &helper.LoggingRoundTrip{
-		Logger: T,
-		ID:     c.Container,
-		Inner:  http.DefaultTransport,
+		Logger:   T,
+		ID:       c.Container,
+		Inner:    http.DefaultTransport,
+		LogLevel: hiveLogLevel,
 	})
 	return ec, nil
 }

--- a/simulators/ethereum/engine/helper/helper.go
+++ b/simulators/ethereum/engine/helper/helper.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"context"
-	"strconv"
 
 	"bytes"
 	"encoding/json"
@@ -34,9 +33,10 @@ type LogF interface {
 }
 
 type LoggingRoundTrip struct {
-	Logger LogF
-	ID     string
-	Inner  http.RoundTripper
+	Logger   LogF
+	ID       string
+	Inner    http.RoundTripper
+	LogLevel int
 }
 
 const MAX_LOG_BYTES = 1024 * 4
@@ -49,9 +49,7 @@ func (rt *LoggingRoundTrip) RoundTrip(req *http.Request) (*http.Response, error)
 		return nil, err
 	}
 	reqLogBytes := bytes.TrimSpace(reqBytes[:])
-
-	hiveLogLevel, _ := strconv.Atoi(os.Getenv("HIVE_LOGLEVEL"))
-	reqTrimLogs := len(reqLogBytes) > MAX_LOG_BYTES && hiveLogLevel <= 3
+	reqTrimLogs := len(reqLogBytes) > MAX_LOG_BYTES && rt.LogLevel <= 3
 	if reqTrimLogs {
 		rt.Logger.Logf(">> (%s) %s... (Log trimmed)", rt.ID, reqLogBytes[:MAX_LOG_BYTES])
 	} else {
@@ -76,7 +74,7 @@ func (rt *LoggingRoundTrip) RoundTrip(req *http.Request) (*http.Response, error)
 	respCopy.Body = io.NopCloser(bytes.NewReader(respBytes))
 	respLogBytes := bytes.TrimSpace(respBytes[:])
 
-	respTrimLogs := len(respLogBytes) > MAX_LOG_BYTES && hiveLogLevel <= 3
+	respTrimLogs := len(respLogBytes) > MAX_LOG_BYTES && rt.LogLevel <= 3
 	if respTrimLogs {
 		rt.Logger.Logf("<< (%s) %s... (Log trimmed)", rt.ID, respLogBytes[:MAX_LOG_BYTES])
 	} else {

--- a/simulators/ethereum/engine/helper/helper.go
+++ b/simulators/ethereum/engine/helper/helper.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"context"
+	"strconv"
 
 	"bytes"
 	"encoding/json"
@@ -48,7 +49,10 @@ func (rt *LoggingRoundTrip) RoundTrip(req *http.Request) (*http.Response, error)
 		return nil, err
 	}
 	reqLogBytes := bytes.TrimSpace(reqBytes[:])
-	if len(reqLogBytes) > MAX_LOG_BYTES {
+
+	hiveLogLevel, _ := strconv.Atoi(os.Getenv("HIVE_LOGLEVEL"))
+	reqTrimLogs := len(reqLogBytes) > MAX_LOG_BYTES && hiveLogLevel <= 3
+	if reqTrimLogs {
 		rt.Logger.Logf(">> (%s) %s... (Log trimmed)", rt.ID, reqLogBytes[:MAX_LOG_BYTES])
 	} else {
 		rt.Logger.Logf(">> (%s) %s", rt.ID, reqLogBytes)
@@ -71,7 +75,9 @@ func (rt *LoggingRoundTrip) RoundTrip(req *http.Request) (*http.Response, error)
 	respCopy := *resp
 	respCopy.Body = io.NopCloser(bytes.NewReader(respBytes))
 	respLogBytes := bytes.TrimSpace(respBytes[:])
-	if len(respLogBytes) > MAX_LOG_BYTES {
+
+	respTrimLogs := len(respLogBytes) > MAX_LOG_BYTES && hiveLogLevel <= 3
+	if respTrimLogs {
 		rt.Logger.Logf("<< (%s) %s... (Log trimmed)", rt.ID, respLogBytes[:MAX_LOG_BYTES])
 	} else {
 		rt.Logger.Logf("<< (%s) %s", rt.ID, respLogBytes)


### PR DESCRIPTION
## Description
Forces RPC log trimming to only take affect when `--sim.loglevel <= 3`. I.e to get the full log we run with:
`--sim.loglevel 4` or `--sim.loglevel 5`. 

## Related Issues or PRs
This PR can be regarded as an extension to following: https://github.com/ethereum/hive/pull/928

cc'ing @flcl42 