### PR TITLE
shisui: make client start quickly

### DIFF
--- a/clients/shisui/shisui.sh
+++ b/clients/shisui/shisui.sh
@@ -30,7 +30,7 @@ else
     FLAGS="$FLAGS --bootnodes=none"
 fi
 
-FLAGS="$FLAGS --nat extip:$IP_ADDR"
+FLAGS="$FLAGS --nat --disable-init-check extip:$IP_ADDR"
 
 shisui $FLAGS
 


### PR DESCRIPTION
For now, the client shisui need 4 seconds before it can work, it will take a lot of time in hive test
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/95d13135-d55a-404d-a7aa-946357169eef" />

So we add a flag `--disable-init-check` o solve the problem, after that, client can start immediately

<img width="1249" alt="image" src="https://github.com/user-attachments/assets/b175f819-4f88-40ce-a246-b22ff47d0a12" />
