### PR TITLE
simulators/ethereum/engine: TTD related fixes

### DIFF
--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -370,10 +370,11 @@ func (n *GethNode) SetBlock(block *types.Block, parentNumber uint64, parentRoot 
 	statedb.StartPrefetcher("chain", nil)
 	var failedProcessing bool
 	result, err := n.eth.BlockChain().Processor().Process(block, statedb, *n.eth.BlockChain().GetVMConfig())
-	if err != nil {
+	if err != nil || result == nil {
 		failedProcessing = true
+	} else {
+		rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), result.Receipts)
 	}
-	rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), result.Receipts)
 	root, err := statedb.Commit(block.NumberU64(), false)
 	if err != nil {
 		return errors.Wrap(err, "failed to commit state")

--- a/simulators/ethereum/engine/config/genesis.go
+++ b/simulators/ethereum/engine/config/genesis.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (f *ForkConfig) ConfigGenesis(genesis *core.Genesis) error {
+	genesis.Config.TerminalTotalDifficulty = genesis.Difficulty
 	genesis.Config.MergeNetsplitBlock = big.NewInt(0)
 	if f.ShanghaiTimestamp != nil {
 		shanghaiTime := f.ShanghaiTimestamp.Uint64()

--- a/simulators/ethereum/engine/devp2p/conn.go
+++ b/simulators/ethereum/engine/devp2p/conn.go
@@ -361,9 +361,6 @@ loop:
 				return nil, fmt.Errorf("wrong head block in status, want:  %#x (block %d) have %#x",
 					want, c.consensusEngine.LatestHeader.Number.Uint64(), have)
 			}
-			if have, want := msg.TD.Cmp(c.consensusEngine.ChainTotalDifficulty), 0; have != want {
-				return nil, fmt.Errorf("wrong TD in status: have %d want %d", have, want)
-			}
 			if have, want := msg.ForkID, localForkID; !reflect.DeepEqual(have, want) {
 				return nil, fmt.Errorf("wrong fork ID in status: have (hash=%#x, next=%d), want (hash=%#x, next=%d)", have.Hash, have.Next, want.Hash, want.Next)
 			}

--- a/simulators/ethereum/engine/globals/globals.go
+++ b/simulators/ethereum/engine/globals/globals.go
@@ -88,10 +88,6 @@ var (
 		"HIVE_FORK_MUIR_GLACIER":   "0",
 		"HIVE_FORK_BERLIN":         "0",
 		"HIVE_FORK_LONDON":         "0",
-		// Tests use clique PoA to mine new blocks until the TTD is reached, then PoS takes over.
-		"HIVE_CLIQUE_PERIOD":     "1",
-		"HIVE_CLIQUE_PRIVATEKEY": MinerPKHex,
-		"HIVE_MINER":             MinerAddrHex,
 		// Merge related
 		"HIVE_MERGE_BLOCK_ID": "100",
 	}

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -163,27 +163,6 @@ func makeRunner(tests []test.Spec, nodeType string) func(t *hivesim.T) {
 				newParams = newParams.Set("HIVE_NODETYPE", nodeType)
 			}
 
-			testFiles := hivesim.Params{}
-			if genesis.Difficulty.Sign() > 0 {
-				if currentTest.GetChainFile() != "" {
-					// We are using a Proof of Work chain file, remove all clique-related settings
-					// TODO: Nethermind still requires HIVE_MINER for the Engine API
-					// delete(newParams, "HIVE_MINER")
-					delete(newParams, "HIVE_CLIQUE_PRIVATEKEY")
-					delete(newParams, "HIVE_CLIQUE_PERIOD")
-					// Add the new file to be loaded as chain.rlp
-					testFiles = testFiles.Set("/chain.rlp", "./chains/"+currentTest.GetChainFile())
-				}
-				if currentTest.IsMiningDisabled() {
-					delete(newParams, "HIVE_MINER")
-				}
-			} else {
-				// This is a post-merge test
-				delete(newParams, "HIVE_CLIQUE_PRIVATEKEY")
-				delete(newParams, "HIVE_CLIQUE_PERIOD")
-				delete(newParams, "HIVE_MINER")
-			}
-
 			if clientTypes, err := t.Sim.ClientTypes(); err == nil {
 				for _, clientType := range clientTypes {
 					test := hivesim.TestSpec{
@@ -195,7 +174,6 @@ func makeRunner(tests []test.Spec, nodeType string) func(t *hivesim.T) {
 								clientType.Name,
 								newParams,
 								genesisStartOption,
-								hivesim.WithStaticFiles(testFiles),
 							)
 							t.Logf("Start test (%s): %s", c.Type, currentTestName)
 							defer func() {
@@ -215,7 +193,7 @@ func makeRunner(tests []test.Spec, nodeType string) func(t *hivesim.T) {
 								genesis,
 								rand.New(rand.NewSource(random_seed)),
 								newParams,
-								testFiles,
+								hivesim.Params{},
 							)
 						},
 					}

--- a/simulators/ethereum/engine/suites/auth/tests.go
+++ b/simulators/ethereum/engine/suites/auth/tests.go
@@ -90,7 +90,7 @@ func (authTestSpec AuthTestSpec) Execute(t *test.Env) {
 	var (
 		// All test cases send a simple TransitionConfigurationV1 to check the Authentication mechanism (JWT)
 		tConf = api.TransitionConfigurationV1{
-			TerminalTotalDifficulty: new(hexutil.Big), // zero
+			TerminalTotalDifficulty: (*hexutil.Big)(t.Genesis.Config.TerminalTotalDifficulty),
 			TerminalBlockHash:       common.Hash{},
 			TerminalBlockNumber:     0,
 		}


### PR DESCRIPTION
Contains the following fixes:
- Fixed an incorrect handling of the `Process` returned value in the geth-node module.
- The genesis configure method now does actually set the TTD because the geth-node module fails to start if the value is nil.
- Remove `HIVE_CLIQUE_PERIOD`, `HIVE_CLIQUE_PRIVATEKEY`, and `HIVE_MINER` are removed.
- Remove Total Difficulty check in the devp2p library because it resulted in nil pointer exception.
- Fix TTD in the auth test suite.