### PR TITLE
clients/ethereumjs: fix for null storage in mapper

### DIFF
--- a/clients/ethereumjs/mapper.jq
+++ b/clients/ethereumjs/mapper.jq
@@ -30,8 +30,8 @@ def to_bool:
 
 # Pads storage keys to 32 bytes.
 def pad_storage_keys:
-  .alloc |= with_entries(
-    .value.storage |= with_entries(
+  .alloc |= (if . == null then . else with_entries(
+    .value.storage |= (if . == null then . else with_entries(
       .key |= (if . == null then . else
                  if startswith("0x") then
                    "0x" + (.[2:] | if length < 64 then ("0" * (64 - length)) + . else . end)
@@ -39,8 +39,8 @@ def pad_storage_keys:
                    "0x" + (if length < 64 then ("0" * (64 - length)) + . else . end)
                  end
                end)
-    )
-  )
+    ) end)
+  ) end)
 ;
 
 # Replace config in input.


### PR DESCRIPTION
It seems like genesis.json format has changed? The new mapper now allows accounts with empty storage (seems like before we required the storage field to be present)