### PR TITLE
simulators/ethereum/eest: update consume dockerfiles

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -1,28 +1,30 @@
 # Builds and runs the EEST (execution-spec-tests) consume engine simulator
-FROM python:3.10-slim
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
 
-## Default fixtures and branch
+## Default fixtures/git-ref
 ARG fixtures=stable@latest
-ENV INPUT=${fixtures}
+ENV FIXTURES=${fixtures}
 ARG branch=main
-ENV BRANCH=${branch}
-
-## Install dependencies
-RUN apt-get update && \
-    apt-get install -y git wget tar && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+ENV GIT_REF=${branch} 
 
 ## Clone and install EEST
-RUN git clone https://github.com/ethereum/execution-spec-tests.git --branch "$BRANCH" --single-branch --depth 1
-WORKDIR execution-spec-tests
-RUN pip install uv && uv sync
+RUN apt-get update && apt-get install -y git
+
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD;
+
+WORKDIR /execution-spec-tests
+RUN uv sync
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$INPUT"
+RUN uv run consume cache --input "$FIXTURES"
 
 ## Define `consume engine` entry point using the local fixtures
-ENTRYPOINT uv run consume engine -v --input "$INPUT"
+ENTRYPOINT uv run consume engine -v --input "$FIXTURES"

--- a/simulators/ethereum/eest/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eest/consume-rlp/Dockerfile
@@ -1,28 +1,30 @@
 # Builds and runs the EEST (execution-spec-tests) consume rlp simulator
-FROM python:3.10-slim
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
 
-## Default fixtures and branch
+## Default fixtures/git-ref
 ARG fixtures=stable@latest
-ENV INPUT=${fixtures}
+ENV FIXTURES=${fixtures}
 ARG branch=main
-ENV BRANCH=${branch}
-
-## Install dependencies
-RUN apt-get update && \
-    apt-get install -y git wget tar && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+ENV GIT_REF=${branch}
 
 ## Clone and install EEST
-RUN git clone https://github.com/ethereum/execution-spec-tests.git --branch "$BRANCH" --single-branch --depth 1
-WORKDIR execution-spec-tests
-RUN pip install uv && uv sync
+RUN apt-get update && apt-get install -y git
+
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD
+
+WORKDIR /execution-spec-tests
+RUN uv sync
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$INPUT"
+RUN uv run consume cache --input "$FIXTURES"
 
 ## Define `consume rlp` entry point using the local fixtures
-ENTRYPOINT uv run consume rlp -v --input "$INPUT"
+ENTRYPOINT uv run consume rlp -v --input "$FIXTURES"


### PR DESCRIPTION
## 🗒️ Description
Updates the consume rlp and engine dockerfiles.

### Before

- Used the `python:3.10-slim` as the base docker image installing additional packages including uv. 

### After 
- Now uses the `ghcr.io/astral-sh/uv:python3.10-bookworm-slim` as the base docker image. No longer requires wget, tar, and uv installs.
- Renames the `INPUT` env var to `FIXTURES`.
- Combines some `RUN` commands to make the Dockerfiles more compact overall.
