### PR TITLE
client/shisui: change docker image repo

### DIFF
--- a/clients/shisui/Dockerfile
+++ b/clients/shisui/Dockerfile
@@ -1,4 +1,4 @@
-ARG baseimage=ghcr.io/optimism-java/shisui
+ARG baseimage=ghcr.io/zen-eth/shisui
 ARG tag=latest
 
 FROM $baseimage:$tag


### PR DESCRIPTION
client shisui has moved to [zen-eth](https://github.com/zen-eth/shisui) organization, so the docker image should be update