### PR TITLE
cmd/hiveview: enable asset loading with relative paths

### DIFF
--- a/cmd/hiveview/assets/index.html
+++ b/cmd/hiveview/assets/index.html
@@ -4,15 +4,15 @@
     <title>hive</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="/images/favicon.svg">
-    <link rel="stylesheet" href="/lib/app.css">
+    <link rel="icon" href="images/favicon.svg">
+    <link rel="stylesheet" href="lib/app.css">
   </head>
 
   <body>
-    <script src="/lib/app-index.js" type="module"></script>
+    <script src="lib/app-index.js" type="module"></script>
     <main role="main">
       <div id="hive-header">
-        <a href="/"><img id="hive-logo" height="35" src="/images/hive3.svg"></a>
+        <a href="index.html"><img id="hive-logo" height="35" src="images/hive3.svg"></a>
         <nav id="hive-static-nav">
           <span class="nav-item" id="hive-instance-info"></span>
           <a class="nav-item" href="https://github.com/ethereum/hive/blob/master/docs/overview.md#what-is-hive">What is Hive?</a>

--- a/cmd/hiveview/assets/lib/routes.js
+++ b/cmd/hiveview/assets/lib/routes.js
@@ -1,4 +1,4 @@
-export const resultsRoot = '/results/';
+export const resultsRoot = 'results/';
 
 // This object has constructor function for various app-internal URLs.
 export function simulatorLog(suiteID, suiteName, file) {
@@ -7,7 +7,7 @@ export function simulatorLog(suiteID, suiteName, file) {
         'suitename': suiteName,
         'file': file,
     });
-    return '/viewer.html?' + params.toString();
+    return 'viewer.html?' + params.toString();
 }
 
 export function testLog(suiteID, suiteName, testIndex) {
@@ -17,7 +17,7 @@ export function testLog(suiteID, suiteName, testIndex) {
         'testid': testIndex,
         'showtestlog': '1',
     });
-    return '/viewer.html?' + params.toString();
+    return 'viewer.html?' + params.toString();
 }
 
 export function clientLog(suiteID, suiteName, testIndex, file) {
@@ -27,12 +27,12 @@ export function clientLog(suiteID, suiteName, testIndex, file) {
         'testid': testIndex,
         'file': file,
     });
-    return '/viewer.html?' + params.toString();
+    return 'viewer.html?' + params.toString();
 }
 
 export function suite(suiteID, suiteName) {
     let params = new URLSearchParams({'suiteid': suiteID, 'suitename': suiteName});
-    return '/suite.html?' + params.toString();
+    return 'suite.html?' + params.toString();
 }
 
 export function testInSuite(suiteID, suiteName, testIndex) {

--- a/cmd/hiveview/assets/suite.html
+++ b/cmd/hiveview/assets/suite.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="/images/favicon.svg">
-    <link rel="stylesheet" href="/lib/app.css">
+    <link rel="icon" href="images/favicon.svg">
+    <link rel="stylesheet" href="lib/app.css">
   </head>
 
   <body>
-    <script src="/lib/app-suite.js" type="module"></script>
+    <script src="lib/app-suite.js" type="module"></script>
     <main role="main">
       <div id="hive-header">
-        <a href="/"><img id="hive-logo" height="35" src="/images/hive3.svg"></a>
+        <a href="index.html"><img id="hive-logo" height="35" src="images/hive3.svg"></a>
         <nav id="hive-static-nav">
           <span class="nav-item" id="hive-instance-info"></span>
           <a class="nav-item" href="https://github.com/ethereum/hive/blob/master/docs/overview.md#what-is-hive">What is Hive?</a>

--- a/cmd/hiveview/assets/viewer.html
+++ b/cmd/hiveview/assets/viewer.html
@@ -4,9 +4,9 @@
     <title>file viewer</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="/images/favicon.svg">
-    <link rel="stylesheet" href="/lib/app.css">
-    <link rel="stylesheet" href="/lib/viewer.css">
+    <link rel="icon" href="images/favicon.svg">
+    <link rel="stylesheet" href="lib/app.css">
+    <link rel="stylesheet" href="lib/viewer.css">
 
     <script id="exampletext" type="text/foo">
       This is some sample text. You can load new files via the little input above, and also
@@ -17,10 +17,10 @@
   </head>
 
   <body>
-    <script src="/lib/app-viewer.js" type="module"></script>
+    <script src="lib/app-viewer.js" type="module"></script>
     <main role="main">
       <div id="hive-header">
-        <a href="/"><img id="hive-logo" height="35" src="/images/hive3.svg"></a>
+        <a href="index.html"><img id="hive-logo" height="35" src="images/hive3.svg"></a>
         <nav id="hive-static-nav">
           <span class="nav-item" id="hive-instance-info"></span>
           <a class="nav-item" href="https://github.com/ethereum/hive/blob/master/docs/overview.md#what-is-hive">What is Hive?</a>


### PR DESCRIPTION
This will allow hiveview to also work with relative paths.

Example: `http://youdomain.com/relative-path/`

This is useful in my case where I'm using a single S3 bucket to publish multiple hiveview UIs across different subpaths. 