### PR TITLE
clients/erigon: Revert "clients/erigon: fix build image dockerfile (#1251)"

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -7,12 +7,7 @@ FROM $baseimage:$tag
 # to install additional commands, so switch back to root.
 USER root
 
-RUN apt-get update && apt-get install -y \
-    bash \
-    build-essential \
-    ca-certificates \
-    git \
-    jq && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash curl jq
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt


### PR DESCRIPTION
This reverts commit e6a0348b4067683fdd15b5ce02e106ea07689d6e.

Reason: The change in baseimage to debian was reverted for the default dockerfile