### PR TITLE
clients/go-ethereum: hardcode deposit contract address

### DIFF
--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -58,5 +58,6 @@ def to_bool:
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
     "terminalTotalDifficultyPassed": true,
+    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
   }|remove_empty
 }


### PR DESCRIPTION
Most of the requests-related failing tests in https://hive.pectra-devnet-5.ethpandaops.io (for geth) are because the deposit contract address is not properly configured. I have for now hardcoded it in the starter script. But probably best to set it as an environment parameter from the simulator?