### PR TITLE
clients/reth: combine remaining blocks before import 

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -101,11 +101,10 @@ fi
 # Load the remainder of the test chain
 echo "Loading remaining individual blocks..."
 if [ -d /blocks ]; then
-    echo "Loading remaining individual blocks..."
-    for file in $(ls /blocks | sort -n); do
-        echo "Importing " $file
-        $reth import $FLAGS /blocks/$file
-    done
+    echo "Concatenating all blocks..."
+    cat $(ls /blocks/*.rlp | sort -n) > combined.rlp
+    echo "Importing combined blocks..."
+    $reth import $FLAGS combined.rlp
 else
     echo "Warning: blocks folder not found."
 fi


### PR DESCRIPTION
```
eest/consume-rlp : tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py::test_block_hashes_history[fork_Prague-blockchain_test-full_history_plus_one_check_blockhash_first]-reth
```

The above test would call the import command block by block. For a total of 8192 blocks. This would result in a timeout, since staged sync (used on `reth import`) is not suited for single blocks.

Combines all individual blocks into one file, before importing them into reth