### PR TITLE
hive: add --sim.buildarg flag

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -8,29 +8,33 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/ethereum/hive/internal/libdocker"
 	"github.com/ethereum/hive/internal/libhive"
-	docker "github.com/fsouza/go-dockerclient"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
-type buildArgs []docker.BuildArg
+type buildArgs map[string]string
 
-func (i *buildArgs) String() string {
-	return fmt.Sprintf("%v", *i)
+func (args *buildArgs) String() string {
+	var kv []string
+	for k, v := range *args {
+		kv = append(kv, k+"="+v)
+	}
+	sort.Strings(kv)
+	return strings.Join(kv, ",")
 }
 
-// Set a single docker build argument that is parsed from the command line.
-func (i *buildArgs) Set(value string) error {
+// Set implements flag.Value.
+func (args *buildArgs) Set(value string) error {
 	parts := strings.SplitN(value, "=", 2)
 	if len(parts) != 2 {
 		return errors.New("invalid build argument format, expected ARG=VALUE")
 	}
-	arg := docker.BuildArg{Name: parts[0], Value: parts[1]}
-	*i = append(*i, arg)
+	(*args)[parts[0]] = parts[1]
 	return nil
 }
 

--- a/internal/fakes/builder.go
+++ b/internal/fakes/builder.go
@@ -5,12 +5,13 @@ import (
 	"io/fs"
 
 	"github.com/ethereum/hive/internal/libhive"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 // BuilderHooks can be used to override the behavior of the fake builder.
 type BuilderHooks struct {
 	BuildClientImage    func(context.Context, libhive.ClientDesignator) (string, error)
-	BuildSimulatorImage func(context.Context, string) (string, error)
+	BuildSimulatorImage func(context.Context, string, []docker.BuildArg) (string, error)
 	ReadFile            func(ctx context.Context, image string, file string) ([]byte, error)
 }
 
@@ -35,9 +36,9 @@ func (b *fakeBuilder) BuildClientImage(ctx context.Context, client libhive.Clien
 	return "fakebuild/client/" + client.Client + ":latest", nil
 }
 
-func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string) (string, error) {
+func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string, buildArgs []docker.BuildArg) (string, error) {
 	if b.hooks.BuildSimulatorImage != nil {
-		return b.hooks.BuildSimulatorImage(ctx, sim)
+		return b.hooks.BuildSimulatorImage(ctx, sim, buildArgs)
 	}
 	return "fakebuild/simulator/" + sim + ":latest", nil
 }

--- a/internal/fakes/builder.go
+++ b/internal/fakes/builder.go
@@ -5,13 +5,12 @@ import (
 	"io/fs"
 
 	"github.com/ethereum/hive/internal/libhive"
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 // BuilderHooks can be used to override the behavior of the fake builder.
 type BuilderHooks struct {
 	BuildClientImage    func(context.Context, libhive.ClientDesignator) (string, error)
-	BuildSimulatorImage func(context.Context, string, []docker.BuildArg) (string, error)
+	BuildSimulatorImage func(context.Context, string, map[string]string) (string, error)
 	ReadFile            func(ctx context.Context, image string, file string) ([]byte, error)
 }
 
@@ -36,7 +35,7 @@ func (b *fakeBuilder) BuildClientImage(ctx context.Context, client libhive.Clien
 	return "fakebuild/client/" + client.Client + ":latest", nil
 }
 
-func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string, buildArgs []docker.BuildArg) (string, error) {
+func (b *fakeBuilder) BuildSimulatorImage(ctx context.Context, sim string, buildArgs map[string]string) (string, error) {
 	if b.hooks.BuildSimulatorImage != nil {
 		return b.hooks.BuildSimulatorImage(ctx, sim, buildArgs)
 	}

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -52,7 +52,7 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
 }
 
 // BuildSimulatorImage builds a docker image of a simulator.
-func (b *Builder) BuildSimulatorImage(ctx context.Context, name string) (string, error) {
+func (b *Builder) BuildSimulatorImage(ctx context.Context, name string, buildArgs []docker.BuildArg) (string, error) {
 	dir := b.config.Inventory.SimulatorDirectory(name)
 	buildContextPath := dir
 	buildDockerfile := "Dockerfile"
@@ -69,7 +69,7 @@ func (b *Builder) BuildSimulatorImage(ctx context.Context, name string) (string,
 		}
 	}
 	tag := fmt.Sprintf("hive/simulators/%s:latest", name)
-	err := b.buildImage(ctx, buildContextPath, buildDockerfile, tag, nil)
+	err := b.buildImage(ctx, buildContextPath, buildDockerfile, tag, buildArgs)
 	return tag, err
 }
 

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -8,8 +8,6 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
-
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 // ContainerBackend captures the docker interactions of the simulation API.
@@ -83,7 +81,7 @@ type ContainerInfo struct {
 // Builder can build docker images of clients and simulators.
 type Builder interface {
 	BuildClientImage(ctx context.Context, client ClientDesignator) (string, error)
-	BuildSimulatorImage(ctx context.Context, name string, buildArgs []docker.BuildArg) (string, error)
+	BuildSimulatorImage(ctx context.Context, name string, buildArgs map[string]string) (string, error)
 	BuildImage(ctx context.Context, name string, fsys fs.FS) error
 
 	// ReadFile returns the content of a file in the given image.

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -8,6 +8,8 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 // ContainerBackend captures the docker interactions of the simulation API.
@@ -81,7 +83,7 @@ type ContainerInfo struct {
 // Builder can build docker images of clients and simulators.
 type Builder interface {
 	BuildClientImage(ctx context.Context, client ClientDesignator) (string, error)
-	BuildSimulatorImage(ctx context.Context, name string) (string, error)
+	BuildSimulatorImage(ctx context.Context, name string, buildArgs []docker.BuildArg) (string, error)
 	BuildImage(ctx context.Context, name string, fsys fs.FS) error
 
 	// ReadFile returns the content of a file in the given image.

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	docker "github.com/fsouza/go-dockerclient"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -42,14 +43,14 @@ func NewRunner(inv Inventory, b Builder, cb ContainerBackend) *Runner {
 }
 
 // Build builds client and simulator images.
-func (r *Runner) Build(ctx context.Context, clientList []ClientDesignator, simList []string) error {
+func (r *Runner) Build(ctx context.Context, clientList []ClientDesignator, simList []string, simBuildArgs []docker.BuildArg) error {
 	if err := r.container.Build(ctx, r.builder); err != nil {
 		return err
 	}
 	if err := r.buildClients(ctx, clientList); err != nil {
 		return err
 	}
-	return r.buildSimulators(ctx, simList)
+	return r.buildSimulators(ctx, simList, simBuildArgs)
 }
 
 // buildClients builds client images.
@@ -86,12 +87,12 @@ func (r *Runner) buildClients(ctx context.Context, clientList []ClientDesignator
 }
 
 // buildSimulators builds simulator images.
-func (r *Runner) buildSimulators(ctx context.Context, simList []string) error {
+func (r *Runner) buildSimulators(ctx context.Context, simList []string, buildArgs []docker.BuildArg) error {
 	r.simImages = make(map[string]string)
 
 	log15.Info(fmt.Sprintf("building %d simulators...", len(simList)))
 	for _, sim := range simList {
-		image, err := r.builder.BuildSimulatorImage(ctx, sim)
+		image, err := r.builder.BuildSimulatorImage(ctx, sim, buildArgs)
 		if err != nil {
 			return err
 		}

--- a/internal/libhive/run.go
+++ b/internal/libhive/run.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	docker "github.com/fsouza/go-dockerclient"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -43,7 +42,7 @@ func NewRunner(inv Inventory, b Builder, cb ContainerBackend) *Runner {
 }
 
 // Build builds client and simulator images.
-func (r *Runner) Build(ctx context.Context, clientList []ClientDesignator, simList []string, simBuildArgs []docker.BuildArg) error {
+func (r *Runner) Build(ctx context.Context, clientList []ClientDesignator, simList []string, simBuildArgs map[string]string) error {
 	if err := r.container.Build(ctx, r.builder); err != nil {
 		return err
 	}
@@ -87,7 +86,7 @@ func (r *Runner) buildClients(ctx context.Context, clientList []ClientDesignator
 }
 
 // buildSimulators builds simulator images.
-func (r *Runner) buildSimulators(ctx context.Context, simList []string, buildArgs []docker.BuildArg) error {
+func (r *Runner) buildSimulators(ctx context.Context, simList []string, buildArgs map[string]string) error {
 	r.simImages = make(map[string]string)
 
 	log15.Info(fmt.Sprintf("building %d simulators...", len(simList)))

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/hive/hivesim"
 	"github.com/ethereum/hive/internal/fakes"
 	"github.com/ethereum/hive/internal/libhive"
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestRunner(t *testing.T) {
@@ -44,17 +43,13 @@ func TestRunner(t *testing.T) {
 	})
 
 	var (
-		runner  = libhive.NewRunner(inv, b, cb)
-		simList = []string{"sim-1"}
-		simOpt  = libhive.SimEnv{LogDir: t.TempDir(), ClientList: simClients}
-		ctx     = context.Background()
+		runner    = libhive.NewRunner(inv, b, cb)
+		simList   = []string{"sim-1"}
+		simOpt    = libhive.SimEnv{LogDir: t.TempDir(), ClientList: simClients}
+		ctx       = context.Background()
+		buildArgs = map[string]string{"SomeArg": "SomeValue"}
 	)
-	if err := runner.Build(ctx, allClients, simList, []docker.BuildArg{
-		{
-			Name:  "SomeArg",
-			Value: "SomeValue",
-		},
-	}); err != nil {
+	if err := runner.Build(ctx, allClients, simList, buildArgs); err != nil {
 		t.Fatal("Build() failed:", err)
 	}
 	if _, err := runner.Run(context.Background(), "sim-1", simOpt); err != nil {

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/hive/hivesim"
 	"github.com/ethereum/hive/internal/fakes"
 	"github.com/ethereum/hive/internal/libhive"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestRunner(t *testing.T) {
@@ -48,7 +49,12 @@ func TestRunner(t *testing.T) {
 		simOpt  = libhive.SimEnv{LogDir: t.TempDir(), ClientList: simClients}
 		ctx     = context.Background()
 	)
-	if err := runner.Build(ctx, allClients, simList); err != nil {
+	if err := runner.Build(ctx, allClients, simList, []docker.BuildArg{
+		{
+			Name:  "SomeArg",
+			Value: "SomeValue",
+		},
+	}); err != nil {
 		t.Fatal("Build() failed:", err)
 	}
 	if _, err := runner.Run(context.Background(), "sim-1", simOpt); err != nil {

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -36,6 +36,7 @@ type SimEnv struct {
 	SimParallelism int
 	SimRandomSeed  int
 	SimTestPattern string
+	SimBuildArgs   []string
 
 	// This is the time limit for the simulation run.
 	// There is no default limit.


### PR DESCRIPTION
Adds `--sim.buildarg` as a parameter to add build arguments to the simulator Dockerfile.