### PR TITLE
clients/besu: Bump java distribution

### DIFF
--- a/clients/besu/Dockerfile.git
+++ b/clients/besu/Dockerfile.git
@@ -9,7 +9,7 @@ ARG github=hyperledger/besu
 RUN echo "installing java on ubuntu base image" \
     && apt-get update && apt-get install -y git libsodium-dev libnss3-dev \
     && apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909* \
-    && apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* libjemalloc-dev=5.* \
+    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* \
     && echo "Cloning: $github - $tag" \
     && git clone --depth 1 --branch $tag https://github.com/$github \
     && cd besu && ./gradlew installDist
@@ -21,7 +21,7 @@ FROM ubuntu:22.04
 COPY --from=builder /besu/build/install/besu /opt/besu
 
 RUN apt-get update && apt-get install -y curl jq libsodium23 libnss3-dev \
-    && apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* libjemalloc-dev=5.*  \
+    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.*  \
     && apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 # Create version.txt

--- a/clients/besu/Dockerfile.local
+++ b/clients/besu/Dockerfile.local
@@ -9,7 +9,7 @@ COPY $local_path besu
 
 RUN apt-get update && apt-get install -y git libsodium-dev libnss3-dev \
     && apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 \
-    && apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* libjemalloc-dev=5.* \
+    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* \
     && cd besu && ./gradlew installDist
 
 ## Final stage: Sets up the environment for running besu
@@ -20,7 +20,7 @@ COPY --from=builder /besu/build/install/besu /opt/besu
 
 RUN apt-get update && apt-get install -y curl jq libsodium23 libnss3-dev \
     && apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 \
-    && apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* libjemalloc-dev=5.* \
+    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt


### PR DESCRIPTION
Bump java distribution to 21: https://github.com/hyperledger/besu/issues/6722