### PR TITLE
simulators/portal: fix off by 1 error in flair calculation

### DIFF
--- a/simulators/portal/src/suites/utils.rs
+++ b/simulators/portal/src/suites/utils.rs
@@ -11,25 +11,25 @@ pub const BYZANTIUM_BLOCK_NUMBER: u64 = 4370000;
 pub const HOMESTEAD_BLOCK_NUMBER: u64 = 1150000;
 
 pub fn get_flair(block_number: u64) -> String {
-    if block_number > PRAGUE_BLOCK_NUMBER {
+    if block_number >= PRAGUE_BLOCK_NUMBER {
         " (post-prague)".to_string()
-    } else if block_number > CANCUN_BLOCK_NUMBER {
+    } else if block_number >= CANCUN_BLOCK_NUMBER {
         " (post-cancun)".to_string()
-    } else if block_number > SHANGHAI_BLOCK_NUMBER {
+    } else if block_number >= SHANGHAI_BLOCK_NUMBER {
         " (post-shanghai)".to_string()
-    } else if block_number > MERGE_BLOCK_NUMBER {
+    } else if block_number >= MERGE_BLOCK_NUMBER {
         " (post-merge)".to_string()
-    } else if block_number > LONDON_BLOCK_NUMBER {
+    } else if block_number >= LONDON_BLOCK_NUMBER {
         " (post-london)".to_string()
-    } else if block_number > BERLIN_BLOCK_NUMBER {
+    } else if block_number >= BERLIN_BLOCK_NUMBER {
         " (post-berlin)".to_string()
-    } else if block_number > ISTANBUL_BLOCK_NUMBER {
+    } else if block_number >= ISTANBUL_BLOCK_NUMBER {
         " (post-istanbul)".to_string()
-    } else if block_number > CONSTANTINOPLE_BLOCK_NUMBER {
+    } else if block_number >= CONSTANTINOPLE_BLOCK_NUMBER {
         " (post-constantinople)".to_string()
-    } else if block_number > BYZANTIUM_BLOCK_NUMBER {
+    } else if block_number >= BYZANTIUM_BLOCK_NUMBER {
         " (post-byzantium)".to_string()
-    } else if block_number > HOMESTEAD_BLOCK_NUMBER {
+    } else if block_number >= HOMESTEAD_BLOCK_NUMBER {
         " (post-homestead)".to_string()
     } else {
         "".to_string()


### PR DESCRIPTION
I added test data for testing if we handle fork boundaries properly and from this I found we have an off by one error when calculating the flair for the test title