### PR TITLE
clients/go-ethereum: add cancun blob schedule

### DIFF
--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -59,6 +59,11 @@ def to_bool:
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
     "terminalTotalDifficultyPassed": true,
     "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
       "prague": {
         "target": (if env.HIVE_PRAGUE_BLOB_TARGET then env.HIVE_PRAGUE_BLOB_TARGET|to_int else 6 end),
         "max": (if env.HIVE_PRAGUE_BLOB_MAX then env.HIVE_PRAGUE_BLOB_MAX|to_int else 9 end),


### PR DESCRIPTION
As per https://github.com/ethereum/go-ethereum/pull/31002 every configured HF needs to have a blob schedule entry. I don't see any reason to make the cancun schedule configurable but happy to change if people disagree.