### PR TITLE
clients/shisui: enable `none` bootnodes for portal hive test

### DIFF
--- a/clients/shisui/shisui.sh
+++ b/clients/shisui/shisui.sh
@@ -22,6 +22,8 @@ fi
 
 if [ "$HIVE_BOOTNODE" != "" ]; then
     FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
+else
+    FLAGS="$FLAGS --bootnodes=none"
 fi
 
 FLAGS="$FLAGS --nat extip:$IP_ADDR"


### PR DESCRIPTION
fix #1123 