### PR TITLE
simulators/portal: move test utils back to Portal simulator

### DIFF
--- a/simulators/portal/Cargo.lock
+++ b/simulators/portal/Cargo.lock
@@ -2687,18 +2687,12 @@ dependencies = [
  "futures",
  "hivesim",
  "itertools 0.10.5",
- "portal-spec-test-utils-rs",
  "serde_json",
  "serde_yaml",
  "tokio",
  "tracing",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "portal-spec-test-utils-rs"
-version = "0.1.0"
-source = "git+https://github.com/ethereum/portal-spec-tests?rev=954f7d0eb2950a2131048404a1a4ce476bb64657#954f7d0eb2950a2131048404a1a4ce476bb64657"
 
 [[package]]
 name = "powerfmt"

--- a/simulators/portal/Cargo.toml
+++ b/simulators/portal/Cargo.toml
@@ -13,7 +13,6 @@ ethportal-api = { git = "https://github.com/ethereum/trin", rev = "688847c64c1ef
 futures = "0.3.25"
 hivesim = { git = "https://github.com/ethereum/hive", rev = "81fc9a350d7f7ca8bcbe5f54886483d405d4daa8" }
 itertools = "0.10.5"
-portal-spec-test-utils-rs = { git = "https://github.com/ethereum/portal-spec-tests", rev = "954f7d0eb2950a2131048404a1a4ce476bb64657" }
 serde_json = "1.0.87"
 serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }

--- a/simulators/portal/src/suites/history/interop.rs
+++ b/simulators/portal/src/suites/history/interop.rs
@@ -1,4 +1,5 @@
 use crate::suites::history::constants::{TEST_DATA_FILE_PATH, TRIN_BRIDGE_CLIENT_TYPE};
+use crate::suites::utils::get_flair;
 use ethportal_api::types::history::ContentInfo;
 use ethportal_api::{
     ContentValue, Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
@@ -6,7 +7,6 @@ use ethportal_api::{
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use itertools::Itertools;
-use portal_spec_test_utils_rs::get_flair;
 use serde_json::json;
 use serde_yaml::Value;
 use tokio::time::Duration;

--- a/simulators/portal/src/suites/history/trin_bridge.rs
+++ b/simulators/portal/src/suites/history/trin_bridge.rs
@@ -2,12 +2,12 @@ use super::constants::{
     BOOTNODES_ENVIRONMENT_VARIABLE, HIVE_CHECK_LIVE_PORT, TEST_DATA_FILE_PATH,
     TRIN_BRIDGE_CLIENT_TYPE,
 };
+use crate::suites::utils::get_flair;
 use ethportal_api::HistoryContentKey;
 use ethportal_api::HistoryContentValue;
 use ethportal_api::{Discv5ApiClient, HistoryNetworkApiClient};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
-use portal_spec_test_utils_rs::get_flair;
 use serde_yaml::Value;
 use std::collections::HashMap;
 use tokio::time::Duration;

--- a/simulators/portal/src/suites/mod.rs
+++ b/simulators/portal/src/suites/mod.rs
@@ -2,3 +2,4 @@ pub mod beacon;
 pub mod environment;
 pub mod history;
 pub mod state;
+pub mod utils;

--- a/simulators/portal/src/suites/utils.rs
+++ b/simulators/portal/src/suites/utils.rs
@@ -1,0 +1,34 @@
+// Execution Layer hard forks https://ethereum.org/en/history/
+pub const CANCUN_BLOCK_NUMBER: u64 = 19426587;
+pub const SHANGHAI_BLOCK_NUMBER: u64 = 17034870;
+pub const MERGE_BLOCK_NUMBER: u64 = 15537394;
+pub const LONDON_BLOCK_NUMBER: u64 = 12965000;
+pub const BERLIN_BLOCK_NUMBER: u64 = 12244000;
+pub const ISTANBUL_BLOCK_NUMBER: u64 = 9069000;
+pub const CONSTANTINOPLE_BLOCK_NUMBER: u64 = 7280000;
+pub const BYZANTIUM_BLOCK_NUMBER: u64 = 4370000;
+pub const HOMESTEAD_BLOCK_NUMBER: u64 = 1150000;
+
+pub fn get_flair(block_number: u64) -> String {
+    if block_number > CANCUN_BLOCK_NUMBER {
+        " (post-cancun)".to_string()
+    } else if block_number > SHANGHAI_BLOCK_NUMBER {
+        " (post-shanghai)".to_string()
+    } else if block_number > MERGE_BLOCK_NUMBER {
+        " (post-merge)".to_string()
+    } else if block_number > LONDON_BLOCK_NUMBER {
+        " (post-london)".to_string()
+    } else if block_number > BERLIN_BLOCK_NUMBER {
+        " (post-berlin)".to_string()
+    } else if block_number > ISTANBUL_BLOCK_NUMBER {
+        " (post-istanbul)".to_string()
+    } else if block_number > CONSTANTINOPLE_BLOCK_NUMBER {
+        " (post-constantinople)".to_string()
+    } else if block_number > BYZANTIUM_BLOCK_NUMBER {
+        " (post-byzantium)".to_string()
+    } else if block_number > HOMESTEAD_BLOCK_NUMBER {
+        " (post-homestead)".to_string()
+    } else {
+        "".to_string()
+    }
+}


### PR DESCRIPTION
We moved these utils to another crate at the time to reduce code duplication, but with the refactors I did a while ago that workaround is no longer needed.