### PR TITLE
clients/fluffy: Update to the new subnetworks and network cli flags

### DIFF
--- a/clients/fluffy/fluffy.sh
+++ b/clients/fluffy/fluffy.sh
@@ -7,7 +7,7 @@ IP_ADDR=$(hostname -i | awk '{print $1}')
 FLAGS=""
 
 if [ "$HIVE_PORTAL_NETWORKS_SELECTED" != "" ]; then
-    FLAGS="$FLAGS --networks=$HIVE_PORTAL_NETWORKS_SELECTED"
+    FLAGS="$FLAGS --portal-subnetworks=$HIVE_PORTAL_NETWORKS_SELECTED"
 
     if [[ $HIVE_PORTAL_NETWORKS_SELECTED =~ "beacon" ]]; then
         # Providing a trusted block root is required currently to fully enable the beacon network.
@@ -15,7 +15,7 @@ if [ "$HIVE_PORTAL_NETWORKS_SELECTED" != "" ]; then
         FLAGS="$FLAGS --trusted-block-root:0x0000000000000000000000000000000000000000000000000000000000000000"
     fi
 else
-    FLAGS="$FLAGS --networks=history"
+    FLAGS="$FLAGS --portal-subnetworks=history"
 fi
 
 
@@ -23,5 +23,5 @@ if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
     FLAGS="$FLAGS --netkey-unsafe=0x$HIVE_CLIENT_PRIVATE_KEY"
 fi
 
-fluffy --log-level=INFO --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --portal-network=none \
+fluffy --log-level=INFO --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none \
     --log-level="debug" --disable-state-root-validation $FLAGS


### PR DESCRIPTION
The old flags are deprecated and will be removed in the future.