### PR TITLE
Add --rpc-api flag to Fluffy startup script

### DIFF
--- a/clients/fluffy/fluffy.sh
+++ b/clients/fluffy/fluffy.sh
@@ -23,5 +23,5 @@ if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
     FLAGS="$FLAGS --netkey-unsafe=0x$HIVE_CLIENT_PRIVATE_KEY"
 fi
 
-fluffy --log-level=INFO --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none \
+fluffy --log-level=INFO --rpc --rpc-address="0.0.0.0" --rpc-api="eth,portal,discovery" --nat:extip:"$IP_ADDR" --network=none \
     --log-level="debug" --disable-state-root-validation $FLAGS


### PR DESCRIPTION
Fluffy's default RPC APIs are now eth and portal but the Discv5 API is used on the portal hive tests so this is needed to enable it.