### PR TITLE
add deposit contract address in the nethermind config

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -161,6 +161,8 @@ def clique_engine:
     "eip7702TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
     "eip7623TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
 
+    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+
     # Other chain parameters
     "networkID": env.HIVE_NETWORK_ID|to_hex,
     "chainID": env.HIVE_CHAIN_ID|to_hex,


### PR DESCRIPTION
`depositContractAddress` is missing in the `clients/nethermind/mapper.jq` config file; it is causing the nethermind container to terminate unexpectedly