### PR TITLE
clients/trin: add Dockerfile support to build Trin from git

### DIFF
--- a/clients/trin/Dockerfile
+++ b/clients/trin/Dockerfile
@@ -9,7 +9,8 @@ RUN chmod +x /trin.sh
 ADD trin_version.sh /trin_version.sh
 RUN chmod +x /trin_version.sh
 
-RUN /trin_version.sh > /version.txt
+# Create version.txt
+RUN /usr/bin/trin --version | head -1 > /version.txt
 
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 9009/udp

--- a/clients/trin/Dockerfile.git
+++ b/clients/trin/Dockerfile.git
@@ -1,0 +1,37 @@
+
+### Build Trin From Git:
+## Pulls trin from a git repository and builds it from source.
+
+## Builder stage: Compiles trin from a git repository
+FROM rust:latest AS builder
+
+ARG github=ethereum/trin
+ARG tag=master
+
+RUN apt-get update && apt-get install -y libclang-dev pkg-config build-essential \
+    && echo "Cloning: $github - $tag" \
+    && git clone https://github.com/$github trin \
+    && cd trin \
+    && git checkout $tag \
+    && cargo build --release \
+    && cp target/release/trin /usr/local/bin/trin
+
+## Final stage: Sets up the environment for running trin
+FROM debian:latest
+RUN apt-get update && apt-get install -y bash curl jq \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy compiled binary from builder
+COPY --from=builder /usr/local/bin/trin /usr/local/bin/trin
+
+# Inject the startup script.
+COPY trin.sh /trin.sh
+RUN chmod +x /trin.sh
+
+# Create version.txt
+RUN /usr/local/bin/trin --version | head -1 > /version.txt
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 9009/udp
+
+ENTRYPOINT ["/trin.sh"]

--- a/clients/trin/trin_version.sh
+++ b/clients/trin/trin_version.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Immediately abort the script on any error encountered
-set -e
-
-#trin --version | tail -1 | sed "s/ /\//g"
-echo "latest"


### PR DESCRIPTION
We want to test experimental branches of Portal clients, here is a PR so we can use a clients file for trin and pull a git branch