### PR TITLE
cmd/hiveview, hivesim: using slices.Contains to simplify the code

### DIFF
--- a/cmd/hiveview/listing.go
+++ b/cmd/hiveview/listing.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -89,21 +90,12 @@ func suiteToEntry(s *libhive.TestSuite, file fs.FileInfo) listingEntry {
 			e.Start = test.Start
 		}
 		for _, client := range test.ClientInfo {
-			if !contains(e.Clients, client.Name) {
+			if !slices.Contains(e.Clients, client.Name) {
 				e.Clients = append(e.Clients, client.Name)
 			}
 		}
 	}
 	return e
-}
-
-func contains(list []string, s string) bool {
-	for _, elem := range list {
-		if elem == s {
-			return true
-		}
-	}
-	return false
 }
 
 type suiteCB func(*libhive.TestSuite, fs.FileInfo) error

--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -1,5 +1,7 @@
 package hivesim
 
+import "slices"
+
 // SuiteID identifies a test suite context.
 type SuiteID uint32
 
@@ -42,10 +44,5 @@ type ClientDefinition struct {
 
 // HasRole reports whether the client has the given role.
 func (m *ClientDefinition) HasRole(role string) bool {
-	for _, m := range m.Meta.Roles {
-		if m == role {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(m.Meta.Roles, role)
 }


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.