### PR TITLE
Update EthereumJS build to support RLP `/blocks`

### DIFF
--- a/clients/ethereumjs/Dockerfile
+++ b/clients/ethereumjs/Dockerfile
@@ -1,6 +1,6 @@
 ### Build EthereumJS From Git:
 
-FROM node:18-alpine as build
+FROM node:20-alpine as build
 
 ARG github=ethereumjs/ethereumjs-monorepo
 ARG tag=master

--- a/clients/ethereumjs/Dockerfile.local
+++ b/clients/ethereumjs/Dockerfile.local
@@ -1,7 +1,7 @@
 ### Build Ethereumjs Locally:
 ### Requires a copy of ethereumjs-monorepo/ -> hive/clients/ethereumjs/
 
-FROM node:18-alpine
+FROM node:20-alpine
 
 RUN apk update && apk add --no-cache bash git jq curl python3 gcc make g++ \
     && rm -rf /var/cache/apk/*

--- a/clients/ethereumjs/ethereumjs-local.sh
+++ b/clients/ethereumjs/ethereumjs-local.sh
@@ -85,6 +85,15 @@ if [ -f /chain.rlp ]; then
   echo "Warning: chain.rlp not found."
 fi
 
+if [[ -d blocks ]]; then
+  for file in blocks/*; do
+    FLAGS="$FLAGS --loadBlocksFromRlp=${file}" 
+    echo $FLAGS
+  done
+  else
+  echo "Warning: blocks directory not found."
+fi
+
 if [ "$HIVE_BOOTNODE" != "" ]; then
     FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
 fi

--- a/clients/ethereumjs/ethereumjs.sh
+++ b/clients/ethereumjs/ethereumjs.sh
@@ -87,6 +87,14 @@ if [ -f /chain.rlp ]; then
   echo "Warning: chain.rlp not found."
 fi
 
+if [[ -d blocks ]]; then
+  for file in blocks/*; do
+    FLAGS="$FLAGS --loadBlocksFromRlp=${file}" 
+  done
+  else
+  echo "Warning: blocks directory not found."
+fi
+
 if [ "$HIVE_BOOTNODE" != "" ]; then
     FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
 fi


### PR DESCRIPTION
- Updates the base image for the EthereumJS client Docker build to node 20
- Adds support for the `/blocks` parameter for loading multiple RLP encoded blocks (used primarily in the `ethereum/consensus` simulator