### PR TITLE
simulators/portal: update ethportal-api (content key api changes)

### DIFF
--- a/simulators/portal/Cargo.lock
+++ b/simulators/portal/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "ethportal-api"
 version = "0.2.2"
-source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
+source = "git+https://github.com/ethereum/trin?rev=0b5f04364478cd4ea0aadebb41e6681f55640934#0b5f04364478cd4ea0aadebb41e6681f55640934"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "trin-utils"
 version = "0.1.1-alpha.1"
-source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
+source = "git+https://github.com/ethereum/trin?rev=0b5f04364478cd4ea0aadebb41e6681f55640934#0b5f04364478cd4ea0aadebb41e6681f55640934"
 dependencies = [
  "ansi_term",
  "atty",

--- a/simulators/portal/Cargo.toml
+++ b/simulators/portal/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 alloy-rlp = "0.3.8"
 alloy-primitives = "0.8.3"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f" }
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "0b5f04364478cd4ea0aadebb41e6681f55640934" }
 futures = "0.3.25"
 hivesim = { git = "https://github.com/ethereum/hive", rev = "4408fc1de3fee3ac23acd25a812c117756af2f39" }
 itertools = "0.10.5"
@@ -16,4 +16,3 @@ serde_yaml = "0.9.33"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-


### PR DESCRIPTION
The https://github.com/ethereum/trin/pull/1544 slightly changed content key api.

This PR updates dependency (no code changes needed).