### PR TITLE
clients/fluffy: Add --disable-state-root-validation to Fluffy startup options

### DIFF
--- a/clients/fluffy/fluffy.sh
+++ b/clients/fluffy/fluffy.sh
@@ -23,4 +23,5 @@ if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
     FLAGS="$FLAGS --netkey-unsafe=0x$HIVE_CLIENT_PRIVATE_KEY"
 fi
 
-fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --portal-network=none --log-level="debug" $FLAGS
+fluffy --log-level=INFO --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --portal-network=none \
+    --log-level="debug" --disable-state-root-validation $FLAGS


### PR DESCRIPTION
Add --disable-state-root-validation to Fluffy startup options to support Portal state hive tests.

I'm working on updating Fluffy in order to pass the portal state hive tests and this new parameter is now required when running the state tests against Fluffy.