### PR TITLE
clients/besu: use JDK instead of JRE for docker builds

### DIFF
--- a/clients/besu/Dockerfile.git
+++ b/clients/besu/Dockerfile.git
@@ -9,7 +9,7 @@ ARG github=hyperledger/besu
 RUN echo "installing java on ubuntu base image" \
     && apt-get update && apt-get install -y git libsodium-dev libnss3-dev \
     && apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909* \
-    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* \
+    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jdk-headless=21* libjemalloc-dev=5.* \
     && echo "Cloning: $github - $tag" \
     && git clone --depth 1 --branch $tag https://github.com/$github \
     && cd besu && ./gradlew installDist

--- a/clients/besu/Dockerfile.local
+++ b/clients/besu/Dockerfile.local
@@ -9,7 +9,7 @@ COPY $local_path besu
 
 RUN apt-get update && apt-get install -y git libsodium-dev libnss3-dev \
     && apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 \
-    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* \
+    && apt-get install --no-install-recommends -q --assume-yes openjdk-21-jdk-headless=21* libjemalloc-dev=5.* \
     && cd besu && ./gradlew installDist
 
 ## Final stage: Sets up the environment for running besu


### PR DESCRIPTION
Besu's docker builds (from git) started failing after they updated the version of `gradlew` used. Looks like the fix is simply to require the JDK instead of the JRE (runtime environment). No idea, why this worked before. The fix was taken from this comment:
- https://github.com/hyperledger/besu/issues/8310#issuecomment-2662275519

Confirmed build works locally with `Dockerfile.git`.