### PR TITLE
simulators/portal: update ethportal-api for cleaner return types for ContentInfo

### DIFF
--- a/simulators/portal/Cargo.lock
+++ b/simulators/portal/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "ethportal-api"
 version = "0.2.2"
-source = "git+https://github.com/ethereum/trin?rev=72f144e8e63751eac5c667753b47a4eda9cb9fea#72f144e8e63751eac5c667753b47a4eda9cb9fea"
+source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "trin-utils"
 version = "0.1.1-alpha.1"
-source = "git+https://github.com/ethereum/trin?rev=72f144e8e63751eac5c667753b47a4eda9cb9fea#72f144e8e63751eac5c667753b47a4eda9cb9fea"
+source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
 dependencies = [
  "ansi_term",
  "atty",

--- a/simulators/portal/Cargo.toml
+++ b/simulators/portal/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 alloy-rlp = "0.3.8"
 alloy-primitives = "0.8.3"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "72f144e8e63751eac5c667753b47a4eda9cb9fea" }
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f" }
 futures = "0.3.25"
 hivesim = { git = "https://github.com/ethereum/hive", rev = "4408fc1de3fee3ac23acd25a812c117756af2f39" }
 itertools = "0.10.5"

--- a/simulators/portal/src/suites/beacon/mesh.rs
+++ b/simulators/portal/src/suites/beacon/mesh.rs
@@ -6,7 +6,7 @@ use crate::suites::environment::PortalNetwork;
 use alloy_primitives::Bytes;
 use ethportal_api::jsonrpsee::core::__reexports::serde_json;
 use ethportal_api::types::distance::{Metric, XorMetric};
-use ethportal_api::types::portal::ContentInfo;
+use ethportal_api::types::portal::FindContentInfo;
 use ethportal_api::{BeaconContentKey, BeaconNetworkApiClient, Discv5ApiClient};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
@@ -85,9 +85,7 @@ dyn_async! {
     async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         let content_key: BeaconContentKey = serde_json::from_value(json!(CONSTANT_CONTENT_KEY)).unwrap();
@@ -96,16 +94,12 @@ dyn_async! {
         // get enr for b and c to seed for the jumps
         let client_b_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         let client_c_enr = match client_c.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // seed client_c_enr into routing table of client_b
@@ -119,7 +113,7 @@ dyn_async! {
 
         // send a ping from client B to C to connect the clients
         if let Err(err) = client_b.rpc.ping(client_c_enr.clone()).await {
-                panic!("Unable to receive pong info: {err:?}");
+            panic!("Unable to receive pong info: {err:?}");
         }
 
         // seed the data into client_c
@@ -127,25 +121,13 @@ dyn_async! {
             Ok(result) => if !result {
                 panic!("Unable to store header with proof for find content immediate return test");
             },
-            Err(err) => {
-                panic!("Error storing header with proof for find content immediate return test: {err:?}");
-            }
+            Err(err) => panic!("Error storing header with proof for find content immediate return test: {err:?}"),
         }
 
         let enrs = match client_a.rpc.find_content(client_b_enr.clone(), content_key.clone()).await {
-            Ok(result) => {
-                match result {
-                    ContentInfo::Enrs{ enrs } => {
-                        enrs
-                    },
-                    other => {
-                        panic!("Error: (Enrs) Unexpected FINDCONTENT response not: {other:?}");
-                    }
-                }
-            },
-            Err(err) => {
-                panic!("Error: (Enrs) Unable to get response from FINDCONTENT request: {err:?}");
-            }
+            Ok(FindContentInfo::Enrs{ enrs }) => enrs,
+            Ok(FindContentInfo::Content { .. }) => panic!("Error: Expected Enrs response, instead got Content response"),
+            Err(err) => panic!("Error: (Enrs) Unable to get response from FINDCONTENT request: {err:?}"),
         };
 
         if enrs.len() != 1 {
@@ -153,25 +135,17 @@ dyn_async! {
         }
 
         match client_a.rpc.find_content(enrs[0].clone(), content_key.clone()).await {
-            Ok(result) => {
-                match result {
-                    ContentInfo::Content{ content, utp_transfer } => {
-                        if content != raw_content_value {
-                            panic!("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
-                        }
+            Ok(FindContentInfo::Content { content, utp_transfer }) => {
+                if content != raw_content_value {
+                    panic!("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
+                }
 
-                        if !utp_transfer {
-                            panic!("Error: Unexpected FINDCONTENT response: utp_transfer was supposed to be true");
-                        }
-                    },
-                    other => {
-                        panic!("Error: Unexpected FINDCONTENT response: {other:?}");
-                    }
+                if !utp_transfer {
+                    panic!("Error: Unexpected FINDCONTENT response: utp_transfer was supposed to be false");
                 }
             },
-            Err(err) => {
-                panic!("Error: Unable to get response from FINDCONTENT request: {err:?}");
-            }
+            Ok(FindContentInfo::Enrs { .. }) => panic!("Error: Expected Content response, instead got Enrs response"),
+            Err(err) => panic!("Error: Unable to get response from FINDCONTENT request: {err:?}"),
         }
     }
 }
@@ -180,24 +154,18 @@ dyn_async! {
     async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // We are adding client C to our list so we then can assume only one client per bucket
         let client_c_enr = match client_c.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // seed enr into routing table

--- a/simulators/portal/src/suites/beacon/rpc_compat.rs
+++ b/simulators/portal/src/suites/beacon/rpc_compat.rs
@@ -200,9 +200,7 @@ dyn_async! {
     async fn test_node_info<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         if let Err(err) = Discv5ApiClient::node_info(&client.rpc).await {
@@ -215,9 +213,7 @@ dyn_async! {
     async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: BeaconContentKey = serde_json::from_value(json!(CONSTANT_CONTENT_KEY)).unwrap();
 
@@ -231,9 +227,7 @@ dyn_async! {
     async fn test_store<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: BeaconContentKey = serde_json::from_value(json!(CONSTANT_CONTENT_KEY)).unwrap();
         let raw_content_value = Bytes::from_str(CONSTANT_CONTENT_VALUE).expect("unable to convert content value to bytes");
@@ -248,9 +242,7 @@ dyn_async! {
     async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: BeaconContentKey = serde_json::from_value(json!(CONSTANT_CONTENT_KEY)).unwrap();
         let raw_content_value = Bytes::from_str(CONSTANT_CONTENT_VALUE).expect("unable to convert content value to bytes");
@@ -267,9 +259,7 @@ dyn_async! {
                     panic!("Error receiving content: Expected content: {raw_content_value:?}, Received content: {possible_content:?}");
                 }
             }
-            Err(err) => {
-                panic!("Expected content returned from local_content to be present {}", &err.to_string());
-            }
+            Err(err) => panic!("Expected content returned from local_content to be present {}", &err.to_string()),
         }
     }
 }
@@ -278,9 +268,7 @@ dyn_async! {
     async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
         match BeaconNetworkApiClient::add_enr(&client.rpc, enr).await {
@@ -297,9 +285,7 @@ dyn_async! {
     async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -313,24 +299,18 @@ dyn_async! {
     async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         // get our local enr from NodeInfo
         let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // check if we can fetch data from routing table
         match BeaconNetworkApiClient::get_enr(&client.rpc, target_enr.node_id()).await {
-            Ok(response) => {
-                if response != target_enr {
-                    panic!("Response from GetEnr didn't return expected Enr")
-                }
+            Ok(response) => if response != target_enr {
+                panic!("Response from GetEnr didn't return expected Enr")
             },
             Err(err) => panic!("{}", &err.to_string()),
         }
@@ -341,9 +321,7 @@ dyn_async! {
     async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -358,11 +336,9 @@ dyn_async! {
 
         // check if we can fetch data from routing table
         match BeaconNetworkApiClient::get_enr(&client.rpc, enr.node_id()).await {
-            Ok(response) => {
-                if response != enr {
-                    panic!("Response from GetEnr didn't return expected Enr")
-                }
-            },
+            Ok(response) => if response != enr {
+                panic!("Response from GetEnr didn't return expected Enr");
+            }
             Err(err) => panic!("{}", &err.to_string()),
         }
     }
@@ -372,9 +348,7 @@ dyn_async! {
     async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
         match BeaconNetworkApiClient::delete_enr(&client.rpc, enr.node_id()).await {
@@ -391,9 +365,7 @@ dyn_async! {
     async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -408,10 +380,8 @@ dyn_async! {
 
         // check if data was seeded into the table
         match BeaconNetworkApiClient::get_enr(&client.rpc, enr.node_id()).await {
-            Ok(response) => {
-                if response != enr {
-                    panic!("Response from GetEnr didn't return expected Enr")
-                }
+            Ok(response) => if response != enr {
+                panic!("Response from GetEnr didn't return expected Enr")
             },
             Err(err) => panic!("{}", &err.to_string()),
         }
@@ -436,9 +406,7 @@ dyn_async! {
     async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -452,9 +420,7 @@ dyn_async! {
     async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -469,10 +435,8 @@ dyn_async! {
 
         // check if we can fetch data from routing table
         match BeaconNetworkApiClient::lookup_enr(&client.rpc, enr.node_id()).await {
-            Ok(response) => {
-                if response != enr {
-                    panic!("Response from LookupEnr didn't return expected Enr")
-                }
+            Ok(response) => if response != enr {
+                panic!("Response from LookupEnr didn't return expected Enr")
             },
             Err(err) => panic!("{}", &err.to_string()),
         }
@@ -483,24 +447,18 @@ dyn_async! {
     async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         // get our local enr from NodeInfo
         let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // check if we can fetch data from routing table
         match BeaconNetworkApiClient::lookup_enr(&client.rpc, target_enr.node_id()).await {
-            Ok(response) => {
-                if response != target_enr {
-                    panic!("Response from LookupEnr didn't return expected Enr")
-                }
+            Ok(response) => if response != target_enr {
+                panic!("Response from LookupEnr didn't return expected Enr")
             },
             Err(err) => panic!("{}", &err.to_string()),
         }
@@ -512,9 +470,7 @@ dyn_async! {
     async fn test_get_content_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let header_with_proof_key: BeaconContentKey = serde_json::from_value(json!(CONSTANT_CONTENT_KEY)).unwrap();
 

--- a/simulators/portal/src/suites/history/mesh.rs
+++ b/simulators/portal/src/suites/history/mesh.rs
@@ -117,7 +117,7 @@ dyn_async! {
 
         let enrs = match client_a.rpc.find_content(client_b_enr.clone(), header_with_proof_key.clone()).await {
             Ok(FindContentInfo::Enrs{ enrs }) => enrs,
-            Ok(FindContentInfo::Content{ content: _, utp_transfer: _ }) => panic!("Error: Unexpected FINDCONTENT response: expected Enrs instead got Content"),
+            Ok(FindContentInfo::Content{ .. }) => panic!("Error: Unexpected FINDCONTENT response: expected Enrs instead got Content"),
             Err(err) => panic!("Error: Unable to get response from FINDCONTENT request: {err:?}"),
         };
 

--- a/simulators/portal/src/suites/history/mesh.rs
+++ b/simulators/portal/src/suites/history/mesh.rs
@@ -1,8 +1,7 @@
-use crate::suites::history::constants::TRIN_BRIDGE_CLIENT_TYPE;
 use alloy_primitives::Bytes;
 use ethportal_api::jsonrpsee::core::__reexports::serde_json;
 use ethportal_api::types::distance::{Metric, XorMetric};
-use ethportal_api::types::portal::ContentInfo;
+use ethportal_api::types::portal::FindContentInfo;
 use ethportal_api::{Discv5ApiClient, HistoryContentKey, HistoryNetworkApiClient};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
@@ -10,6 +9,8 @@ use itertools::Itertools;
 use serde_json::json;
 use std::collections::HashMap;
 use std::str::FromStr;
+
+use crate::suites::history::constants::TRIN_BRIDGE_CLIENT_TYPE;
 
 // Header with proof for block number 14764013
 const HEADER_WITH_PROOF_KEY: &str =
@@ -75,9 +76,7 @@ dyn_async! {
     async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(HEADER_WITH_PROOF_KEY)).unwrap();
@@ -86,16 +85,12 @@ dyn_async! {
         // get enr for b and c to seed for the jumps
         let client_b_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         let client_c_enr = match client_c.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // seed client_c_enr into routing table of client_b
@@ -109,7 +104,7 @@ dyn_async! {
 
         // send a ping from client B to C to connect the clients
         if let Err(err) = client_b.rpc.ping(client_c_enr.clone()).await {
-                panic!("Unable to receive pong info: {err:?}");
+            panic!("Unable to receive pong info: {err:?}");
         }
 
         // seed the data into client_c
@@ -117,25 +112,13 @@ dyn_async! {
             Ok(result) => if !result {
                 panic!("Unable to store header with proof for find content immediate return test");
             },
-            Err(err) => {
-                panic!("Error storing header with proof for find content immediate return test: {err:?}");
-            }
+            Err(err) => panic!("Error storing header with proof for find content immediate return test: {err:?}"),
         }
 
         let enrs = match client_a.rpc.find_content(client_b_enr.clone(), header_with_proof_key.clone()).await {
-            Ok(result) => {
-                match result {
-                    ContentInfo::Enrs{ enrs } => {
-                        enrs
-                    },
-                    other => {
-                        panic!("Error: (Enrs) Unexpected FINDCONTENT response not: {other:?}");
-                    }
-                }
-            },
-            Err(err) => {
-                panic!("Error: (Enrs) Unable to get response from FINDCONTENT request: {err:?}");
-            }
+            Ok(FindContentInfo::Enrs{ enrs }) => enrs,
+            Ok(FindContentInfo::Content{ content: _, utp_transfer: _ }) => panic!("Error: Unexpected FINDCONTENT response: expected Enrs instead got Content"),
+            Err(err) => panic!("Error: Unable to get response from FINDCONTENT request: {err:?}"),
         };
 
         if enrs.len() != 1 {
@@ -143,25 +126,17 @@ dyn_async! {
         }
 
         match client_a.rpc.find_content(enrs[0].clone(), header_with_proof_key.clone()).await {
-            Ok(result) => {
-                match result {
-                    ContentInfo::Content{ content, utp_transfer } => {
-                        if content != raw_header_with_proof_value {
-                            panic!("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
-                        }
+            Ok(FindContentInfo::Content { content, utp_transfer }) => {
+                if content != raw_header_with_proof_value {
+                    panic!("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
+                }
 
-                        if utp_transfer {
-                            panic!("Error: Unexpected FINDCONTENT response: utp_transfer was supposed to be false");
-                        }
-                    },
-                    other => {
-                        panic!("Error: Unexpected FINDCONTENT response: {other:?}");
-                    }
+                if utp_transfer {
+                    panic!("Error: Unexpected FINDCONTENT response: utp_transfer was supposed to be false");
                 }
             },
-            Err(err) => {
-                panic!("Error: Unable to get response from FINDCONTENT request: {err:?}");
-            }
+            Ok(FindContentInfo::Enrs { .. }) => panic!("Error: Unexpected FINDCONTENT response: expected Content instead got Enrs"),
+            Err(err) => panic!("Error: Unable to get response from FINDCONTENT request: {err:?}"),
         }
     }
 }
@@ -170,24 +145,18 @@ dyn_async! {
     async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: ()) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // We are adding client C to our list so we then can assume only one client per bucket
         let client_c_enr = match client_c.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // seed enr into routing table

--- a/simulators/portal/src/suites/history/rpc_compat.rs
+++ b/simulators/portal/src/suites/history/rpc_compat.rs
@@ -197,9 +197,7 @@ dyn_async! {
     async fn test_node_info<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         if let Err(err) = Discv5ApiClient::node_info(&client.rpc).await {
@@ -212,9 +210,7 @@ dyn_async! {
     async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: HistoryContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
 
@@ -228,9 +224,7 @@ dyn_async! {
     async fn test_store<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: HistoryContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
         let raw_content_value = Bytes::from_str(CONTENT_VALUE).expect("unable to convert content value to bytes");
@@ -245,9 +239,7 @@ dyn_async! {
     async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: HistoryContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
         let raw_content_value = Bytes::from_str(CONTENT_VALUE).expect("unable to convert content value to bytes");
@@ -264,9 +256,7 @@ dyn_async! {
                     panic!("Error receiving content: Expected content: {raw_content_value:?}, Received content: {possible_content:?}");
                 }
             }
-            Err(err) => {
-                panic!("Expected content returned from local_content to be present {}", &err.to_string());
-            }
+            Err(err) => panic!("Expected content returned from local_content to be present {}", &err.to_string()),
         }
     }
 }
@@ -275,9 +265,7 @@ dyn_async! {
     async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
         match HistoryNetworkApiClient::add_enr(&client.rpc, enr).await {
@@ -294,9 +282,7 @@ dyn_async! {
     async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -310,16 +296,12 @@ dyn_async! {
     async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         // get our local enr from NodeInfo
         let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // check if we can fetch data from routing table
@@ -338,9 +320,7 @@ dyn_async! {
     async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -369,9 +349,7 @@ dyn_async! {
     async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
         match HistoryNetworkApiClient::delete_enr(&client.rpc, enr.node_id()).await {
@@ -388,9 +366,7 @@ dyn_async! {
     async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -433,9 +409,7 @@ dyn_async! {
     async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -449,9 +423,7 @@ dyn_async! {
     async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -480,16 +452,12 @@ dyn_async! {
     async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         // get our local enr from NodeInfo
         let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // check if we can fetch data from routing table
@@ -509,9 +477,7 @@ dyn_async! {
     async fn test_get_content_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
 

--- a/simulators/portal/src/suites/history/trin_bridge.rs
+++ b/simulators/portal/src/suites/history/trin_bridge.rs
@@ -75,16 +75,12 @@ dyn_async! {
     async fn test_bridge<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         let client_enr = match client.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
         client.test.start_client(TRIN_BRIDGE_CLIENT_TYPE.to_string(), Some(HashMap::from([(BOOTNODES_ENVIRONMENT_VARIABLE.to_string(), client_enr.to_base64()), (HIVE_CHECK_LIVE_PORT.to_string(), 0.to_string())]))).await;
 
@@ -112,9 +108,7 @@ dyn_async! {
                         result.push(format!("Error content received for block {} was different then expected: Provided: {content:?} Expected: {content_value:?}", comments[index]));
                     }
                 }
-                Err(err) => {
-                    panic!("Unable to get received content: {err:?}");
-                }
+                Err(err) => panic!("Unable to get received content: {err:?}"),
             }
         }
 

--- a/simulators/portal/src/suites/state/rpc_compat.rs
+++ b/simulators/portal/src/suites/state/rpc_compat.rs
@@ -200,9 +200,7 @@ dyn_async! {
     async fn test_node_info<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
 
         if let Err(err) = Discv5ApiClient::node_info(&client.rpc).await {
@@ -215,9 +213,7 @@ dyn_async! {
     async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: StateContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
 
@@ -231,9 +227,7 @@ dyn_async! {
     async fn test_store<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: StateContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
         let raw_content_offer_value = Bytes::from_str(CONTENT_OFFER_VALUE).unwrap();
@@ -248,9 +242,7 @@ dyn_async! {
     async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let content_key: StateContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
         let raw_content_offer_value = Bytes::from_str(CONTENT_OFFER_VALUE).unwrap();
@@ -268,9 +260,7 @@ dyn_async! {
                     panic!("Error receiving content: Expected content: {raw_content_lookup_value:?}, Received content: {possible_content:?}");
                 }
             }
-            Err(err) => {
-                panic!("Expected content returned from local_content to be present {}", &err.to_string());
-            }
+            Err(err) => panic!("Expected content returned from local_content to be present {}", &err.to_string()),
         }
     }
 }
@@ -279,9 +269,7 @@ dyn_async! {
     async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
         match StateNetworkApiClient::add_enr(&client.rpc, enr).await {
@@ -298,9 +286,7 @@ dyn_async! {
     async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -314,16 +300,12 @@ dyn_async! {
     async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         // get our local enr from NodeInfo
         let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // check if we can fetch data from routing table
@@ -342,9 +324,7 @@ dyn_async! {
     async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -373,9 +353,7 @@ dyn_async! {
     async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
         match StateNetworkApiClient::delete_enr(&client.rpc, enr.node_id()).await {
@@ -392,9 +370,7 @@ dyn_async! {
     async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -437,9 +413,7 @@ dyn_async! {
     async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -453,9 +427,7 @@ dyn_async! {
     async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let (_, enr) = generate_random_remote_enr();
 
@@ -484,16 +456,12 @@ dyn_async! {
     async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         // get our local enr from NodeInfo
         let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
+            Err(err) => panic!("Error getting node info: {err:?}"),
         };
 
         // check if we can fetch data from routing table
@@ -513,9 +481,7 @@ dyn_async! {
     async fn test_get_content_content_absent<'a>(clients: Vec<Client>, _: ()) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
+            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
         };
         let header_with_proof_key: StateContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
 


### PR DESCRIPTION
Our old ContentInfo type was exposing implementation internals which was bad