### PR TITLE
clients/erigon: update dockerhub

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -1,6 +1,6 @@
 ## Build Erigon Via Pre-Built Image:
-ARG baseimage=thorax/erigon
-ARG tag=latest
+ARG baseimage=erigontech/erigon
+ARG tag=main-latest
 FROM $baseimage:$tag
 
 # The upstream erigon container uses a non-root user, but we need


### PR DESCRIPTION
We're moving from `thorax` to `erigontech` on DockerHub. Tag `latest` there points to the latest release instead of the latest commit to branch `main`.