### PR TITLE
cmd/hiveview: align load results button better

### DIFF
--- a/cmd/hiveview/assets/lib/app-index.js
+++ b/cmd/hiveview/assets/lib/app-index.js
@@ -129,7 +129,7 @@ function showFileListing(data) {
                 render: function(data) {
                     let url = routes.suite(data.fileName, data.name);
                     let loadText = 'Load (' + formatBytes(data.size) + ')';
-                    return makeButton(url, loadText).outerHTML;
+                    return makeButton(url, loadText, "btn-load-results").outerHTML;
                 },
             },
         ],

--- a/cmd/hiveview/assets/lib/app.css
+++ b/cmd/hiveview/assets/lib/app.css
@@ -168,3 +168,7 @@ td.ellipsis {
         margin-top: 5px;
     }
 }
+
+.btn-load-results {
+    width: 100%;
+}

--- a/cmd/hiveview/assets/lib/html.js
+++ b/cmd/hiveview/assets/lib/html.js
@@ -23,9 +23,9 @@ export function makeLink(url, text) {
 }
 
 // makeButton creates a button-shaped link element.
-export function makeButton(url, text) {
+export function makeButton(url, text, classes = '') {
     let a = makeLink(url, text);
-    a.setAttribute('class', 'btn btn-primary btn-sm');
+    a.setAttribute('class', `btn btn-primary btn-sm ${classes}`.trim());
     return a;
 }
 


### PR DESCRIPTION
Minor design nit: Align the load results buttons to fill 100% of the width.

Before:
![image](https://github.com/user-attachments/assets/8ffbf797-c1ac-46b3-b145-1101fa971f07)

After:
![image](https://github.com/user-attachments/assets/67211136-4bc9-42e0-b7c9-69a7c8b45cca)
