### PR TITLE
simulators/portal: fix race condition in `beacon-sync` suite

### DIFF
--- a/simulators/portal/src/suites/beacon/bridge/service.rs
+++ b/simulators/portal/src/suites/beacon/bridge/service.rs
@@ -126,7 +126,6 @@ impl BridgeService {
                     break;
                 }
             }
-            println!("Bridge service stopped");
         });
     }
 }

--- a/simulators/portal/src/suites/beacon/bridge/service.rs
+++ b/simulators/portal/src/suites/beacon/bridge/service.rs
@@ -121,8 +121,7 @@ impl BridgeService {
                 }
 
                 if !stay_updated {
-                    // Break out of the loop and stop syncing from the provider (for tests where we don't want to pull 
-                    // new updates)
+                    // Break out of the loop and stop syncing from the provider in tests where additional updates are not needed
                     break;
                 }
             }

--- a/simulators/portal/src/suites/beacon/bridge/service.rs
+++ b/simulators/portal/src/suites/beacon/bridge/service.rs
@@ -48,7 +48,7 @@ impl BridgeService {
         *self.trusted_block_root.lock().await
     }
 
-    pub async fn start(&self) {
+    pub async fn start(&self, stay_updated: bool) {
         let provider = self.provider.clone();
         let query_interval = self.query_interval;
         let portal_client = self.portal_client.clone();
@@ -119,7 +119,14 @@ impl BridgeService {
                         };
                     }
                 }
+
+                if !stay_updated {
+                    // Break out of the loop and stop syncing from the provider (for tests where we don't want to pull 
+                    // new updates)
+                    break;
+                }
             }
+            println!("Bridge service stopped");
         });
     }
 }

--- a/simulators/portal/src/suites/beacon/sync.rs
+++ b/simulators/portal/src/suites/beacon/sync.rs
@@ -29,7 +29,7 @@ dyn_async! {
         for client in &clients {
             test.run(
                 NClientTestSpec {
-                    name: format!("Beacon sync test: latest finalized root{}", client.name),
+                    name: format!("Beacon sync test: latest finalized root. {}", client.name),
                     description: "".to_string(),
                     always_run: false,
                     run: test_client_syncs_with_latest_finalized_root,
@@ -66,7 +66,7 @@ dyn_async! {
         let bridge_service = Arc::new(BridgeService::new(client.clone()));
         let service_for_task = bridge_service.clone();
         let provider_handle = tokio::spawn(async move {
-            service_for_task.start().await;
+            service_for_task.start(true).await;
         });
 
         // get enr
@@ -140,7 +140,7 @@ dyn_async! {
         let bridge_service = Arc::new(BridgeService::new(client.clone()));
         let service_for_task = bridge_service.clone();
         let provider_handle = tokio::spawn(async move {
-            service_for_task.start().await;
+            service_for_task.start(false).await;
         });
 
         // get enr
@@ -184,10 +184,10 @@ dyn_async! {
                 sleep(Duration::from_secs(1)).await;
             }
         }).await;
-
+        
         match result {
             Ok(val) => {
-                let actual_optimistic_root = bridge_service.latest_optimistic_root().await.expect("to find a latest finalized root");
+                let actual_optimistic_root = bridge_service.latest_optimistic_root().await.expect("to find a latest optimistic root");
                 assert_eq!(val, actual_optimistic_root);
             }
             Err(err) => {

--- a/simulators/portal/src/suites/beacon/sync.rs
+++ b/simulators/portal/src/suites/beacon/sync.rs
@@ -184,7 +184,6 @@ dyn_async! {
                 sleep(Duration::from_secs(1)).await;
             }
         }).await;
-        
         match result {
             Ok(val) => {
                 let actual_optimistic_root = bridge_service.latest_optimistic_root().await.expect("to find a latest optimistic root");


### PR DESCRIPTION
**The issue**:
The `portal/beacon-sync` test suite currently pulls test data from a live beacon node in order to test syncing the Portal beacon light clients. 

The bridge client that retrieves the finalized and optimistic updates continues to pull new updates from the beacon client as long as the test is running.

This can be an issue in the `optimistic update` test where a new optimistic update is produced every slot.  

Only one optimistic update is pushed into the network and the simulator then retrieves a new update from the bridge to compare to when validating the test results.  

**The solution**

Add a parameter to the `start` method in the `BridgeService` that tells the bridge whether to continue to retrive new updates from the Beacon Node provider or not.  In the the `optimistic update` test, setting this parameter to `false` will ensure that we don't accidentally pull a new optimistic update when validating the test result since this is current test only tests for a single update.