### PR TITLE
clients/reth: enable discv5

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -159,6 +159,9 @@ fi
 # Configure NAT
 FLAGS="$FLAGS --nat none"
 
+# Configure discv5.
+FLAGS="$FLAGS --enable.discv5.discovery --discovery.v5.port=30303"
+
 # Launch the main client.
 echo "Running reth with flags: $FLAGS"
 RUST_LOG=info $reth node $FLAGS


### PR DESCRIPTION
Closes https://github.com/ethereum/hive/issues/1073.

Enables discv5 on same port as discv4 for reth.