### PR TITLE
simulators/ethereum/engine: Increase engine timeouts

### DIFF
--- a/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
@@ -117,7 +117,7 @@ func (s HiveRPCEngineStarter) StartClient(T *hivesim.T, testContext context.Cont
 }
 
 func CheckEthEngineLive(c *hivesim.Client) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	var (
 		ticker = time.NewTicker(100 * time.Millisecond)

--- a/simulators/ethereum/engine/globals/globals.go
+++ b/simulators/ethereum/engine/globals/globals.go
@@ -47,7 +47,7 @@ var (
 	GenesisTimestamp = uint64(0x1234)
 
 	// RPC Timeout for every call
-	RPCTimeout = 10 * time.Second
+	RPCTimeout = 20 * time.Second
 
 	// Engine, Eth ports
 	EthPortHTTP    = 8545


### PR DESCRIPTION
A simple PR to increase engine timeout values.

Some tests on the hive cancun public interface occasionally fail with the `context deadline exceeded` error. That is they pass most of the time but on occasion fail with this error.

1) For the `engine-cancun` tests we have the following [case](https://hivecancun.ethdevops.io/viewer.html?suiteid=1712709430-25ebe939b252698029586282b0af316e.json&suitename=engine-cancun&testid=216&file=%2Fresults%2Fnethermind%2Fclient-e4776ef8bda35d0b1b55b46f2b3a23c33bd2a749a1582662db3b787748adef18.log) that occurs waiting for an FCU response. The proposed solution is to increase the RPC timeout from 10 seconds to 20.
2) For the `pyspec` tests we have this [case](https://hivecancun.ethdevops.io/suite.html?suiteid=1712730801-2ce030e108054ff3b951b7db867a0fbf.json&suitename=pyspec#test-913) where we timeout waiting for the engine client to start. I have seen this occur randomly across most clients. The proposed solution is to increase the engine live check timeout from 5 seconds to 10.

Unfortunately these cases can't be reproduced locally as they are for tests that always pass when running locally.
