### PR TITLE
internal/libdocker: fix typo in comment

### DIFF
--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -209,7 +209,7 @@ func (b *Builder) ReadFile(ctx context.Context, image, path string) ([]byte, err
 }
 
 // buildImage builds a single docker image from the specified context.
-// branch specifes a build argument to use a specific base image branch or github source branch.
+// branch specifies a build argument to use a specific base image branch or github source branch.
 func (b *Builder) buildImage(ctx context.Context, contextDir, dockerFile, imageTag string, buildArgs map[string]string) error {
 	logger := b.logger.With("image", imageTag)
 	context, err := filepath.Abs(contextDir)


### PR DESCRIPTION
# Pull Request: Fix Typo in `builder.go`

## Description

This pull request addresses a typo in the `builder.go` file, correcting **"specifes"** to **"specifies**. This change improves the readability and accuracy of the code comments.

## Changes Made

- Replaced **"specifes"** with **"specifies"** in `builder.go`.

## Rationale


``
