### PR TITLE
simulators/ethereum/graphql: fix test by importing os package

### DIFF
--- a/simulators/ethereum/graphql/graphql_test.go
+++ b/simulators/ethereum/graphql/graphql_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 	"strconv"
 	"testing"
 


### PR DESCRIPTION
Since `io/ioutil` was removed in #817, package `os` should be imported to use `os.ReadFile`. This fixes the failing GraphQL test.