### PR TITLE
clients/shisui: hot fix for the wrong flags

### DIFF
--- a/clients/shisui/shisui.sh
+++ b/clients/shisui/shisui.sh
@@ -30,7 +30,7 @@ else
     FLAGS="$FLAGS --bootnodes=none"
 fi
 
-FLAGS="$FLAGS --nat --disable-init-check extip:$IP_ADDR"
+FLAGS="$FLAGS --disable-init-check --nat extip:$IP_ADDR"
 
 shisui $FLAGS
 


### PR DESCRIPTION
@KolbyML 
the `--disable-init-check` flag put the wrong place, cause the fail in hive test