### PR TITLE
geth: bump golang to v1.23 for git build

### DIFF
--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -1,6 +1,6 @@
 ## Pulls geth from a git repository and builds it from source.
 
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 ARG github=ethereum/go-ethereum
 ARG tag=master
 


### PR DESCRIPTION
Otherwise it fails to build