### PR TITLE
simulators/ethereum/engine: fix typo in README.md

### DIFF
--- a/simulators/ethereum/engine/README.md
+++ b/simulators/ethereum/engine/README.md
@@ -78,7 +78,7 @@ Verify the Block returned by the Eth RPC using the `finalized` keyword after a n
 Verify the Block returned by the Eth RPC using the `finalized`/`safe` keyword after following the canonical chain is correctly updated to the canonical values set by `forkchoiceUpdated` calls.
 
 - `latest` Block after Reorg:  
-Verify the Block returned by the Eth RPC after a forkchoiceUpdated reorgs HeadBlockHash/SafeBlockHash to a sidechain and back. Eth RPC should return the appropriate block everytime.
+Verify the Block returned by the Eth RPC after a forkchoiceUpdated reorgs HeadBlockHash/SafeBlockHash to a sidechain and back. Eth RPC should return the appropriate block every time.
 
 ### Payload Execution
 - Re-Execute Payload:  


### PR DESCRIPTION
# Pull Request Title: Typo fix in README.md

## Description:
This pull request fixes a typo in the `README.md` file. The word "everytime" has been corrected to "every time."

## Changes:
- Corrected the spelling of "everytime" to "every time" in the text explaining the verification process for the Eth RPC after reorgs.

## File(s) Modified:
- `simulators/ethereum/engine/README.md`

## Reasoning:
Correcting the typo ensures proper grammar and improves the clarity of the documentation.

## Checklist:
- [x] The code follows the project's coding guidelines.
- [x] All relevant tests are passing.
- [x] I have updated the documentation (if necessary).
- [x] I have tested the changes locally.

## Related Issues:
N/A

## Additional Notes:
N/A
