### PR TITLE
clients/ethereumjs: add .git approach Dockerfile

### DIFF
--- a/clients/ethereumjs/Dockerfile.git
+++ b/clients/ethereumjs/Dockerfile.git
@@ -2,15 +2,6 @@
 
 FROM node:20-alpine as build
 
-
-# TODO: This should work like other EL clients and use
-# a docker image from the registry. The git build approach is
-# used in Dockerfile.git
-#
-#  ARG baseimage=ethpandaops/ethereumjs
-#  ARG tag=main
-#  FROM $baseimage:$tag
-
 ARG github=ethereumjs/ethereumjs-monorepo
 ARG tag=master
 


### PR DESCRIPTION
EthereumJS seems to be the only client that isn't following the Dockerfile convention of all the other EL clients.

- `Dockerfile` uses `baseimage` and `tag` inputs. This points to an existing docker image from a client.
- `Dockerfile.git`. uses the `github` and `tag` inputs. Used to clone the repo and build the client .