### PR TITLE
clients/trin-bridge: update outdated bridge args

### DIFF
--- a/clients/trin-bridge/trin_bridge.sh
+++ b/clients/trin-bridge/trin_bridge.sh
@@ -13,4 +13,4 @@ else
     exit 1
 fi
 
-RUST_LOG="error,portal_bridge=debug,portalnet=debug" portal-bridge --node-count 1 $FLAGS --executable-path /usr/bin/trin --mode test:/test_data_collection_of_forks_blocks.yaml --external-ip $IP_ADDR --epoch-accumulator-path . trin
+RUST_LOG="error,portal_bridge=debug,portalnet=debug" portal-bridge $FLAGS --executable-path /usr/bin/trin --mode test:/test_data_collection_of_forks_blocks.yaml --external-ip $IP_ADDR --epoch-accumulator-path . trin


### PR DESCRIPTION
we no longer support the `--node-count` flag inside trin-bridge