### PR TITLE
simulators/portal: update portal simulators to newest version of hivesim 

### DIFF
--- a/simulators/portal/Cargo.lock
+++ b/simulators/portal/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b155716bab55763c95ba212806cf43d05bcc70e5f35b02bad20cf5ec7fe11fed"
+checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -1772,7 +1772,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 [[package]]
 name = "hivesim"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/ethereum/hive?rev=62b3362bae655754b5f624c36720ba8c44a2f375#62b3362bae655754b5f624c36720ba8c44a2f375"
+source = "git+https://github.com/ethereum/hive?rev=81fc9a350d7f7ca8bcbe5f54886483d405d4daa8#81fc9a350d7f7ca8bcbe5f54886483d405d4daa8"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -2680,6 +2680,8 @@ dependencies = [
 name = "portal"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "enr",
  "ethportal-api",
  "futures",
@@ -2691,9 +2693,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "zstd",
- "zstd-safe",
- "zstd-sys",
 ]
 
 [[package]]
@@ -4568,32 +4567,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/simulators/portal/Cargo.toml
+++ b/simulators/portal/Cargo.toml
@@ -5,19 +5,18 @@ authors = ["Kolby ML (Moroz Liebl) <kolbydml@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "688847c64c1ef15df20828aa44ef871d3345fc98" }
-portal-spec-test-utils-rs = { git = "https://github.com/ethereum/portal-spec-tests", rev = "954f7d0eb2950a2131048404a1a4ce476bb64657" }
-hivesim = { git = "https://github.com/ethereum/hive", rev = "62b3362bae655754b5f624c36720ba8c44a2f375" }
-futures = "0.3.25"
-itertools = "0.10.5"
-serde_json = "1.0.87"
-serde_yaml = "0.9"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
-tokio = { version = "1", features = ["full"] }
-
+alloy-rlp = "0.3.8"
+alloy-primitives = "0.7.7"
 # todo: remove this when we update discv5. Added this because enr 10.1 is a breaking change
 enr = { version = "=0.10.0", features = ["k256", "ed25519"] }
-zstd = "=0.13.0"
-zstd-safe = "=7.0.0"
-zstd-sys = "=2.0.9+zstd.1.5.5"
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "688847c64c1ef15df20828aa44ef871d3345fc98" }
+futures = "0.3.25"
+hivesim = { git = "https://github.com/ethereum/hive", rev = "81fc9a350d7f7ca8bcbe5f54886483d405d4daa8" }
+itertools = "0.10.5"
+portal-spec-test-utils-rs = { git = "https://github.com/ethereum/portal-spec-tests", rev = "954f7d0eb2950a2131048404a1a4ce476bb64657" }
+serde_json = "1.0.87"
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
+

--- a/simulators/portal/src/suites/beacon/interop.rs
+++ b/simulators/portal/src/suites/beacon/interop.rs
@@ -5,11 +5,8 @@ use ethportal_api::types::beacon::ContentInfo;
 use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::{
     BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, ContentValue, Discv5ApiClient,
-    OverlayContentKey,
 };
 use hivesim::types::ClientDefinition;
-use hivesim::types::ContentKeyValue;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use itertools::Itertools;
 use serde_json::json;
@@ -20,21 +17,13 @@ use std::collections::HashMap;
 const MAX_PORTAL_CONTENT_PAYLOAD_SIZE: usize = 1165;
 const BOOTSTRAP_KEY: &str = "0x10bd9f42d9a42d972bdaf4dee84e5b419dd432b52867258acb7bcc7f567b6e3af1";
 
-fn content_pair_to_string_pair(
-    content_pair: (BeaconContentKey, BeaconContentValue),
-) -> ContentKeyValue {
-    let (content_key, content_value) = content_pair;
-    ContentKeyValue {
-        key: content_key.to_hex(),
-        value: hex_encode(content_value.encode()),
-    }
-}
+type TestData = (BeaconContentKey, BeaconContentValue);
 
 /// Processed content data for beacon tests
 struct ProcessedContent {
     content_type: String,
     identifier: String,
-    test_data: Vec<ContentKeyValue>,
+    test_data: TestData,
 }
 
 fn process_content(content: Vec<(BeaconContentKey, BeaconContentValue)>) -> Vec<ProcessedContent> {
@@ -44,7 +33,7 @@ fn process_content(content: Vec<(BeaconContentKey, BeaconContentValue)>) -> Vec<
             BeaconContentKey::LightClientBootstrap(bootstrap) => (
                 "Bootstrap".to_string(),
                 hex_encode(bootstrap.block_hash),
-                vec![content_pair_to_string_pair(beacon_content)],
+                beacon_content,
             ),
             BeaconContentKey::LightClientUpdatesByRange(updates_by_range) => (
                 "Updates by Range".to_string(),
@@ -52,22 +41,22 @@ fn process_content(content: Vec<(BeaconContentKey, BeaconContentValue)>) -> Vec<
                     "start period: {} count: {}",
                     updates_by_range.start_period, updates_by_range.count
                 ),
-                vec![content_pair_to_string_pair(beacon_content)],
+                beacon_content,
             ),
             BeaconContentKey::LightClientFinalityUpdate(finality_update) => (
                 "Finality Update".to_string(),
                 format!("finalized slot: {}", finality_update.finalized_slot),
-                vec![content_pair_to_string_pair(beacon_content)],
+                beacon_content,
             ),
             BeaconContentKey::LightClientOptimisticUpdate(optimistic_update) => (
                 "Optimistic Update".to_string(),
                 format!("optimistic slot: {}", optimistic_update.signature_slot),
-                vec![content_pair_to_string_pair(beacon_content)],
+                beacon_content,
             ),
             BeaconContentKey::HistoricalSummariesWithProof(historical_summaries) => (
                 "Historical Summaries".to_string(),
                 format!("historical summaries epoch: {}", historical_summaries.epoch),
-                vec![content_pair_to_string_pair(beacon_content)],
+                beacon_content,
             ),
         };
         result.push(ProcessedContent {
@@ -107,7 +96,7 @@ dyn_async! {
                         always_run: false,
                         run: test_recursive_find_content,
                         environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                        test_data: Some(TestData::ContentList(test_data.clone())),
+                        test_data: test_data.clone(),
                         clients: vec![client_a.clone(), client_b.clone()],
                     }
                 ).await;
@@ -119,7 +108,7 @@ dyn_async! {
                         always_run: false,
                         run: test_find_content,
                         environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                        test_data: Some(TestData::ContentList(test_data)),
+                        test_data,
                         clients: vec![client_a.clone(), client_b.clone()],
                     }
                 ).await;
@@ -132,7 +121,7 @@ dyn_async! {
                     always_run: false,
                     run: test_ping,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
@@ -144,7 +133,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_content_non_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
@@ -156,7 +145,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_nodes_zero_distance,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
@@ -166,7 +155,7 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will not return content via FINDCONTENT.
-    async fn test_find_content_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_content_non_present<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
@@ -208,7 +197,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_ping<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_ping<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
@@ -249,7 +238,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_nodes_zero_distance<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_nodes_zero_distance<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
@@ -285,23 +274,14 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a content via RECURSIVEFINDCONTENT template that it has stored locally
-    async fn test_recursive_find_content<'a>(clients: Vec<Client>, test_data: Option<TestData>) {
+    async fn test_recursive_find_content<'a>(clients: Vec<Client>, test_data: TestData) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
                 panic!("Unable to get expected amount of clients from NClientTestSpec");
             }
         };
-        let test_data = match test_data.map(|data| data.content_list()) {
-            Some(test_data) => test_data,
-            None => panic!("Expected test data non was provided"),
-        };
-
-        let ContentKeyValue { key: target_key, value: target_value } = test_data.first().expect("Target content is required for this test");
-        let target_key: BeaconContentKey =
-            serde_json::from_value(json!(target_key)).unwrap();
-        let target_value: BeaconContentValue =
-            serde_json::from_value(json!(target_value)).unwrap();
+        let (target_key, target_value) = test_data;
         match client_b.rpc.store(target_key.clone(), target_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Error storing target content for recursive find content");
@@ -356,22 +336,14 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a x content via FINDCONTENT that it has stored locally
-    async fn test_find_content<'a> (clients: Vec<Client>, test_data: Option<TestData>) {
+    async fn test_find_content<'a> (clients: Vec<Client>, test_data: TestData) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
                 panic!("Unable to get expected amount of clients from NClientTestSpec");
             }
         };
-        let test_data = match test_data.map(|data| data.content_list()) {
-            Some(test_data) => test_data,
-            None => panic!("Expected test data none was provided"),
-        };
-        let ContentKeyValue { key: target_key, value: target_value } = test_data.first().expect("Target content is required for this test");
-        let target_key: BeaconContentKey =
-            serde_json::from_value(json!(target_key)).unwrap();
-        let target_value: BeaconContentValue =
-            serde_json::from_value(json!(target_value)).unwrap();
+        let (target_key, target_value) = test_data;
         match client_b.rpc.store(target_key.clone(), target_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Error storing target content for find content");

--- a/simulators/portal/src/suites/beacon/mesh.rs
+++ b/simulators/portal/src/suites/beacon/mesh.rs
@@ -9,7 +9,6 @@ use ethportal_api::{
     BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, Discv5ApiClient,
 };
 use hivesim::types::ClientDefinition;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use itertools::Itertools;
 use serde_json::json;
@@ -34,7 +33,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_content_two_jumps,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -47,7 +46,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_content_two_jumps,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -59,7 +58,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_nodes_distance_of_client_c,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -68,7 +67,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
             None => {
@@ -163,7 +162,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
             None => {

--- a/simulators/portal/src/suites/beacon/rpc_compat.rs
+++ b/simulators/portal/src/suites/beacon/rpc_compat.rs
@@ -7,7 +7,6 @@ use ethportal_api::BeaconContentValue;
 use ethportal_api::Discv5ApiClient;
 use ethportal_api::{BeaconContentKey, BeaconNetworkApiClient};
 use hivesim::types::ClientDefinition;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use serde_json::json;
 use std::collections::HashMap;
@@ -28,7 +27,7 @@ dyn_async! {
                     always_run: false,
                     run: test_node_info,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -40,7 +39,7 @@ dyn_async! {
                     always_run: false,
                     run: test_local_content_expect_content_absent,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -52,7 +51,7 @@ dyn_async! {
                     always_run: false,
                     run: test_store,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -64,7 +63,7 @@ dyn_async! {
                     always_run: false,
                     run: test_local_content_expect_content_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -76,7 +75,7 @@ dyn_async! {
                     always_run: false,
                     run: test_add_enr_expect_true,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -88,7 +87,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_non_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -100,7 +99,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_enr_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -112,7 +111,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_local_enr,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -124,7 +123,7 @@ dyn_async! {
                     always_run: false,
                     run: test_delete_enr_non_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -136,7 +135,7 @@ dyn_async! {
                     always_run: false,
                     run: test_delete_enr_enr_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -148,7 +147,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_non_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -160,7 +159,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_enr_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -172,7 +171,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_local_enr,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -184,7 +183,7 @@ dyn_async! {
                     always_run: false,
                     run: test_recursive_find_content_content_absent,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -193,7 +192,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_node_info<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_node_info<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -208,7 +207,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -224,7 +223,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_store<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_store<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -241,7 +240,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -271,7 +270,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -290,7 +289,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -306,7 +305,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -334,7 +333,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -365,7 +364,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -384,7 +383,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -429,7 +428,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -445,7 +444,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -476,7 +475,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -505,7 +504,7 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a AbsentContent via RecursiveFindContent when the data doesn't exist
-    async fn test_recursive_find_content_content_absent<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_recursive_find_content_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {

--- a/simulators/portal/src/suites/history/interop.rs
+++ b/simulators/portal/src/suites/history/interop.rs
@@ -1,13 +1,9 @@
 use crate::suites::history::constants::{TEST_DATA_FILE_PATH, TRIN_BRIDGE_CLIENT_TYPE};
 use ethportal_api::types::history::ContentInfo;
-use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::{
     ContentValue, Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
-    OverlayContentKey,
 };
 use hivesim::types::ClientDefinition;
-use hivesim::types::ContentKeyValue;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use itertools::Itertools;
 use portal_spec_test_utils_rs::get_flair;
@@ -22,21 +18,13 @@ const MAX_PORTAL_CONTENT_PAYLOAD_SIZE: usize = 1165;
 const HEADER_WITH_PROOF_KEY: &str =
     "0x00720704f3aa11c53cf344ea069db95cecb81ad7453c8f276b2a1062979611f09c";
 
-fn content_pair_to_string_pair(
-    content_pair: (HistoryContentKey, HistoryContentValue),
-) -> ContentKeyValue {
-    let (content_key, content_value) = content_pair;
-    ContentKeyValue {
-        key: content_key.to_hex(),
-        value: hex_encode(content_value.encode()),
-    }
-}
+type TestData = Vec<(HistoryContentKey, HistoryContentValue)>;
 
 /// Processed content data for history tests
 struct ProcessedContent {
     content_type: String,
     block_number: u64,
-    test_data: Vec<ContentKeyValue>,
+    test_data: TestData,
 }
 
 fn process_content(
@@ -55,28 +43,22 @@ fn process_content(
                     HistoryContentKey::BlockHeaderWithProof(_) => (
                         "Block Header".to_string(),
                         header_with_proof.header.number,
-                        vec![content_pair_to_string_pair(last_header.clone())],
+                        vec![last_header.clone()],
                     ),
                     HistoryContentKey::BlockBody(_) => (
                         "Block Body".to_string(),
                         header_with_proof.header.number,
-                        vec![
-                            content_pair_to_string_pair(history_content),
-                            content_pair_to_string_pair(last_header.clone()),
-                        ],
+                        vec![history_content, last_header.clone()],
                     ),
                     HistoryContentKey::BlockReceipts(_) => (
                         "Block Receipt".to_string(),
                         header_with_proof.header.number,
-                        vec![
-                            content_pair_to_string_pair(history_content),
-                            content_pair_to_string_pair(last_header.clone()),
-                        ],
+                        vec![history_content, last_header.clone()],
                     ),
                     HistoryContentKey::EpochAccumulator(_) => (
                         "Epoch Accumulator".to_string(),
                         u64::MAX,
-                        vec![content_pair_to_string_pair(history_content)],
+                        vec![history_content],
                     ),
                 }
             } else {
@@ -127,7 +109,7 @@ dyn_async! {
                         always_run: false,
                         run: test_offer,
                         environments: None,
-                        test_data: Some(TestData::ContentList(test_data.clone())),
+                        test_data: test_data.clone(),
                         clients: vec![client_a.clone(), client_b.clone()],
                     }
                 ).await;
@@ -139,7 +121,7 @@ dyn_async! {
                         always_run: false,
                         run: test_recursive_find_content,
                         environments: None,
-                        test_data: Some(TestData::ContentList(test_data.clone())),
+                        test_data: test_data.clone(),
                         clients: vec![client_a.clone(), client_b.clone()],
                     }
                 ).await;
@@ -151,7 +133,7 @@ dyn_async! {
                         always_run: false,
                         run: test_find_content,
                         environments: None,
-                        test_data: Some(TestData::ContentList(test_data)),
+                        test_data,
                         clients: vec![client_a.clone(), client_b.clone()],
                     }
                 ).await;
@@ -164,7 +146,7 @@ dyn_async! {
                     always_run: false,
                     run: test_ping,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
@@ -176,7 +158,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_content_non_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
@@ -188,7 +170,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_nodes_zero_distance,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
@@ -201,7 +183,7 @@ dyn_async! {
                     always_run: false,
                     run: test_gossip_two_nodes,
                     environments: None,
-                    test_data: Some(TestData::ContentList(content.clone().into_iter().map(content_pair_to_string_pair).collect())),
+                    test_data: content.clone(),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
@@ -211,7 +193,7 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will not return content via FINDCONTENT.
-    async fn test_find_content_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_content_non_present<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
@@ -253,22 +235,14 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_offer<'a>(clients: Vec<Client>, test_data: Option<TestData>) {
+    async fn test_offer<'a>(clients: Vec<Client>, test_data: TestData) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
                 panic!("Unable to get expected amount of clients from NClientTestSpec");
             }
         };
-        let test_data = match test_data.map(|data| data.content_list()) {
-            Some(test_data) => test_data,
-            None => panic!("Expected test data non was provided"),
-        };
-        if let Some(ContentKeyValue { key: optional_key, value: optional_value }) = test_data.get(1) {
-            let optional_key: HistoryContentKey =
-                serde_json::from_value(json!(optional_key)).unwrap();
-            let optional_value: HistoryContentValue =
-                serde_json::from_value(json!(optional_value)).unwrap();
+        if let Some((optional_key, optional_value)) = test_data.get(1).cloned() {
             match client_b.rpc.store(optional_key, optional_value).await {
                 Ok(result) => if !result {
                     panic!("Unable to store optional content for recursive find content");
@@ -278,11 +252,7 @@ dyn_async! {
                 }
             }
         }
-        let ContentKeyValue { key: target_key, value: target_value } = test_data.first().expect("Target content is required for this test");
-        let target_key: HistoryContentKey =
-            serde_json::from_value(json!(target_key)).unwrap();
-        let target_value: HistoryContentValue =
-            serde_json::from_value(json!(target_value)).unwrap();
+        let (target_key, target_value) = test_data.first().cloned().expect("Target content is required for this test");
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
@@ -309,7 +279,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_ping<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_ping<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
@@ -350,7 +320,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_nodes_zero_distance<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_nodes_zero_distance<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
@@ -386,22 +356,14 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a content via RECURSIVEFINDCONTENT template that it has stored locally
-    async fn test_recursive_find_content<'a>(clients: Vec<Client>, test_data: Option<TestData>) {
+    async fn test_recursive_find_content<'a>(clients: Vec<Client>, test_data: TestData) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
                 panic!("Unable to get expected amount of clients from NClientTestSpec");
             }
         };
-        let test_data = match test_data.map(|data| data.content_list()) {
-            Some(test_data) => test_data,
-            None => panic!("Expected test data non was provided"),
-        };
-        if let Some(ContentKeyValue { key: optional_key, value: optional_value }) = test_data.get(1) {
-            let optional_key: HistoryContentKey =
-                serde_json::from_value(json!(optional_key)).unwrap();
-            let optional_value: HistoryContentValue =
-                serde_json::from_value(json!(optional_value)).unwrap();
+        if let Some((optional_key, optional_value)) = test_data.get(1).cloned() {
             match client_b.rpc.store(optional_key, optional_value).await {
                 Ok(result) => if !result {
                     panic!("Unable to store optional content for recursive find content");
@@ -412,11 +374,7 @@ dyn_async! {
             }
         }
 
-        let ContentKeyValue { key: target_key, value: target_value } = test_data.first().expect("Target content is required for this test");
-        let target_key: HistoryContentKey =
-            serde_json::from_value(json!(target_key)).unwrap();
-        let target_value: HistoryContentValue =
-            serde_json::from_value(json!(target_value)).unwrap();
+        let (target_key, target_value) = test_data.first().cloned().expect("Target content is required for this test");
         match client_b.rpc.store(target_key.clone(), target_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Error storing target content for recursive find content");
@@ -471,22 +429,14 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a x content via FINDCONTENT that it has stored locally
-    async fn test_find_content<'a> (clients: Vec<Client>, test_data: Option<TestData>) {
+    async fn test_find_content<'a> (clients: Vec<Client>, test_data: TestData) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
                 panic!("Unable to get expected amount of clients from NClientTestSpec");
             }
         };
-        let test_data = match test_data.map(|data| data.content_list()) {
-            Some(test_data) => test_data,
-            None => panic!("Expected test data none was provided"),
-        };
-        if let Some(ContentKeyValue { key: optional_key, value: optional_value }) = test_data.get(1) {
-            let optional_key: HistoryContentKey =
-                serde_json::from_value(json!(optional_key)).unwrap();
-            let optional_value: HistoryContentValue =
-                serde_json::from_value(json!(optional_value)).unwrap();
+        if let Some((optional_key, optional_value)) = test_data.get(1).cloned() {
             match client_b.rpc.store(optional_key, optional_value).await {
                 Ok(result) => if !result {
                     panic!("Unable to store optional content for find content");
@@ -497,11 +447,7 @@ dyn_async! {
             }
         }
 
-        let ContentKeyValue { key: target_key, value: target_value } = test_data.first().expect("Target content is required for this test");
-        let target_key: HistoryContentKey =
-            serde_json::from_value(json!(target_key)).unwrap();
-        let target_value: HistoryContentValue =
-            serde_json::from_value(json!(target_value)).unwrap();
+        let (target_key, target_value) = test_data.first().cloned().expect("Target content is required for this test");
         match client_b.rpc.store(target_key.clone(), target_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Error storing target content for find content");
@@ -547,16 +493,12 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_gossip_two_nodes<'a> (clients: Vec<Client>, test_data: Option<TestData>) {
+    async fn test_gossip_two_nodes<'a> (clients: Vec<Client>, test_data: TestData) {
         let (client_a, client_b) = match clients.iter().collect_tuple() {
             Some((client_a, client_b)) => (client_a, client_b),
             None => {
                 panic!("Unable to get expected amount of clients from NClientTestSpec");
             }
-        };
-        let test_data = match test_data.map(|data| data.content_list()) {
-            Some(test_data) => test_data,
-            None => panic!("Expected test data non was provided"),
         };
         // connect clients
         let client_b_enr = match client_b.rpc.node_info().await {
@@ -574,12 +516,7 @@ dyn_async! {
         }
 
         // With default node settings nodes should be storing all content
-        for ContentKeyValue { key: content_key, value: content_value } in test_data.clone() {
-            let content_key: HistoryContentKey =
-                serde_json::from_value(json!(content_key)).unwrap();
-            let content_value: HistoryContentValue =
-                serde_json::from_value(json!(content_value)).unwrap();
-
+        for (content_key, content_value) in test_data.clone() {
             match client_a.rpc.gossip(content_key.clone(), content_value.clone()).await {
                 Ok(nodes_gossiped_to) => {
                    if nodes_gossiped_to != 1 {
@@ -600,19 +537,10 @@ dyn_async! {
         tokio::time::sleep(Duration::from_secs(test_data.len() as u64)).await;
 
         // process raw test data to generate content details for error output
-        let ContentKeyValue { key: first_header_key, value: first_header_value } = test_data.first().unwrap();
-        let first_header_key: HistoryContentKey =
-                serde_json::from_value(json!(first_header_key)).unwrap();
-        let first_header_value: HistoryContentValue =
-                serde_json::from_value(json!(first_header_value)).unwrap();
+        let (first_header_key, first_header_value) = test_data.first().cloned().unwrap();
         let mut last_header_seen: (HistoryContentKey, HistoryContentValue) = (first_header_key, first_header_value);
         let mut result = vec![];
-        for ContentKeyValue { key: content_key, value: content_value } in test_data.into_iter() {
-            let content_key: HistoryContentKey =
-                serde_json::from_value(json!(content_key)).unwrap();
-            let content_value: HistoryContentValue =
-                serde_json::from_value(json!(content_value)).unwrap();
-
+        for (content_key, content_value) in test_data.into_iter() {
             if let HistoryContentKey::BlockHeaderWithProof(_) = &content_key {
                 last_header_seen = (content_key.clone(), content_value.clone());
             }

--- a/simulators/portal/src/suites/history/mesh.rs
+++ b/simulators/portal/src/suites/history/mesh.rs
@@ -6,7 +6,6 @@ use ethportal_api::{
     Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
 };
 use hivesim::types::ClientDefinition;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use itertools::Itertools;
 use serde_json::json;
@@ -39,7 +38,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_content_two_jumps,
                     environments: Some(vec![None, Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -52,7 +51,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_content_two_jumps,
                     environments: Some(vec![None, Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -64,7 +63,7 @@ dyn_async! {
                     always_run: false,
                     run: test_find_nodes_distance_of_client_c,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -73,7 +72,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
             None => {
@@ -168,7 +167,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
             None => {

--- a/simulators/portal/src/suites/history/rpc_compat.rs
+++ b/simulators/portal/src/suites/history/rpc_compat.rs
@@ -3,7 +3,6 @@ use ethportal_api::types::enr::generate_random_remote_enr;
 use ethportal_api::Discv5ApiClient;
 use ethportal_api::{HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient};
 use hivesim::types::ClientDefinition;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use serde_json::json;
 
@@ -27,7 +26,7 @@ dyn_async! {
                     always_run: false,
                     run: test_node_info,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -39,7 +38,7 @@ dyn_async! {
                     always_run: false,
                     run: test_local_content_expect_content_absent,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -51,7 +50,7 @@ dyn_async! {
                     always_run: false,
                     run: test_store,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -63,7 +62,7 @@ dyn_async! {
                     always_run: false,
                     run: test_local_content_expect_content_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -75,7 +74,7 @@ dyn_async! {
                     always_run: false,
                     run: test_add_enr_expect_true,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -87,7 +86,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_non_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -99,7 +98,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_enr_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -111,7 +110,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_local_enr,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -123,7 +122,7 @@ dyn_async! {
                     always_run: false,
                     run: test_delete_enr_non_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -135,7 +134,7 @@ dyn_async! {
                     always_run: false,
                     run: test_delete_enr_enr_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -147,7 +146,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_non_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -159,7 +158,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_enr_present,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -171,7 +170,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_local_enr,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -183,7 +182,7 @@ dyn_async! {
                     always_run: false,
                     run: test_recursive_find_content_content_absent,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -192,7 +191,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_node_info<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_node_info<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -207,7 +206,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -223,7 +222,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_store<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_store<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -240,7 +239,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -270,7 +269,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -289,7 +288,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -305,7 +304,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -333,7 +332,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -364,7 +363,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -383,7 +382,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -428,7 +427,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -444,7 +443,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -475,7 +474,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -504,7 +503,7 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a AbsentContent via RecursiveFindContent when the data doesn't exist
-    async fn test_recursive_find_content_content_absent<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_recursive_find_content_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {

--- a/simulators/portal/src/suites/history/trin_bridge.rs
+++ b/simulators/portal/src/suites/history/trin_bridge.rs
@@ -6,7 +6,6 @@ use ethportal_api::HistoryContentKey;
 use ethportal_api::HistoryContentValue;
 use ethportal_api::{Discv5ApiClient, HistoryNetworkApiClient};
 use hivesim::types::ClientDefinition;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use portal_spec_test_utils_rs::get_flair;
 use serde_yaml::Value;
@@ -61,7 +60,7 @@ dyn_async! {
                     always_run: false,
                     run: test_bridge,
                     environments: None,
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -70,7 +69,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_bridge<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_bridge<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {

--- a/simulators/portal/src/suites/state/rpc_compat.rs
+++ b/simulators/portal/src/suites/state/rpc_compat.rs
@@ -6,7 +6,6 @@ use ethportal_api::types::enr::generate_random_remote_enr;
 use ethportal_api::Discv5ApiClient;
 use ethportal_api::{StateContentKey, StateContentValue, StateNetworkApiClient};
 use hivesim::types::ClientDefinition;
-use hivesim::types::TestData;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use serde_json::json;
 use std::collections::HashMap;
@@ -27,7 +26,7 @@ dyn_async! {
                     always_run: false,
                     run: test_node_info,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -39,7 +38,7 @@ dyn_async! {
                     always_run: false,
                     run: test_local_content_expect_content_absent,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -51,7 +50,7 @@ dyn_async! {
                     always_run: false,
                     run: test_store,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -63,7 +62,7 @@ dyn_async! {
                     always_run: false,
                     run: test_local_content_expect_content_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -75,7 +74,7 @@ dyn_async! {
                     always_run: false,
                     run: test_add_enr_expect_true,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -87,7 +86,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_non_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -99,7 +98,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_enr_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -111,7 +110,7 @@ dyn_async! {
                     always_run: false,
                     run: test_get_enr_local_enr,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -123,7 +122,7 @@ dyn_async! {
                     always_run: false,
                     run: test_delete_enr_non_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -135,7 +134,7 @@ dyn_async! {
                     always_run: false,
                     run: test_delete_enr_enr_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -147,7 +146,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_non_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -159,7 +158,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_enr_present,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -171,7 +170,7 @@ dyn_async! {
                     always_run: false,
                     run: test_lookup_enr_local_enr,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -183,7 +182,7 @@ dyn_async! {
                     always_run: false,
                     run: test_recursive_find_content_content_absent,
                     environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
-                    test_data: None,
+                    test_data: (),
                     clients: vec![client.clone()],
                 }
             ).await;
@@ -192,7 +191,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_node_info<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_node_info<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -207,7 +206,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -223,7 +222,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_store<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_store<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -240,7 +239,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -270,7 +269,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -289,7 +288,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -305,7 +304,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -333,7 +332,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -364,7 +363,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -383,7 +382,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -428,7 +427,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -444,7 +443,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -475,7 +474,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -504,7 +503,7 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a AbsentContent via RecursiveFindContent when the data doesn't exist
-    async fn test_recursive_find_content_content_absent<'a>(clients: Vec<Client>, _: Option<TestData>) {
+    async fn test_recursive_find_content_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {


### PR DESCRIPTION
Update Portal simulators to use updated version of hivesim (with generic test data type, see #1150).

I run the tests locally and I didn't observe any unexpected behavior or tests failing