### PR TITLE
clients/reth: improve version parsing in dockerfiles

### DIFF
--- a/clients/reth/Dockerfile
+++ b/clients/reth/Dockerfile
@@ -20,7 +20,7 @@ ADD enode.sh /hive-bin/enode.sh
 RUN chmod +x /hive-bin/enode.sh
 
 # Create version.txt
-RUN /usr/local/bin/reth --version | sed -e 's/reth \(.*\)/\1/' > /version.txt
+RUN /usr/local/bin/reth --version | head -2 | awk 'NR==1 {gsub("reth Version: ", ""); version=$0} NR==2 {gsub("Commit SHA: ", ""); sha=substr($0, 1, 8)} END {print version"+"sha}' > /version.txt
 
 # Export the usual networking ports to allow outside access to the node.
 EXPOSE 8545 8546 30303 30303/udp

--- a/clients/reth/Dockerfile.git
+++ b/clients/reth/Dockerfile.git
@@ -32,7 +32,7 @@ COPY enode.sh /hive-bin/enode.sh
 RUN chmod +x /reth.sh /hive-bin/enode.sh
 
 # Create version.txt
-RUN /usr/local/bin/reth --version | head -1 > /version.txt
+RUN /usr/local/bin/reth --version | head -2 | awk 'NR==1 {gsub("reth Version: ", ""); version=$0} NR==2 {gsub("Commit SHA: ", ""); sha=substr($0, 1, 8)} END {print version"+"sha}' > /version.txt
 
 # Export the usual networking ports
 EXPOSE 8545 8546 30303 30303/udp

--- a/clients/reth/Dockerfile.local
+++ b/clients/reth/Dockerfile.local
@@ -30,7 +30,7 @@ COPY enode.sh /hive-bin/enode.sh
 RUN chmod +x /reth.sh /hive-bin/enode.sh
 
 # Create version.txt
-RUN /usr/local/bin/reth --version | head -1 > /version.txt
+RUN /usr/local/bin/reth --version | head -2 | awk 'NR==1 {gsub("reth Version: ", ""); version=$0} NR==2 {gsub("Commit SHA: ", ""); sha=substr($0, 1, 8)} END {print version"+"sha}' > /version.txt
 
 # Export the usual networking ports
 EXPOSE 8545 8546 30303 30303/udp


### PR DESCRIPTION
Hiveview reports reth's version without a commit hash: `reth Version: 1.3.8`. 

This PR adds the build's commit hash: `1.3.8+52c3e3cc`.

Try it out with the full output of `reth --version`:
```
echo "reth Version: 1.3.8
  Commit SHA: df6d5dd1dd23da180ecd2e15585b3bebc3b5c656
  Build Timestamp: 2025-04-14T08:43:20.271808115Z
  Build Features: jemalloc
  Build Profile: release" | head -2 | awk 'NR==1 {gsub("reth Version: ", ""); version=$0} NR==2 {gsub("Commit SHA: ", ""); sha=substr($0, 1, 8)} END {print version"+"sha}'
```

It's more brittle, but I don't think unexpected output would prevent the image getting built. 

These checks should be outsourced to a helper library that we can independently unit test.