### PR TITLE
simulators/ethereum/engine: fix typo in comment

### DIFF
--- a/simulators/ethereum/engine/suites/engine/payload_attributes.go
+++ b/simulators/ethereum/engine/suites/engine/payload_attributes.go
@@ -67,7 +67,7 @@ func (tc InvalidPayloadAttributesTest) Execute(t *test.Env) {
 			// 3) Check payloadAttributes, if invalid respond with error: code: Invalid payload attributes
 			// 4) Start payload build process and respond with VALID
 			if tc.Syncing {
-				// If we are SYNCING, the outcome should be SYNCING regardless of the validity of the payload atttributes
+				// If we are SYNCING, the outcome should be SYNCING regardless of the validity of the payload attributes
 				r := t.TestEngine.TestEngineForkchoiceUpdated(&fcu, attr, t.CLMock.LatestPayloadBuilt.Timestamp)
 				r.ExpectPayloadStatus(test.Syncing)
 				r.ExpectPayloadID(nil)


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `payload_attributes.go`**

## Description  
This pull request corrects a typo in the `payload_attributes.go` file. The word "atttributes" has been corrected to "attributes" to ensure proper spelling.

### Changes Made:
- **File Modified:** `payload_attributes.go`
- **Summary of Changes:**  
  - Corrected the typo from "atttributes" to "attributes" in the comment on line 67.

## Checklist  
- [x] Fixed the typo in the file.
- [x] Verified that the code comment is now correctly spelled.

## Additional Notes  
This change improves the readability and professionalism of the code comments.

---

**Allow edits by maintainers:** [x]
