### PR TITLE
simulators/portal: update history tests to use new test data format

### DIFF
--- a/simulators/portal/Dockerfile
+++ b/simulators/portal/Dockerfile
@@ -39,7 +39,8 @@ RUN apt-get update && apt-get install -y wget git ca-certificates
 # copy build artifacts from build stage
 COPY --from=builder /portal/target/release/portal .
 
-# clone portal-spec-tests repo
+# clone portal-spec-tests repo. The add command is used to reset docker's cache so new data is pulled
+ADD "https://api.github.com/repos/ethereum/portal-spec-tests/commits?per_page=1" latest_commit
 RUN git clone https://github.com/ethereum/portal-spec-tests.git ./portal-spec-tests
 
 ENV RUST_LOG=debug,hyper_util=info,hyper=info,reqwest=info

--- a/simulators/portal/Dockerfile
+++ b/simulators/portal/Dockerfile
@@ -34,13 +34,13 @@ ARG PORTAL_CONSENSUS_AUTH
 ENV PORTAL_CONSENSUS_URL=$PORTAL_CONSENSUS_URL
 ENV PORTAL_CONSENSUS_AUTH=$PORTAL_CONSENSUS_AUTH
 
-RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get install -y wget git ca-certificates
 
 # copy build artifacts from build stage
 COPY --from=builder /portal/target/release/portal .
-ADD https://raw.githubusercontent.com/ethereum/portal-spec-tests/master/tests/mainnet/history/hive/test_data_collection_of_forks_blocks.yaml ./test-data/test_data_collection_of_forks_blocks.yaml
-ADD https://raw.githubusercontent.com/ethereum/portal-spec-tests/master/tests/mainnet/state/hive/test_data.yaml ./test-data/state_test_data.yaml
-ADD https://raw.githubusercontent.com/ethereum/portal-spec-tests/master/tests/mainnet/beacon_chain/hive/test_data.yaml ./test-data/beacon_test_data.yaml
+
+# clone portal-spec-tests repo
+RUN git clone https://github.com/ethereum/portal-spec-tests.git ./portal-spec-tests
 
 ENV RUST_LOG=debug,hyper_util=info,hyper=info,reqwest=info
 

--- a/simulators/portal/src/suites/beacon/constants.rs
+++ b/simulators/portal/src/suites/beacon/constants.rs
@@ -3,7 +3,8 @@ use ethportal_api::{BeaconContentKey, BeaconContentValue, ContentValue};
 use serde_yaml::Value;
 use std::str::FromStr;
 
-pub const TEST_DATA_FILE_PATH: &str = "./test-data/beacon_test_data.yaml";
+pub const TEST_DATA_FILE_PATH: &str =
+    "./portal-spec-tests/tests/mainnet/beacon_chain/hive/test_data.yaml";
 
 pub fn get_test_data() -> anyhow::Result<Vec<(BeaconContentKey, BeaconContentValue)>> {
     let values = std::fs::read_to_string(TEST_DATA_FILE_PATH)?;

--- a/simulators/portal/src/suites/state/constants.rs
+++ b/simulators/portal/src/suites/state/constants.rs
@@ -2,7 +2,7 @@ use alloy_primitives::Bytes;
 use ethportal_api::StateContentKey;
 use std::str::FromStr;
 
-pub const TEST_DATA_FILE_PATH: &str = "./test-data/state_test_data.yaml";
+pub const TEST_DATA_FILE_PATH: &str = "./portal-spec-tests/tests/mainnet/state/hive/test_data.yaml";
 
 // trin-bridge constants
 pub const TRIN_BRIDGE_CLIENT_TYPE: &str = "trin-bridge";


### PR DESCRIPTION
We are updating our test data format so we don't just read a gigantic yaml file. We are starting out with History because that is the priority right now, but we will expand over time