### PR TITLE
clients/erigon: disable incompatible performance optimization

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -133,6 +133,9 @@ FLAGS="$FLAGS --ws --ws.port=8546"
 # Increase blob slots for tests
 FLAGS="$FLAGS --txpool.blobslots=1000 --txpool.totalblobpoollimit=10000"
 
+# Disable performance optimization incompatible with the tests
+FLAGS="$FLAGS --sync.parallel-state-flushing=false"
+
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
     echo -n $JWT_SECRET > /jwt.secret


### PR DESCRIPTION
https://github.com/erigontech/erigon/pull/11300 introduced a performance optimization that's fine with the actual CL workflow but that breaks Hive tests