### PR TITLE
internal/libdocker: return context error correctly in archiveFS

### DIFF
--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -115,7 +115,7 @@ func (b *Builder) archiveFS(ctx context.Context, out io.WriteCloser, fsys fs.FS)
 		if err != nil {
 			return err
 		}
-		if ctx.Err() != nil {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
the err has been checked in line 115 and is a nil value in line 119