### PR TITLE
clients/trin: set max default radius to 100%

### DIFF
--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -26,4 +26,4 @@ else
     FLAGS="$FLAGS --bootnodes none"
 fi
 
-RUST_LOG="trace,neli=error,hyper=error,discv5=info" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 $FLAGS
+RUST_LOG="trace,neli=error,hyper=error,discv5=info" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --max-radius 100 $FLAGS


### PR DESCRIPTION
Trin recently made it so the default radius is 5 percent, but the tests are hive are designed for 100% radius