### PR TITLE
clients/besu,erigon,ethereumjs,go-ethereum,nethermind,reth,nimbus-el: Add `pragueTime`

### DIFF
--- a/clients/besu/mapper.jq
+++ b/clients/besu/mapper.jq
@@ -49,5 +49,6 @@ def to_int:
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
   }|remove_empty
 }

--- a/clients/erigon/mapper.jq
+++ b/clients/erigon/mapper.jq
@@ -57,5 +57,6 @@ def to_bool:
     "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED == null then true else env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED|to_bool end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
   }|remove_empty
 }

--- a/clients/ethereumjs/mapper.jq
+++ b/clients/ethereumjs/mapper.jq
@@ -72,5 +72,6 @@ def pad_storage_keys:
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
   }
 } | pad_storage_keys | remove_empty

--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -56,6 +56,7 @@ def to_bool:
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
     "terminalTotalDifficultyPassed": true,
   }|remove_empty
 }

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -151,6 +151,15 @@ def clique_engine:
     "eip5656TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
     "eip6780TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
 
+    # Prague
+    "eip2537TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
+    "eip2935TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
+    "eip6110TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
+    "eip7002TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
+    "eip7251TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
+    "eip7685TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
+    "eip7702TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
+
     # Other chain parameters
     "networkID": env.HIVE_NETWORK_ID|to_hex,
     "chainID": env.HIVE_CHAIN_ID|to_hex,

--- a/clients/nimbus-el/mapper.jq
+++ b/clients/nimbus-el/mapper.jq
@@ -77,6 +77,7 @@ def to_bool:
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
     "terminalTotalDifficultyPassed": true,
   }|remove_empty
 }

--- a/clients/reth/mapper.jq
+++ b/clients/reth/mapper.jq
@@ -57,5 +57,6 @@ def to_bool:
     "terminalTotalDifficultyPassed": env.HIVE_TERMINAL_TOTAL_DIFFICULTY_PASSED|to_bool,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
   }|remove_empty
 }


### PR DESCRIPTION
Adds `pragueTime` to all EL clients' mappers.