### PR TITLE
clients/ethereumjs: enable WS in startup script

### DIFF
--- a/clients/ethereumjs/ethereumjs-local.sh
+++ b/clients/ethereumjs/ethereumjs-local.sh
@@ -47,7 +47,7 @@
 set -e
 
 ethereumjs="node /ethereumjs-monorepo/packages/client/dist/esm/bin/cli.js"
-FLAGS="--gethGenesis /genesis.json --rpc --rpcEngine --saveReceipts --rpcAddr 0.0.0.0 --rpcEngineAddr 0.0.0.0 --rpcEnginePort 8551 --ws false --logLevel debug --rpcDebug all --rpcDebugVerbose all --isSingleNode"
+FLAGS="--gethGenesis /genesis.json --rpc --rpcEngine --saveReceipts --rpcAddr 0.0.0.0 --rpcEngineAddr 0.0.0.0 --rpcEnginePort 8551 --ws --logLevel debug --rpcDebug all --rpcDebugVerbose all --isSingleNode"
 
 # Configure the chain.
 mv /genesis.json /genesis-input.json

--- a/clients/ethereumjs/ethereumjs.sh
+++ b/clients/ethereumjs/ethereumjs.sh
@@ -49,7 +49,7 @@ set -e
 CLIENT_DIRECTORY=/ethereumjs-monorepo/packages/client
 
 ethereumjs="node $CLIENT_DIRECTORY/dist/esm/bin/cli.js"
-FLAGS="--gethGenesis ./genesis.json --rpc --rpcEngine --saveReceipts --rpcAddr 0.0.0.0 --rpcEngineAddr 0.0.0.0 --rpcEnginePort 8551 --ws false --logLevel debug --rpcDebug all --rpcDebugVerbose all --isSingleNode"
+FLAGS="--gethGenesis ./genesis.json --rpc --rpcEngine --saveReceipts --rpcAddr 0.0.0.0 --rpcEngineAddr 0.0.0.0 --rpcEnginePort 8551 --ws --logLevel debug --rpcDebug all --rpcDebugVerbose all --isSingleNode"
 
 # Configure the chain.
 mv /genesis.json /genesis-input.json


### PR DESCRIPTION
EthereumJS fails the "websocket" tests in `ethereum/rpc` because the startup script has the `--ws` flag set to `false`.

This sets the `--ws` option to true to enable the websocket server for these tests.