### PR TITLE
clients/ultralight: set network radius in script

### DIFF
--- a/clients/ultralight/ultralight.sh
+++ b/clients/ultralight/ultralight.sh
@@ -4,7 +4,7 @@
 set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
-FLAGS=""
+FLAGS="--radiusHistory=256 --radiusState=256 --radiusBeacon=256"
 
 if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
     FLAGS="$FLAGS --pk=0x1a2408021220$HIVE_CLIENT_PRIVATE_KEY"


### PR DESCRIPTION
Updates the startup script for ultralight at `clients/ultralight/ultralight.sh`

Adds command line flags to set the network radius for ultralight nodes.  Recent updates to Ultralight code cause some hive tests to fail if these flags are not set.