### PR TITLE
fix: remove blob fields from ethereum/sync newPayloadV2

### DIFF
--- a/simulators/ethereum/sync/chain/headnewpayload.json
+++ b/simulators/ethereum/sync/chain/headnewpayload.json
@@ -18,9 +18,7 @@
       "baseFeePerGas": "0x7",
       "blockHash": "0x07f7d3c5744ffddc5441cf31074c91a934afbf6ddb7e8234a081ee1f21140455",
       "transactions": [],
-      "withdrawals": [],
-      "blobGasUsed": null,
-      "excessBlobGas": null
+      "withdrawals": []
     }
   ]
 }


### PR DESCRIPTION
Reth does not support these fields as `null` when using newPayloadV2, and AFAIK it does not need to. We currently do not progress in this test because we report the request as malformed. This removes the `blobGasUsed` and `excessBlobGas` fields from the `ethereum/sync` test.