### PR TITLE
internal/libhive: skip unsuccessful build of client

### DIFF
--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -58,7 +58,7 @@ func (r *Runner) buildClients(ctx context.Context, clientList []ClientDesignator
 		return errors.New("client list is empty, cannot simulate")
 	}
 
-	r.clientDefs = make([]*ClientDefinition, len(clientList))
+	r.clientDefs = make([]*ClientDefinition, 0, len(clientList))
 
 	var anyBuilt bool
 	log15.Info(fmt.Sprintf("building %d clients...", len(clientList)))
@@ -72,12 +72,12 @@ func (r *Runner) buildClients(ctx context.Context, clientList []ClientDesignator
 		if err != nil {
 			log15.Warn("can't read version info of "+client.Client, "image", image, "err", err)
 		}
-		r.clientDefs[i] = &ClientDefinition{
+		r.clientDefs = append(r.clientDefs, &ClientDefinition{
 			Name:    client.Name(),
 			Version: strings.TrimSpace(string(version)),
 			Image:   image,
 			Meta:    r.inv.Clients[client.Client].Meta,
-		}
+		})
 	}
 	if !anyBuilt {
 		return errors.New("all clients failed to build")


### PR DESCRIPTION
To reproduce the issue, set this clients definition:

```yaml
- client: go-ethereum
  nametag: multicall-git
  dockerfile: git
  build_args:
    github: s1na/go-ethereum
    tag: multicall

- client: nethermind
  nametag: multicall-git
  dockerfile: git
  build_args:
    github: NethermindEth/nethermind
    tag: feature/eth_simulate_fix
```

The branch feature/eth_simulate_fix has been removed from the nethermind repo. This causes the container build to fail:

```
Cloning: NethermindEth/nethermind - feature/eth_simulate_fix
Cloning into 'nethermind'...
fatal: Remote branch feature/eth_simulate_fix not found in upstream origin
EROR[08-20|11:49:12] image build failed                       image=hive/clients/nethermind_multicall-git:latest err="The command '/bin/sh -c echo \"Cloning: $github - $tag\" &&     git clone -b $tag https://github.com/$github &&     cd /nethermind/src/Nethermind/Nethermind.Runner &&     dotnet build -c release' returned a non-zero code: 128"
```

However hive still tries to run the simulation against that client and crashes:

```
[a3bf5ee8] panic: runtime error: invalid memory address or nil pointer dereference
[a3bf5ee8] [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x6a3508]
[a3bf5ee8] 
[a3bf5ee8] goroutine 1 [running]:
[a3bf5ee8] github.com/ethereum/hive/hivesim.(*ClientDefinition).HasRole(...)
[a3bf5ee8]      /go/pkg/mod/github.com/ethereum/hive@v0.0.0-20240610172825-2430a68c753a/hivesim/data.go:45
[a3bf5ee8] github.com/ethereum/hive/hivesim.ClientTestSpec.runTest({{0x77b078, 0xd}, {0x0, 0x0}, {0x78c3b1, 0x34}, {0x0, 0x0}, 0x1, {0x778533, ...}, ...}, ...)
[a3bf5ee8]      /go/pkg/mod/github.com/ethereum/hive@v0.0.0-20240610172825-2430a68c753a/hivesim/testapi.go:411 +0xe8
[a3bf5ee8] github.com/ethereum/hive/hivesim.RunSuite(0x4000024440, {{0x779df5, 0xa}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x791159, ...}, ...})
[a3bf5ee8]      /go/pkg/mod/github.com/ethereum/hive@v0.0.0-20240610172825-2430a68c753a/hivesim/testapi.go:81 +0x2fc
[a3bf5ee8] github.com/ethereum/hive/hivesim.MustRunSuite(0x0?, {{0x779df5, 0xa}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x791159, ...}, ...})
[a3bf5ee8]      /go/pkg/mod/github.com/ethereum/hive@v0.0.0-20240610172825-2430a68c753a/hivesim/testapi.go:91 +0x7c
[a3bf5ee8] main.main()
[a3bf5ee8]      /source/main.go:58 +0x1e8
```