### PR TITLE
simulators/portal: add docker caching step for building rust simulator dependencies

### DIFF
--- a/simulators/portal/beacon/Dockerfile
+++ b/simulators/portal/beacon/Dockerfile
@@ -8,8 +8,17 @@ RUN apt-get update && apt-get install clang -y
 
 # copy over manifests and source to build image
 COPY Cargo.toml ./Cargo.toml
+
+# create fake main.rs and build dependencies
+RUN echo "fn main() {}" > ./src/main.rs
+
+RUN cargo build --release
+
+# copy real src over and make newest modified file
 COPY src ./src
 RUN apt-get update && apt-get install clang -y
+
+RUN touch -a -m ./src/main.rs
 
 # build for release
 RUN cargo build --release

--- a/simulators/portal/history/Dockerfile
+++ b/simulators/portal/history/Dockerfile
@@ -16,6 +16,7 @@ RUN cargo build --release
 # copy real src over and make newest modified file
 COPY src ./src
 
+RUN touch -a -m ./src/main.rs
 
 # build for release
 RUN cargo build --release

--- a/simulators/portal/history/Dockerfile
+++ b/simulators/portal/history/Dockerfile
@@ -5,7 +5,6 @@ RUN USER=root cargo new --bin history
 WORKDIR /history
 
 # copy over manifests and source to build image
-# copy over manifests and source to build image
 COPY Cargo.toml ./Cargo.toml
 
 # create fake main.rs and build dependencies

--- a/simulators/portal/history/Dockerfile
+++ b/simulators/portal/history/Dockerfile
@@ -5,9 +5,17 @@ RUN USER=root cargo new --bin history
 WORKDIR /history
 
 # copy over manifests and source to build image
+# copy over manifests and source to build image
 COPY Cargo.toml ./Cargo.toml
-COPY src ./src
+
+# create fake main.rs and build dependencies
+RUN echo "fn main() {}" > ./src/main.rs
 RUN apt-get update && apt-get install clang -y
+RUN cargo build --release
+
+# copy real src over and make newest modified file
+COPY src ./src
+
 
 # build for release
 RUN cargo build --release

--- a/simulators/portal/state/Dockerfile
+++ b/simulators/portal/state/Dockerfile
@@ -8,8 +8,16 @@ RUN apt-get update && apt-get install clang -y
 
 # copy over manifests and source to build image
 COPY Cargo.toml ./Cargo.toml
-COPY src ./src
+
+# create fake main.rs and build dependencies
+RUN echo "fn main() {}" > ./src/main.rs
+
 RUN apt-get update && apt-get install clang -y
+RUN cargo build --release
+
+# copy real src over and make newest modified file
+COPY src ./src
+
 
 # build for release
 RUN cargo build --release

--- a/simulators/portal/state/Dockerfile
+++ b/simulators/portal/state/Dockerfile
@@ -18,6 +18,7 @@ RUN cargo build --release
 # copy real src over and make newest modified file
 COPY src ./src
 
+RUN touch -a -m ./src/main.rs
 
 # build for release
 RUN cargo build --release


### PR DESCRIPTION
Adds a caching step in the docker build process for the `portal` simulators to allow for quicker rebuilding of simulator containers when working on `portal` hive tests locally.