### PR TITLE
simulators/portal: store block header before gossip and offer state requests

### DIFF
--- a/simulators/portal/src/suites/beacon/constants.rs
+++ b/simulators/portal/src/suites/beacon/constants.rs
@@ -1,6 +1,4 @@
 pub const TEST_DATA_FILE_PATH: &str = "./test-data/beacon_test_data.yaml";
-pub const HIVE_PORTAL_NETWORKS_SELECTED: &str = "HIVE_PORTAL_NETWORKS_SELECTED";
-pub const BEACON_STRING: &str = "beacon";
 
 // private key hive environment variable
 pub const PRIVATE_KEY_ENVIRONMENT_VARIABLE: &str = "HIVE_CLIENT_PRIVATE_KEY";

--- a/simulators/portal/src/suites/beacon/interop.rs
+++ b/simulators/portal/src/suites/beacon/interop.rs
@@ -1,6 +1,7 @@
-use crate::suites::beacon::constants::{
-    BEACON_STRING, HIVE_PORTAL_NETWORKS_SELECTED, TEST_DATA_FILE_PATH, TRIN_BRIDGE_CLIENT_TYPE,
-};
+use std::collections::HashMap;
+
+use crate::suites::beacon::constants::{TEST_DATA_FILE_PATH, TRIN_BRIDGE_CLIENT_TYPE};
+use crate::suites::environment::PortalNetwork;
 use ethportal_api::types::beacon::ContentInfo;
 use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::{
@@ -11,7 +12,6 @@ use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use itertools::Itertools;
 use serde_json::json;
 use serde_yaml::Value;
-use std::collections::HashMap;
 
 // This is taken from Trin. It should be fairly standard
 const MAX_PORTAL_CONTENT_PAYLOAD_SIZE: usize = 1165;
@@ -75,6 +75,9 @@ dyn_async! {
         // todo: remove this once we implement role in hivesim-rs
         let clients: Vec<ClientDefinition> = clients.into_iter().filter(|client| client.name != *TRIN_BRIDGE_CLIENT_TYPE).collect();
 
+        let environment = Some(HashMap::from([PortalNetwork::as_environment_flag([PortalNetwork::Beacon])]));
+        let environments = Some(vec![environment.clone(), environment]);
+
         let values = std::fs::read_to_string(TEST_DATA_FILE_PATH)
             .expect("cannot find test asset");
         let values: Value = serde_yaml::from_str(&values).unwrap();
@@ -95,7 +98,7 @@ dyn_async! {
                         description: "".to_string(),
                         always_run: false,
                         run: test_recursive_find_content,
-                        environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                        environments: environments.clone(),
                         test_data: test_data.clone(),
                         clients: vec![client_a.clone(), client_b.clone()],
                     }
@@ -107,7 +110,7 @@ dyn_async! {
                         description: "".to_string(),
                         always_run: false,
                         run: test_find_content,
-                        environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                        environments: environments.clone(),
                         test_data,
                         clients: vec![client_a.clone(), client_b.clone()],
                     }
@@ -120,7 +123,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_ping,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
@@ -132,7 +135,7 @@ dyn_async! {
                     description: "find content: calls find content that doesn't exist".to_string(),
                     always_run: false,
                     run: test_find_content_non_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }
@@ -144,7 +147,7 @@ dyn_async! {
                     description: "find nodes: distance zero expect called nodes enr".to_string(),
                     always_run: false,
                     run: test_find_nodes_zero_distance,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone()],
                 }

--- a/simulators/portal/src/suites/beacon/mesh.rs
+++ b/simulators/portal/src/suites/beacon/mesh.rs
@@ -1,7 +1,8 @@
 use crate::suites::beacon::constants::{
-    BEACON_STRING, CONSTANT_CONTENT_KEY, CONSTANT_CONTENT_VALUE, HIVE_PORTAL_NETWORKS_SELECTED,
-    PRIVATE_KEY_ENVIRONMENT_VARIABLE, TRIN_BRIDGE_CLIENT_TYPE,
+    CONSTANT_CONTENT_KEY, CONSTANT_CONTENT_VALUE, PRIVATE_KEY_ENVIRONMENT_VARIABLE,
+    TRIN_BRIDGE_CLIENT_TYPE,
 };
+use crate::suites::environment::PortalNetwork;
 use ethportal_api::jsonrpsee::core::__reexports::serde_json;
 use ethportal_api::types::beacon::ContentInfo;
 use ethportal_api::types::distance::{Metric, XorMetric};
@@ -21,6 +22,8 @@ dyn_async! {
         // todo: remove this once we implement role in hivesim-rs
         let clients: Vec<ClientDefinition> = clients.into_iter().filter(|client| client.name != *TRIN_BRIDGE_CLIENT_TYPE).collect();
 
+        let environment_flag = PortalNetwork::as_environment_flag([PortalNetwork::Beacon]);
+
         let private_key_1 = "fc34e57cc83ed45aae140152fd84e2c21d1f4d46e19452e13acc7ee90daa5bac".to_string();
         let private_key_2 = "e5add57dc4c9ef382509e61ce106ec86f60eb73bbfe326b00f54bf8e1819ba11".to_string();
 
@@ -32,7 +35,11 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_two_jumps,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: Some(vec![
+                        Some(HashMap::from([environment_flag.clone()])),
+                        Some(HashMap::from([environment_flag.clone(), (PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())])),
+                        Some(HashMap::from([environment_flag.clone(), (PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())])),
+                    ]),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
@@ -45,7 +52,11 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_two_jumps,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone()), (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: Some(vec![
+                        Some(HashMap::from([environment_flag.clone()])),
+                        Some(HashMap::from([environment_flag.clone(), (PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())])),
+                        Some(HashMap::from([environment_flag.clone(), (PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())])),
+                    ]),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
@@ -57,7 +68,11 @@ dyn_async! {
                     description: "find nodes: distance of client A expect seeded enr returned".to_string(),
                     always_run: false,
                     run: test_find_nodes_distance_of_client_c,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())])), Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: Some(vec![
+                        Some(HashMap::from([environment_flag.clone()])),
+                        Some(HashMap::from([environment_flag.clone()])),
+                        Some(HashMap::from([environment_flag.clone()])),
+                    ]),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }

--- a/simulators/portal/src/suites/beacon/rpc_compat.rs
+++ b/simulators/portal/src/suites/beacon/rpc_compat.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
 use crate::suites::beacon::constants::{
-    BEACON_STRING, CONSTANT_CONTENT_KEY, CONSTANT_CONTENT_VALUE, HIVE_PORTAL_NETWORKS_SELECTED,
-    TRIN_BRIDGE_CLIENT_TYPE,
+    CONSTANT_CONTENT_KEY, CONSTANT_CONTENT_VALUE, TRIN_BRIDGE_CLIENT_TYPE,
 };
+use crate::suites::environment::PortalNetwork;
 use ethportal_api::types::enr::generate_random_remote_enr;
 use ethportal_api::BeaconContentValue;
 use ethportal_api::Discv5ApiClient;
@@ -9,7 +11,6 @@ use ethportal_api::{BeaconContentKey, BeaconNetworkApiClient};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use serde_json::json;
-use std::collections::HashMap;
 
 dyn_async! {
     pub async fn run_rpc_compat_beacon_test_suite<'a> (test: &'a mut Test, _client: Option<Client>) {
@@ -17,6 +18,9 @@ dyn_async! {
         let clients = test.sim.client_types().await;
         // todo: remove this once we implement role in hivesim-rs
         let clients: Vec<ClientDefinition> = clients.into_iter().filter(|client| client.name != *TRIN_BRIDGE_CLIENT_TYPE).collect();
+
+        let environment_flag = PortalNetwork::as_environment_flag([PortalNetwork::Beacon]);
+        let environments = Some(vec![Some(HashMap::from([environment_flag]))]);
 
         // Test single type of client
         for client in &clients {
@@ -26,7 +30,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_node_info,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -38,7 +42,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_local_content_expect_content_absent,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -50,7 +54,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_store,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -62,7 +66,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_local_content_expect_content_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -74,7 +78,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_add_enr_expect_true,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -86,7 +90,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_get_enr_non_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -98,7 +102,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_get_enr_enr_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -110,7 +114,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_get_enr_local_enr,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -122,7 +126,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_delete_enr_non_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -134,7 +138,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_delete_enr_enr_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -146,7 +150,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_lookup_enr_non_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -158,7 +162,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_lookup_enr_enr_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -170,7 +174,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_lookup_enr_local_enr,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -182,7 +186,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_recursive_find_content_content_absent,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), BEACON_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }

--- a/simulators/portal/src/suites/environment.rs
+++ b/simulators/portal/src/suites/environment.rs
@@ -1,0 +1,34 @@
+use std::fmt::Display;
+
+use itertools::Itertools;
+
+pub const HIVE_PORTAL_NETWORKS_SELECTED: &str = "HIVE_PORTAL_NETWORKS_SELECTED";
+
+#[derive(Debug, Clone, Copy)]
+pub enum PortalNetwork {
+    History,
+    Beacon,
+    State,
+}
+
+impl PortalNetwork {
+    pub fn as_environment_flag(
+        networks: impl IntoIterator<Item = PortalNetwork>,
+    ) -> (String, String) {
+        let joined = networks
+            .into_iter()
+            .map(|network| network.to_string())
+            .join(",");
+        (HIVE_PORTAL_NETWORKS_SELECTED.to_string(), joined)
+    }
+}
+
+impl Display for PortalNetwork {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PortalNetwork::History => f.write_str("history"),
+            PortalNetwork::Beacon => f.write_str("beacon"),
+            PortalNetwork::State => f.write_str("state"),
+        }
+    }
+}

--- a/simulators/portal/src/suites/mod.rs
+++ b/simulators/portal/src/suites/mod.rs
@@ -1,3 +1,4 @@
 pub mod beacon;
+pub mod environment;
 pub mod history;
 pub mod state;

--- a/simulators/portal/src/suites/state/constants.rs
+++ b/simulators/portal/src/suites/state/constants.rs
@@ -1,6 +1,4 @@
 pub const TEST_DATA_FILE_PATH: &str = "./test-data/state_test_data.yaml";
-pub const HIVE_PORTAL_NETWORKS_SELECTED: &str = "HIVE_PORTAL_NETWORKS_SELECTED";
-pub const STATE_STRING: &str = "state";
 
 // trin-bridge constants
 pub const TRIN_BRIDGE_CLIENT_TYPE: &str = "trin-bridge";

--- a/simulators/portal/src/suites/state/rpc_compat.rs
+++ b/simulators/portal/src/suites/state/rpc_compat.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
+use crate::suites::environment::PortalNetwork;
 use crate::suites::state::constants::{
-    CONTENT_KEY, CONTENT_LOOKUP_VALUE, CONTENT_OFFER_VALUE, HIVE_PORTAL_NETWORKS_SELECTED,
-    STATE_STRING, TRIN_BRIDGE_CLIENT_TYPE,
+    CONTENT_KEY, CONTENT_LOOKUP_VALUE, CONTENT_OFFER_VALUE, TRIN_BRIDGE_CLIENT_TYPE,
 };
 use ethportal_api::types::enr::generate_random_remote_enr;
 use ethportal_api::Discv5ApiClient;
@@ -8,7 +10,6 @@ use ethportal_api::{StateContentKey, StateContentValue, StateNetworkApiClient};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use serde_json::json;
-use std::collections::HashMap;
 
 dyn_async! {
     pub async fn run_rpc_compat_state_test_suite<'a> (test: &'a mut Test, _client: Option<Client>) {
@@ -16,6 +17,9 @@ dyn_async! {
         let clients = test.sim.client_types().await;
         // todo: remove this once we implement role in hivesim-rs
         let clients: Vec<ClientDefinition> = clients.into_iter().filter(|client| client.name != *TRIN_BRIDGE_CLIENT_TYPE).collect();
+
+        let environment_flag = PortalNetwork::as_environment_flag([PortalNetwork::State, PortalNetwork::History]);
+        let environments = Some(vec![Some(HashMap::from([environment_flag]))]);
 
         // Test single type of client
         for client in &clients {
@@ -25,7 +29,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_node_info,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -37,7 +41,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_local_content_expect_content_absent,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -49,7 +53,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_store,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -61,7 +65,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_local_content_expect_content_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -73,7 +77,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_add_enr_expect_true,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -85,7 +89,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_get_enr_non_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -97,7 +101,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_get_enr_enr_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -109,7 +113,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_get_enr_local_enr,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -121,7 +125,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_delete_enr_non_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -133,7 +137,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_delete_enr_enr_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -145,7 +149,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_lookup_enr_non_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -157,7 +161,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_lookup_enr_enr_present,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -169,7 +173,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_lookup_enr_local_enr,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }
@@ -181,7 +185,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_recursive_find_content_content_absent,
-                    environments: Some(vec![Some(HashMap::from([(HIVE_PORTAL_NETWORKS_SELECTED.to_string(), STATE_STRING.to_string())]))]),
+                    environments: environments.clone(),
                     test_data: (),
                     clients: vec![client.clone()],
                 }


### PR DESCRIPTION
The state network should verify that content is anchored to the canonical blockchain. For that, in needs access to the block header, which we have to seed at the start of the test.

Now that some tests require more than one portal network running, I refactored how that is configured.