### PR TITLE
Revert pull/1128 

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -159,9 +159,6 @@ fi
 # Configure NAT
 FLAGS="$FLAGS --nat none"
 
-# Configure discv5.
-FLAGS="$FLAGS --enable.discv5.discovery --discovery.v5.port=30303"
-
 # Launch the main client.
 echo "Running reth with flags: $FLAGS"
 RUST_LOG=info $reth node $FLAGS


### PR DESCRIPTION
Reverts https://github.com/ethereum/hive/pull/1128 

Reth is running discv5 as an additional service, with its own port. https://github.com/ethereum/hive/issues/1073 needs another solution than using same port.