### PR TITLE
clients/ultralight: expose clients commit hash as version.txt for hiveview

### DIFF
--- a/clients/ultralight/Dockerfile
+++ b/clients/ultralight/Dockerfile
@@ -7,7 +7,7 @@ FROM $baseimage:$tag
 COPY ultralight.sh /ultralight.sh
 RUN chmod +x /ultralight.sh
 
-RUN echo "latest" > /version.txt
+RUN echo "$(git rev-parse --short HEAD)" > /version.txt
 
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 9000/udp

--- a/clients/ultralight/Dockerfile.git
+++ b/clients/ultralight/Dockerfile.git
@@ -25,7 +25,7 @@ COPY ultralight.sh /ultralight.sh
 RUN chmod +x /ultralight.sh
 
 # Create version.txt
-RUN echo "latest" > /version.txt
+RUN echo "$(git rev-parse --short HEAD)" > /version.txt
 
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 9000/udp


### PR DESCRIPTION
Currently Ultralight exposes no information about what version is being ran on hive, it looks like an old version is being ran on our main instance

![image](https://github.com/user-attachments/assets/bdbeee2b-7632-4fb3-a6b1-e2e312b76435)

^ this is what it will look like now, before it showed "latest"