### PR TITLE
simulators/ethereum: add eest/execute simulator

### DIFF
--- a/simulators/ethereum/eest/execute/Dockerfile
+++ b/simulators/ethereum/eest/execute/Dockerfile
@@ -4,10 +4,12 @@ FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
 ## Default fork/marker/git-ref
 ARG fork=Prague
 ENV FORK=${fork}
-ARG marker_expr=
+ARG marker_expr=transaction_test
 ENV MARKER_EXPR=${marker_expr}
 ARG branch=main
 ENV GIT_REF=${branch} 
+ARG keyword=
+ENV KEYWORD=${keyword}
 
 ## Clone and install EEST
 RUN apt-get update && apt-get install -y git
@@ -23,4 +25,5 @@ WORKDIR /execution-spec-tests
 RUN uv sync
 
 ## Define `execute hive` entry point using the local fixtures
-ENTRYPOINT uv run execute hive --fork "$FORK" -m "$MARKER_EXPR"
+ENTRYPOINT uv run execute hive --fork "$FORK" -m "$MARKER_EXPR" -k "$KEYWORD" -v
+

--- a/simulators/ethereum/eest/execute/Dockerfile
+++ b/simulators/ethereum/eest/execute/Dockerfile
@@ -1,9 +1,11 @@
 # Builds and runs the EEST (execution-spec-tests) execute hive simulator
 FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
 
-## Default fixtures/git-ref
-ARG fixtures=stable@latest
-ENV FIXTURES=${fixtures}
+## Default fork/marker/git-ref
+ARG fork=Prague
+ENV FORK=${fork}
+ARG marker=
+ENV MARKER=${marker}
 ARG branch=main
 ENV GIT_REF=${branch} 
 
@@ -20,11 +22,5 @@ RUN git init execution-spec-tests && \
 WORKDIR /execution-spec-tests
 RUN uv sync
 
-# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
-# the container starts.
-# If newer version of the fixtures is needed, the image needs to be rebuilt.
-# Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$FIXTURES"
-
 ## Define `execute hive` entry point using the local fixtures
-ENTRYPOINT uv run execute hive --fork=Prague -m transaction_test 
+ENTRYPOINT uv run execute hive --fork "$FORK" -m "$MARKER"

--- a/simulators/ethereum/eest/execute/Dockerfile
+++ b/simulators/ethereum/eest/execute/Dockerfile
@@ -23,4 +23,4 @@ WORKDIR /execution-spec-tests
 RUN uv sync
 
 ## Define `execute hive` entry point using the local fixtures
-ENTRYPOINT uv run execute hive --fork "$FORK" -m "$MARKER"
+ENTRYPOINT uv run execute hive --fork "$FORK" -m "$MARKER_EXPR"

--- a/simulators/ethereum/eest/execute/Dockerfile
+++ b/simulators/ethereum/eest/execute/Dockerfile
@@ -4,8 +4,8 @@ FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
 ## Default fork/marker/git-ref
 ARG fork=Prague
 ENV FORK=${fork}
-ARG marker=
-ENV MARKER=${marker}
+ARG marker_expr=
+ENV MARKER_EXPR=${marker_expr}
 ARG branch=main
 ENV GIT_REF=${branch} 
 

--- a/simulators/ethereum/eest/execute/Dockerfile
+++ b/simulators/ethereum/eest/execute/Dockerfile
@@ -1,0 +1,30 @@
+# Builds and runs the EEST (execution-spec-tests) execute hive simulator
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+
+## Default fixtures/git-ref
+ARG fixtures=stable@latest
+ENV FIXTURES=${fixtures}
+ARG branch=main
+ENV GIT_REF=${branch} 
+
+## Clone and install EEST
+RUN apt-get update && apt-get install -y git
+
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD;
+
+WORKDIR /execution-spec-tests
+RUN uv sync
+
+# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
+# the container starts.
+# If newer version of the fixtures is needed, the image needs to be rebuilt.
+# Use `--docker.nocache` flag to force rebuild.
+RUN uv run consume cache --input "$FIXTURES"
+
+## Define `execute hive` entry point using the local fixtures
+ENTRYPOINT uv run execute hive --fork=Prague -m transaction_test 


### PR DESCRIPTION
## Description

Adds execute from [EEST](https://github.com/ethereum/execution-spec-tests) as a hive simulators, utilizing its hive mode extension.

Specifically runs transactions tests.