### PR TITLE
feat: enable beacon subnetwork for trin client and in portal simulators

### DIFF
--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -13,7 +13,7 @@ fi
 if [ "$HIVE_PORTAL_NETWORKS_SELECTED" != "" ]; then
     FLAGS="$FLAGS --portal-subnetworks $HIVE_PORTAL_NETWORKS_SELECTED"
 else
-    FLAGS="$FLAGS --portal-subnetworks history"
+    FLAGS="$FLAGS --portal-subnetworks beacon,history"
 fi
 
 if [ "$HIVE_TRUSTED_BLOCK_ROOT" != "" ]; then

--- a/simulators/portal/Cargo.lock
+++ b/simulators/portal/Cargo.lock
@@ -1498,8 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.7.0"
-source = "git+https://github.com/ethereum/trin?rev=2fdcce72bf21bbc128a1b6d6a96b20c0ca077c0b#2fdcce72bf21bbc128a1b6d6a96b20c0ca077c0b"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "867347901415dc912ff8b9b12435bd80b72940bc852e958e5bbb583521ff7c6f"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/simulators/portal/Cargo.toml
+++ b/simulators/portal/Cargo.toml
@@ -10,7 +10,7 @@ alloy-rlp = "0.3.11"
 alloy-primitives = "0.8.24"
 anyhow = "1.0"
 chrono = "0.4"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "2fdcce72bf21bbc128a1b6d6a96b20c0ca077c0b" }
+ethportal-api = "0.8.1"
 futures = "0.3.25"
 hivesim = { git = "https://github.com/ethereum/hive", rev = "4408fc1de3fee3ac23acd25a812c117756af2f39" }
 itertools = "0.14"

--- a/simulators/portal/src/suites/history/interop.rs
+++ b/simulators/portal/src/suites/history/interop.rs
@@ -56,6 +56,12 @@ fn process_content(
                         header_with_proof.header.number,
                         vec![history_content, last_header.clone()],
                     ),
+                    HistoryContentKey::EphemeralHeadersFindContent(_) => {
+                        todo!("Add test for EphemeralHeadersFindContent")
+                    }
+                    HistoryContentKey::EphemeralHeaderOffer(_) => {
+                        todo!("Add tests for EphemeralHeaderOffer")
+                    }
                 }
             } else {
                 unreachable!("History test dated is formatted incorrectly")
@@ -468,6 +474,8 @@ dyn_async! {
                         HistoryContentKey::BlockHeaderByNumber(_) => "header by number".to_string(),
                         HistoryContentKey::BlockBody(_) => "body".to_string(),
                         HistoryContentKey::BlockReceipts(_) => "receipt".to_string(),
+                        HistoryContentKey::EphemeralHeadersFindContent(_) => "ephemeral headers find_content".to_string(),
+                        HistoryContentKey::EphemeralHeaderOffer(_) => "ephemeral header offer".to_string(),
                     };
                     format!(
                         "{} {}",

--- a/simulators/portal/src/suites/state/interop.rs
+++ b/simulators/portal/src/suites/state/interop.rs
@@ -152,7 +152,7 @@ dyn_async! {
         // todo: remove this once we implement role in hivesim-rs
         let clients: Vec<ClientDefinition> = clients.into_iter().filter(|client| client.name != *TRIN_BRIDGE_CLIENT_TYPE).collect();
 
-        let environment = Some(HashMap::from([PortalNetwork::as_environment_flag([PortalNetwork::State, PortalNetwork::History])]));
+        let environment = Some(HashMap::from([PortalNetwork::as_environment_flag([PortalNetwork::Beacon, PortalNetwork::History, PortalNetwork::State])]));
         let environments = Some(vec![environment.clone(), environment]);
 
         let content = parse_test_values().expect("unable to parse test values");

--- a/simulators/portal/src/suites/state/rpc_compat.rs
+++ b/simulators/portal/src/suites/state/rpc_compat.rs
@@ -19,7 +19,7 @@ dyn_async! {
         // todo: remove this once we implement role in hivesim-rs
         let clients: Vec<ClientDefinition> = clients.into_iter().filter(|client| client.name != *TRIN_BRIDGE_CLIENT_TYPE).collect();
 
-        let environment_flag = PortalNetwork::as_environment_flag([PortalNetwork::State, PortalNetwork::History]);
+        let environment_flag = PortalNetwork::as_environment_flag([PortalNetwork::Beacon, PortalNetwork::History, PortalNetwork::State]);
         let environments = Some(vec![Some(HashMap::from([environment_flag]))]);
 
         // Test single type of client


### PR DESCRIPTION
With recent  change in trin (https://github.com/ethereum/trin/pull/1775), we need to enable Beacon subnetwork in all tests and add it as a default flag for trin client.

I also updated ethportal-api library version.