### PR TITLE
clients/erigon: update erigon tag

### DIFF
--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -4,7 +4,7 @@
 FROM golang:1.22-alpine as builder
 
 ARG github=ledgerwatch/erigon
-ARG tag=devel
+ARG tag=main
 
 RUN echo "Cloning: $github - $tag" \
     && apk add bash build-base ca-certificates git jq \


### PR DESCRIPTION
The `devel` branch has been deprecated, the `main` branch houses the latest and greatest now for Erigon.