### PR TITLE
simulators/ethereum/eest: New simulator `execute-blobs`

### DIFF
--- a/simulators/ethereum/eest/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eest/execute-blobs/Dockerfile
@@ -1,0 +1,24 @@
+# Builds and runs the EEST (execution-spec-tests) consume engine simulator
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+
+## Default git-ref/fork
+ARG branch=main
+ENV GIT_REF=${branch} 
+ARG fork=Osaka
+ENV FORK=${fork}
+
+## Clone and install EEST
+RUN apt-get update && apt-get install -y git
+
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD;
+
+WORKDIR /execution-spec-tests
+RUN uv sync
+
+## Define `consume engine` entry point using the local fixtures
+ENTRYPOINT uv run execute hive --fork=$FORK -v -m get_blobs

--- a/simulators/ethereum/eest/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eest/execute-blobs/Dockerfile
@@ -21,4 +21,4 @@ WORKDIR /execution-spec-tests
 RUN uv sync
 
 ## Define `consume engine` entry point using the local fixtures
-ENTRYPOINT uv run execute hive --fork=$FORK -v -m get_blobs
+ENTRYPOINT uv run execute hive --fork=$FORK -v -m blob_transaction_test


### PR DESCRIPTION
Adds new simulator `execute-blobs` which uses the EEST `execute` command to run blob tests:
- Send blob transactions with cell proofs to the client.
- Use `engine_getBlobsV2` to get proofs back from the client
- Verify proofs

At the moment contains only three tests and relies on branch [`devnets/osaka/0`](https://github.com/ethereum/execution-spec-tests/tree/devnets/osaka/0), but more tests will be added soon.