### PR TITLE
Nethermind jammy->noble dotnet9

### DIFF
--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -1,7 +1,7 @@
 ### Build Nethermind From Git:
 
 ## Builder stage: Compiles nethermind from a git repository
-FROM mcr.microsoft.com/dotnet/sdk:9.0-jammy AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS build
 
 ARG github=nethermindeth/nethermind
 ARG tag=master


### PR DESCRIPTION
`dotnet/sdk:9.0-jammy` isn't a valid tag of a dotnet dokcer image, ref: https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md#full-tag-listing