### PR TITLE
clients/erigon: Add deposit contract to mapper jq

### DIFF
--- a/clients/erigon/mapper.jq
+++ b/clients/erigon/mapper.jq
@@ -65,5 +65,6 @@ def to_bool:
         "baseFeeUpdateFraction": (if env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 5007716 end)
       }
     },
+    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
   }|remove_empty
 }


### PR DESCRIPTION
Without this deposit and deposit request related tests may fail as erigon doesn't use default for this value