### PR TITLE
clients/nimbus-el: change command line option --prune-mode to --chaindb

### DIFF
--- a/clients/nimbus-el/nimbus.sh
+++ b/clients/nimbus-el/nimbus.sh
@@ -48,7 +48,7 @@
 set -e
 
 nimbus=/usr/bin/nimbus
-FLAGS="--prune-mode:archive --nat:extip:0.0.0.0"
+FLAGS="--chaindb:archive --nat:extip:0.0.0.0"
 
 loglevel=DEBUG
 case "$HIVE_LOGLEVEL" in


### PR DESCRIPTION
Because of recent addition of AristoDB in Nimbus-eth1, `--prune-mode` no longer used. Now it is replaced by `--chaindb`