### PR TITLE
simulators/portal: initial clients during history tests with HistoricalSummaries

### DIFF
--- a/simulators/portal/Cargo.lock
+++ b/simulators/portal/Cargo.lock
@@ -1535,8 +1535,8 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.8.1"
-source = "git+https://github.com/ethereum/trin?rev=743475f5ebac00c1359a7b61c45125b22efd841c#743475f5ebac00c1359a7b61c45125b22efd841c"
+version = "0.10.0"
+source = "git+https://github.com/ethereum/trin?rev=fd0b3c19c20c68059370a51d9b433ed34daa0591#fd0b3c19c20c68059370a51d9b433ed34daa0591"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3132,6 +3132,7 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "chrono",
+ "ethereum_ssz",
  "ethportal-api",
  "futures",
  "hivesim",
@@ -3140,6 +3141,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "serde_yaml",
+ "snap",
  "ssz_types",
  "tokio",
  "tracing",
@@ -4012,6 +4014,12 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"

--- a/simulators/portal/Cargo.toml
+++ b/simulators/portal/Cargo.toml
@@ -10,7 +10,8 @@ alloy-rlp = "0.3.11"
 alloy-primitives = "1.1"
 anyhow = "1.0"
 chrono = "0.4"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "743475f5ebac00c1359a7b61c45125b22efd841c" }
+ethereum_ssz = "0.9"
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "fd0b3c19c20c68059370a51d9b433ed34daa0591" }
 futures = "0.3.25"
 hivesim = { git = "https://github.com/ethereum/hive", rev = "4408fc1de3fee3ac23acd25a812c117756af2f39" }
 itertools = "0.14"
@@ -18,6 +19,7 @@ lazy_static = "1.4.0"
 reqwest = { version = "0.12.7", features = ["json"] }
 serde_json = "1.0.95"
 serde_yaml = "0.9.33"
+snap = "1.1"
 ssz_types = "0.11"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.37"

--- a/simulators/portal/src/suites/beacon/bridge/provider.rs
+++ b/simulators/portal/src/suites/beacon/bridge/provider.rs
@@ -2,8 +2,8 @@ use alloy_primitives::B256;
 use anyhow::{anyhow, Result};
 use ethportal_api::{
     light_client::{
-        bootstrap::LightClientBootstrapDeneb, finality_update::LightClientFinalityUpdateDeneb,
-        optimistic_update::LightClientOptimisticUpdateDeneb,
+        bootstrap::LightClientBootstrapElectra, finality_update::LightClientFinalityUpdateElectra,
+        optimistic_update::LightClientOptimisticUpdateElectra,
     },
     types::content_key::beacon::{
         LightClientBootstrapKey, LightClientFinalityUpdateKey, LightClientOptimisticUpdateKey,
@@ -82,7 +82,7 @@ impl ConsensusProvider {
         let content_key = BeaconContentKey::LightClientBootstrap(LightClientBootstrapKey {
             block_hash: block_hash.into(),
         });
-        let bootstrap: LightClientBootstrapDeneb = serde_json::from_value(data)?;
+        let bootstrap: LightClientBootstrapElectra = serde_json::from_value(data)?;
         let content_value = BeaconContentValue::LightClientBootstrap(bootstrap.into());
 
         Ok((content_key, content_value))
@@ -97,7 +97,7 @@ impl ConsensusProvider {
             self.base_url
         );
         let data = make_request(&self.client, &url).await?;
-        let update: LightClientFinalityUpdateDeneb = serde_json::from_value(data)?;
+        let update: LightClientFinalityUpdateElectra = serde_json::from_value(data)?;
         let new_finalized_slot = update.finalized_header.beacon.slot;
         let content_key = BeaconContentKey::LightClientFinalityUpdate(
             LightClientFinalityUpdateKey::new(new_finalized_slot),
@@ -116,7 +116,7 @@ impl ConsensusProvider {
             self.base_url
         );
         let data = make_request(&self.client, &url).await?;
-        let update: LightClientOptimisticUpdateDeneb = serde_json::from_value(data)?;
+        let update: LightClientOptimisticUpdateElectra = serde_json::from_value(data)?;
         let content_key = BeaconContentKey::LightClientOptimisticUpdate(
             LightClientOptimisticUpdateKey::new(update.signature_slot),
         );

--- a/simulators/portal/src/suites/history/mesh.rs
+++ b/simulators/portal/src/suites/history/mesh.rs
@@ -1,15 +1,21 @@
 use alloy_primitives::Bytes;
 use ethportal_api::types::distance::{Metric, XorMetric};
 use ethportal_api::types::portal::FindContentInfo;
-use ethportal_api::{Discv5ApiClient, HistoryContentKey, HistoryNetworkApiClient};
+use ethportal_api::{
+    BeaconNetworkApiClient, ContentValue, Discv5ApiClient, HistoryContentKey,
+    HistoryNetworkApiClient,
+};
 use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, NClientTestSpec, Test};
 use itertools::Itertools;
 use std::collections::HashMap;
 
+use crate::suites::environment::PortalNetwork;
 use crate::suites::history::constants::{
     HEADER_WITH_PROOF_KEY, HEADER_WITH_PROOF_VALUE, TRIN_BRIDGE_CLIENT_TYPE,
 };
+
+use super::constants::LATEST_HISTORICAL_SUMMARIES;
 
 // private key hive environment variable
 const PRIVATE_KEY_ENVIRONMENT_VARIABLE: &str = "HIVE_CLIENT_PRIVATE_KEY";
@@ -24,6 +30,8 @@ dyn_async! {
         let private_key_1 = "fc34e57cc83ed45aae140152fd84e2c21d1f4d46e19452e13acc7ee90daa5bac".to_string();
         let private_key_2 = "e5add57dc4c9ef382509e61ce106ec86f60eb73bbfe326b00f54bf8e1819ba11".to_string();
 
+        let selected_networks = PortalNetwork::as_environment_flag([PortalNetwork::Beacon, PortalNetwork::History]);
+
         // Iterate over all possible pairings of clients and run the tests (including self-pairings)
         for ((client_a, client_b), client_c) in clients.iter().cartesian_product(clients.iter()).cartesian_product(clients.iter()) {
             test.run(
@@ -32,7 +40,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_two_jumps,
-                    environments: Some(vec![None, Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())]))]),
+                    environments: Some(vec![Some(HashMap::from([selected_networks.clone()])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone()), selected_networks.clone()])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone()), selected_networks.clone()]))]),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
@@ -45,7 +53,7 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_two_jumps,
-                    environments: Some(vec![None, Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())]))]),
+                    environments: Some(vec![Some(HashMap::from([selected_networks.clone()])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone()), selected_networks.clone()])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone()), selected_networks.clone()]))]),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
@@ -57,7 +65,7 @@ dyn_async! {
                     description: "find nodes: distance of client A expect seeded enr returned".to_string(),
                     always_run: false,
                     run: test_find_nodes_distance_of_client_c,
-                    environments: None,
+                    environments: Some(vec![Some(HashMap::from([selected_networks.clone()])), Some(HashMap::from([selected_networks.clone()])), Some(HashMap::from([selected_networks.clone()]))]),
                     test_data: (),
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
@@ -68,10 +76,7 @@ dyn_async! {
 
 dyn_async! {
     async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: ()) {
-        let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
-            Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
-            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
-        };
+        let (client_a, client_b, client_c) = initialize_clients(clients).await;
 
         let header_with_proof_key: &HistoryContentKey = &HEADER_WITH_PROOF_KEY;
         let raw_header_with_proof_value: &Bytes = &HEADER_WITH_PROOF_VALUE;
@@ -102,14 +107,14 @@ dyn_async! {
         }
 
         // seed the data into client_c
-        match client_c.rpc.store(header_with_proof_key.clone(), raw_header_with_proof_value.clone()).await {
+        match HistoryNetworkApiClient::store(&client_c.rpc, header_with_proof_key.clone(), raw_header_with_proof_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Unable to store header with proof for find content immediate return test");
             },
             Err(err) => panic!("Error storing header with proof for find content immediate return test: {err:?}"),
         }
 
-        let enrs = match client_a.rpc.find_content(client_b_enr.clone(), header_with_proof_key.clone()).await {
+        let enrs = match  HistoryNetworkApiClient::find_content(&client_a.rpc, client_b_enr.clone(), header_with_proof_key.clone()).await {
             Ok(FindContentInfo::Enrs{ enrs }) => enrs,
             Ok(FindContentInfo::Content{ .. }) => panic!("Error: Unexpected FINDCONTENT response: expected Enrs instead got Content"),
             Err(err) => panic!("Error: Unable to get response from FINDCONTENT request: {err:?}"),
@@ -119,7 +124,7 @@ dyn_async! {
             panic!("Known node is closer to content, Enrs returned should be 0 instead got: length {}", enrs.len());
         }
 
-        match client_a.rpc.find_content(enrs[0].clone(), header_with_proof_key.clone()).await {
+        match HistoryNetworkApiClient::find_content(&client_a.rpc, enrs[0].clone(), header_with_proof_key.clone()).await {
             Ok(FindContentInfo::Content { content, utp_transfer }) => {
                 if content != raw_header_with_proof_value.clone() {
                     panic!("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
@@ -137,10 +142,7 @@ dyn_async! {
 
 dyn_async! {
     async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: ()) {
-        let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
-            Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
-            None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
-        };
+        let (client_a, client_b, client_c) = initialize_clients(clients).await;
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
@@ -162,7 +164,7 @@ dyn_async! {
         }
 
         if let Some(distance) = XorMetric::distance(&target_enr.node_id().raw(), &client_c_enr.node_id().raw()).log2() {
-            match client_a.rpc.find_nodes(target_enr.clone(), vec![distance as u16]).await {
+            match HistoryNetworkApiClient::find_nodes(&client_a.rpc, target_enr.clone(), vec![distance as u16]).await {
                 Ok(response) => {
                     if response.is_empty() {
                         panic!("FindNodes expected to have received a non-empty response");
@@ -177,5 +179,42 @@ dyn_async! {
         } else {
             panic!("Distance calculation failed");
         }
+    }
+}
+
+/// Initialize clients for the test
+///
+/// It will insert HistoricalSummariesWithProof content into the clients
+///
+/// Panics if the clients are not of length 3, or if HistoricalSummaries can't be seeded
+async fn initialize_clients(clients: Vec<Client>) -> (Client, Client, Client) {
+    let (content_key, content_value) = LATEST_HISTORICAL_SUMMARIES.as_ref().clone();
+
+    for client in clients.iter() {
+        match BeaconNetworkApiClient::store(
+            &client.rpc,
+            content_key.clone(),
+            content_value.encode(),
+        )
+        .await
+        {
+            Ok(result) => {
+                if !result {
+                    panic!(
+                        "Unable to HistoricalSummaries for client_type {}",
+                        client.kind
+                    );
+                }
+            }
+            Err(err) => panic!(
+                "Error storing HistoricalSummaries for client_type {}: {err:?}",
+                client.kind
+            ),
+        }
+    }
+
+    match clients.into_iter().collect_tuple() {
+        Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
+        None => panic!("Unable to get expected amount of clients from NClientTestSpec"),
     }
 }


### PR DESCRIPTION
To validate post capella content, clients require access to HistoricalSummaries