### PR TITLE
clients/ultralight: move .git to root directory

### DIFF
--- a/clients/ultralight/Dockerfile.git
+++ b/clients/ultralight/Dockerfile.git
@@ -17,7 +17,8 @@ RUN echo "Cloning: $github - $tag" \
     && git clone https://github.com/$github ultralight \
     && cd ultralight \
     && git checkout $tag \
-    && npm i 
+    && npm i \
+    && mv .git /.git
 
 # Inject the startup script.
 COPY ultralight.sh /ultralight.sh


### PR DESCRIPTION
In ultralight's new ping extension branch they require the .git folder be accessible in the base directly in this case it is the root direclty.

@acolytec3 for review