### PR TITLE
simulators/ethereum/engine: lower withdrawals test timeout to 240s

### DIFF
--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -215,7 +215,7 @@ var Tests = []test.Spec{
 			- Spawn a secondary client and send FCUV2(head)
 			- Wait for sync and verify withdrawn account's balance
 			`,
-				TimeoutSeconds: 6000,
+				TimeoutSeconds: 240,
 			},
 			WithdrawalsForkHeight:    1,
 			WithdrawalsBlockCount:    2,


### PR DESCRIPTION
Lowers the withdrawal test timeout to a more sane value