### PR TITLE
simulators/ethereum/eest: Update default fixtures, use cache

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -1,8 +1,8 @@
 # Builds and runs the EEST (execution-spec-tests) consume engine simulator
 FROM python:3.10-slim
 
-## Default fixtures
-ARG fixtures=latest-stable-release
+## Default fixtures and branch
+ARG fixtures=stable@latest
 ENV INPUT=${fixtures}
 ARG branch=main
 ENV BRANCH=${branch}
@@ -17,6 +17,12 @@ RUN apt-get update && \
 RUN git clone https://github.com/ethereum/execution-spec-tests.git --branch "$BRANCH" --single-branch --depth 1
 WORKDIR execution-spec-tests
 RUN pip install uv && uv sync
+
+# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
+# the container starts.
+# If newer version of the fixtures is needed, the image needs to be rebuilt.
+# Use `--docker.nocache` flag to force rebuild.
+RUN uv run consume cache --input "$INPUT"
 
 ## Define `consume engine` entry point using the local fixtures
 ENTRYPOINT uv run consume engine -v --input "$INPUT"

--- a/simulators/ethereum/eest/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eest/consume-rlp/Dockerfile
@@ -1,8 +1,8 @@
 # Builds and runs the EEST (execution-spec-tests) consume rlp simulator
 FROM python:3.10-slim
 
-## Default fixtures
-ARG fixtures=latest-stable-release
+## Default fixtures and branch
+ARG fixtures=stable@latest
 ENV INPUT=${fixtures}
 ARG branch=main
 ENV BRANCH=${branch}
@@ -17,6 +17,12 @@ RUN apt-get update && \
 RUN git clone https://github.com/ethereum/execution-spec-tests.git --branch "$BRANCH" --single-branch --depth 1
 WORKDIR execution-spec-tests
 RUN pip install uv && uv sync
+
+# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
+# the container starts.
+# If newer version of the fixtures is needed, the image needs to be rebuilt.
+# Use `--docker.nocache` flag to force rebuild.
+RUN uv run consume cache --input "$INPUT"
 
 ## Define `consume rlp` entry point using the local fixtures
 ENTRYPOINT uv run consume rlp -v --input "$INPUT"


### PR DESCRIPTION
Fixes the default fixtures tag to the new reference format `stable@latest`.

Use `consume cache` to download fixtures during image build, instead of downloading them each time the container is started.