### PR TITLE
clients/go-ethereum: fix default TTD

### DIFF
--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -53,7 +53,7 @@ def to_bool:
     "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
-    "terminalTotalDifficulty": (env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int // 0),
+    "terminalTotalDifficulty": (env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int // 9223372036854775807),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,


### PR DESCRIPTION
I believe this is the correct default value because EEST tests will not provide a value for TOTALTERMINALDIFFICULTY when testing HFs prior to the merge and in that case we shouldn't assume to be post-PoW.