### PR TITLE
simulators/eth/eest: use `--sim.buildarg` for consume

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -1,6 +1,10 @@
 # Builds and runs the EEST (execution-spec-tests) consume engine simulator
 FROM python:3.10-slim
 
+## Default fixtures
+ARG fixtures=latest-stable-release
+ENV INPUT=${fixtures}
+
 ## Install dependencies
 RUN apt-get update && \
     apt-get install -y git wget tar && \
@@ -13,4 +17,4 @@ WORKDIR execution-spec-tests
 RUN pip install uv && uv sync
 
 ## Define `consume engine` entry point using the local fixtures
-ENTRYPOINT ["uv", "run", "consume", "engine", "-v", "--input", "latest-stable-release"]
+ENTRYPOINT uv run consume engine -v --input "$INPUT"

--- a/simulators/ethereum/eest/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eest/consume-rlp/Dockerfile
@@ -1,6 +1,10 @@
 # Builds and runs the EEST (execution-spec-tests) consume rlp simulator
 FROM python:3.10-slim
 
+## Default fixtures
+ARG fixtures=latest-stable-release
+ENV INPUT=${fixtures}
+
 ## Install dependencies
 RUN apt-get update && \
     apt-get install -y git wget tar && \
@@ -13,4 +17,4 @@ WORKDIR execution-spec-tests
 RUN pip install uv && uv sync
 
 ## Define `consume rlp` entry point using the local fixtures
-ENTRYPOINT ["uv", "run", "consume", "rlp", "-v", "--input", "latest-stable-release"]
+ENTRYPOINT uv run consume rlp -v --input "$INPUT"


### PR DESCRIPTION
## Description

Updates the consume simulator dockerfiles to use input build args. This will allow us to pass different release fixtures dynamically to both `consume rlp` and `consume engine`.

The default remains as `latest-stable-release`, as these are the fixtures that validate client mainnet releases.

## Requirements

The PR requires that #1179 is merged first, as it utilizes the `--sim.buildarg` flag that the latter adds.