### PR TITLE
Add deposit contract to Nethermind's mapper

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -177,6 +177,8 @@ def clique_engine:
         "baseFeeUpdateFraction": (if env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x4c6964" end)
       }
     },
+
+    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
Add's a `depositContract` to a Nethermind's genesis. Relevant PR: https://github.com/NethermindEth/nethermind/pull/8268