### PR TITLE
simulators/portal: update test data file link

### DIFF
--- a/simulators/portal/Dockerfile
+++ b/simulators/portal/Dockerfile
@@ -31,7 +31,7 @@ RUN apt update && apt install wget -y
 
 # copy build artifacts from build stage
 COPY --from=builder /portal/target/release/portal .
-ADD https://raw.githubusercontent.com/KolbyML/portal-spec-tests/epoch/tests/mainnet/history/hive/test_data_collection_of_forks_blocks.yaml ./test-data/test_data_collection_of_forks_blocks.yaml
+ADD https://raw.githubusercontent.com/ethereum/portal-spec-tests/master/tests/mainnet/history/hive/test_data_collection_of_forks_blocks.yaml ./test-data/test_data_collection_of_forks_blocks.yaml
 ADD https://raw.githubusercontent.com/ethereum/portal-spec-tests/master/tests/mainnet/state/hive/test_data.yaml ./test-data/state_test_data.yaml
 ADD https://raw.githubusercontent.com/ethereum/portal-spec-tests/master/tests/mainnet/beacon_chain/hive/test_data.yaml ./test-data/beacon_test_data.yaml
 


### PR DESCRIPTION
updates our dockerfile for simulators/portal to pull from the main test file, there appears to be issues with our bridge handling epoch files.