### PR TITLE
hive: add flag to enable just docker build outputs to stderr

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -47,6 +47,7 @@ func main() {
 		dockerNoCache         = flag.String("docker.nocache", "", "Regular `expression` selecting the docker images to forcibly rebuild.")
 		dockerPull            = flag.Bool("docker.pull", false, "Refresh base images when building images.")
 		dockerOutput          = flag.Bool("docker.output", false, "Relay all docker output to stderr.")
+		dockerBuildOutput     = flag.Bool("docker.buildoutput", false, "Relay only docker build output to stderr.")
 		simPattern            = flag.String("sim", "", "Regular `expression` selecting the simulators to run.")
 		simTestPattern        = flag.String("sim.limit", "", "Regular `expression` selecting tests/suites (interpreted by simulators).")
 		simParallelism        = flag.Int("sim.parallelism", 1, "Max `number` of parallel clients/containers (interpreted by simulators).")
@@ -124,6 +125,8 @@ func main() {
 	}
 	if *dockerOutput {
 		dockerConfig.ContainerOutput = os.Stderr
+		dockerConfig.BuildOutput = os.Stderr
+	} else if *dockerBuildOutput {
 		dockerConfig.BuildOutput = os.Stderr
 	}
 	builder, cb, err := libdocker.Connect(*dockerEndpoint, dockerConfig)


### PR DESCRIPTION
I already had a couple of flaky runs in CI runners where building an image failed. I noticed that there was the `docker.output` flag, that would show the problem. But it would also enable log output for any container that hive runs. To avoid adding too much unnecessary logging to the test runs, I've added a flag that just enables the docker outputs for any image that is built.

Example failure on a CI job:

```
Jan 17 16:52:43.498 INF building image image=hive/hiveproxy nocache=false pull=false
Jan 17 16:53:00.502 ERR image build failed image=hive/hiveproxy err="The command '/bin/sh -c go mod download' returned a non-zero code: 1"
The command '/bin/sh -c go mod download' returned a non-zero code: 1
```