### PR TITLE
all: Add hive instance information endpoint

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -168,20 +168,24 @@ func main() {
 			clientList = libhive.FilterClients(clientList, filter)
 		}
 	}
+	hiveInfo := libhive.HiveInfo{
+		Command:    os.Args,
+		ClientFile: clientList,
+	}
 
 	// Build clients and simulators.
 	if err := runner.Build(ctx, clientList, simList, simBuildArgs); err != nil {
 		fatal(err)
 	}
 	if *simDevMode {
-		runner.RunDevMode(ctx, env, *simDevModeAPIEndpoint)
+		runner.RunDevMode(ctx, env, *simDevModeAPIEndpoint, hiveInfo)
 		return
 	}
 
 	// Run simulators.
 	var failCount int
 	for _, sim := range simList {
-		result, err := runner.Run(ctx, sim, env)
+		result, err := runner.Run(ctx, sim, env, hiveInfo)
 		if err != nil {
 			fatal(err)
 		}

--- a/hivesim/hive_test.go
+++ b/hivesim/hive_test.go
@@ -407,7 +407,10 @@ func newFakeAPI(hooks *fakes.BackendHooks) (*libhive.TestManager, *httptest.Serv
 	}
 	env := libhive.SimEnv{}
 	backend := fakes.NewContainerBackend(hooks)
-	tm := libhive.NewTestManager(env, backend, defs)
+	hiveInfo := libhive.HiveInfo{
+		Command: []string{"/hive"},
+	}
+	tm := libhive.NewTestManager(env, backend, defs, hiveInfo)
 	srv := httptest.NewServer(tm.API())
 	return tm, srv
 }

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -27,11 +27,12 @@ const hiveEnvvarPrefix = "HIVE_"
 const defaultStartTimeout = time.Duration(60 * time.Second)
 
 // newSimulationAPI creates handlers for the simulation API.
-func newSimulationAPI(b ContainerBackend, env SimEnv, tm *TestManager) http.Handler {
-	api := &simAPI{backend: b, env: env, tm: tm}
+func newSimulationAPI(b ContainerBackend, env SimEnv, tm *TestManager, hive HiveInfo) http.Handler {
+	api := &simAPI{backend: b, env: env, tm: tm, hive: hive}
 
 	// API routes.
 	router := mux.NewRouter()
+	router.HandleFunc("/hive", api.getHiveInfo).Methods("GET")
 	router.HandleFunc("/clients", api.getClientTypes).Methods("GET")
 	router.HandleFunc("/testsuite/{suite}/test/{test}/node/{node}/exec", api.execInClient).Methods("POST")
 	router.HandleFunc("/testsuite/{suite}/test/{test}/node/{node}", api.getNodeStatus).Methods("GET")
@@ -56,6 +57,13 @@ type simAPI struct {
 	backend ContainerBackend
 	env     SimEnv
 	tm      *TestManager
+	hive    HiveInfo
+}
+
+// getHiveInfo returns information about the hive server instance.
+func (api *simAPI) getHiveInfo(w http.ResponseWriter, r *http.Request) {
+	slog.Info("API: hive info requested")
+	serveJSON(w, api.hive)
 }
 
 // getClientTypes returns all known client types.

--- a/internal/libhive/inventory.go
+++ b/internal/libhive/inventory.go
@@ -183,19 +183,19 @@ func loadClientMetadata(path string) (m ClientMetadata, err error) {
 type ClientDesignator struct {
 	// Client is the client name.
 	// This must refer to a subdirectory of clients/
-	Client string `yaml:"client"`
+	Client string `yaml:"client" json:"client"`
 
 	// Nametag is used in the name of the client image.
 	// This is for assigning meaningful names to different builds of the same client.
 	// If unspecified, a default value is chosen to make client names unique.
-	Nametag string `yaml:"nametag,omitempty"`
+	Nametag string `yaml:"nametag,omitempty" json:"nametag,omitempty"`
 
 	// DockerfileExt is the extension of the Docker that should be used to build the
 	// client. Example: setting this to "git" will build using "Dockerfile.git".
-	DockerfileExt string `yaml:"dockerfile,omitempty"`
+	DockerfileExt string `yaml:"dockerfile,omitempty" json:"dockerfile,omitempty"`
 
 	// Arguments passed to the docker build.
-	BuildArgs map[string]string `yaml:"build_args,omitempty"`
+	BuildArgs map[string]string `yaml:"build_args,omitempty" json:"build_args,omitempty"`
 }
 
 func (c ClientDesignator) buildString() string {

--- a/internal/libhive/run_test.go
+++ b/internal/libhive/run_test.go
@@ -52,7 +52,7 @@ func TestRunner(t *testing.T) {
 	if err := runner.Build(ctx, allClients, simList, buildArgs); err != nil {
 		t.Fatal("Build() failed:", err)
 	}
-	if _, err := runner.Run(context.Background(), "sim-1", simOpt); err != nil {
+	if _, err := runner.Run(context.Background(), "sim-1", simOpt, libhive.HiveInfo{}); err != nil {
 		t.Fatal("Run() failed:", err)
 	}
 


### PR DESCRIPTION
Adds a `/hive` endpoint to the server API that returns an object containing information about the hive instance that is currently running.

#### Hive info object contents
- `command`: Command line used to start the hive server.
- `clientFile`: Contents of the file specified in `--client-file` if any.
- `commit`: Git commit used build the hive binary.
- `date`: Date of build of the hive binary.