### PR TITLE
clients/reth: combine all blocks except the last before import 

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -103,7 +103,7 @@ echo "Loading remaining individual blocks..."
 mapfile -t BLOCKS < <(ls /blocks/*.rlp 2>/dev/null | sort -n)
 
 if [[ ! -d "/blocks" || ${#BLOCKS[@]} -eq 0 ]]; then
-    echo "Error: No blocks found."
+    echo "Warning: No blocks found."
 elif [[ ${#BLOCKS[@]} -eq 1 ]]; then
     # Import the only existing block
     $reth import $FLAGS "${BLOCKS[0]}"

--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -100,14 +100,23 @@ fi
 
 # Load the remainder of the test chain
 echo "Loading remaining individual blocks..."
-if [ -d /blocks ]; then
-    echo "Loading remaining individual blocks..."
-    for file in $(ls /blocks | sort -n); do
-        echo "Importing " $file
-        $reth import $FLAGS /blocks/$file
-    done
+mapfile -t BLOCKS < <(ls /blocks/*.rlp 2>/dev/null | sort -n)
+
+if [[ ! -d "/blocks" || ${#BLOCKS[@]} -eq 0 ]]; then
+    echo "Error: No blocks found."
+elif [[ ${#BLOCKS[@]} -eq 1 ]]; then
+    # Import the only existing block
+    $reth import $FLAGS "${BLOCKS[0]}"
 else
-    echo "Warning: blocks folder not found."
+    # First import as many blocks as possible, and only then import the last one.
+    # This is important because usually tests expecting a failure will assert that the last valid inserted block is at last - 1. If we attempted to import all of them the pipeline would unwind the whole range.
+    cat "${BLOCKS[@]:0:${#BLOCKS[@]}-1}" > "combined.rlp"
+
+    # Import all but the last block first
+    $reth import $FLAGS "combined.rlp"
+
+    # Import the last block separately
+    $reth import $FLAGS "${BLOCKS[-1]}"
 fi
 
 # Only set boot nodes in online steps


### PR DESCRIPTION
Previous PR https://github.com/ethereum/hive/pull/1230 fixed some, but broke other tests setup. This should cover both cases.

> First import as many blocks as possible, and only then import the last one.
> This is important because usually tests expecting a failure will assert that the last valid inserted block is at `last - 1`. If we attempted to import all of them the pipeline would unwind the whole range.

run: https://github.com/paradigmxyz/reth/actions/runs/13084266651