### PR TITLE
clients/ethereumjs: pad genesis storage keys with mapper

### DIFF
--- a/clients/ethereumjs/mapper.jq
+++ b/clients/ethereumjs/mapper.jq
@@ -28,6 +28,21 @@ def to_bool:
   end
 ;
 
+# Pads storage keys to 32 bytes.
+def pad_storage_keys:
+  .alloc |= with_entries(
+    .value.storage |= with_entries(
+      .key |= (if . == null then . else
+                 if startswith("0x") then
+                   "0x" + (.[2:] | if length < 64 then ("0" * (64 - length)) + . else . end)
+                 else
+                   "0x" + (if length < 64 then ("0" * (64 - length)) + . else . end)
+                 end
+               end)
+    )
+  )
+;
+
 # Replace config in input.
 . + {
   "config": {
@@ -58,4 +73,4 @@ def to_bool:
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
   }
-} | remove_empty
+} | pad_storage_keys | remove_empty


### PR DESCRIPTION
## Description

Pads storage keys to 32 bytes within the `genesis.json` for ethereumjs to resolve the following error:
```
[f8c2f37c] [05-30|18:42:16] ERROR Error starting client Storage key must be 32 bytes long
```
on client start up.

## Why?

This appeared for us when trying to run our python based `consume rlp` simulator (using hive as the backend), which is essentially a port of the consensus simulator.

We could alternatively update this on our end, forcing storage keys to be 32 bytes long but this breaks some functionality for us as well as bloating the fixture content. We could also add the padding after processing the fixture content but as this is client specific it seems like adding this to the mapper within hive is the most reasonable approach.

This change will likely save us some error hunting when we start testing verkle transitions with a large pre state (genesis alloc) where mpt storage key/values are present.

This error could also be removed from ethereumjs but it seems relevant to keep it.