### PR TITLE
hivesim-rs: bump dependency versions

### DIFF
--- a/hivesim-rs/Cargo.toml
+++ b/hivesim-rs/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 
 
 [dependencies]
-async-trait = "0.1.59"
+async-trait = "0.1.68"
 dyn-clone = "1.0.11"
 jsonrpsee = {version="0.20.0", features = ["client"]}
 regex = "1.10.5"
-reqwest = { version = "0.11.12", default-features = false, features = ["json", "multipart"] }
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87"
-tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "multipart"] }
+serde = { version = "1.0.150", features = ["derive"] }
+serde_json = "1.0.95"
+tokio = { version = "1.14.0", features = ["full"] }


### PR DESCRIPTION
To update ethportal-api in simulators/portal I need to update these depends