### PR TITLE
Chore: returned ethrex to point to your local image

### DIFF
--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,6 +1,7 @@
 # This is the image we build on a push to main
 # We do have a problem, if we're testing locally it doesn't show changes
 # Removing this from here now, but the upstream version should use the ghcr.io version
+# For now, users needs to build locally ethrex
 # ARG baseimage=ghcr.io/lambdaclass/ethrex 
 ARG baseimage=ethrex # We don
 

--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,7 +1,12 @@
-ARG baseimage=ghcr.io/lambdaclass/ethrex
+# This is the image we build on a push to main
+# We do have a problem, if we're testing locally it doesn't show changes
+# Removing this from here now, but the upstream version should use the ghcr.io version
+# ARG baseimage=ghcr.io/lambdaclass/ethrex 
+ARG baseimage=ethrex # We don
+
 ARG tag=latest
 
-FROM $baseimage:$tag as builder
+FROM $baseimage:$tag AS builder
 
 # Install script tools.
 RUN apt-get update -y

--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -85,13 +85,14 @@ fi
 # Configure RPC.
 FLAGS="$FLAGS --http.addr=0.0.0.0  --authrpc.addr=0.0.0.0"
 
-# We don't support pre merge so we exit with an error if HIVE_TERMINAL_TOTAL_DIFFICULTY is set
+# We don't support pre merge
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     JWT_SECRET="7365637265747365637265747365637265747365637265747365637265747365"
     echo -n $JWT_SECRET > /jwt.secret
     FLAGS="$FLAGS  --authrpc.jwtsecret=/jwt.secret"
 else
-    exit 1
+    # We dont exit because some tests require this
+    echo "Warning: HIVE_TERMINAL_TOTAL_DIFFICULTY not supported."
 fi
 
 FLAGS="$FLAGS  $HIVE_ETHREX_FLAGS"


### PR DESCRIPTION
** Motivation **

The image in "ghcr.io/lambdaclass/ethrex" is only updated on main, and it doesn't take into account the locally built image (unless we change the name). Reverting the base image will allow proper local development again.

** Changes **

* Changed the base image of ethrex to "ethrex"
* Added comment explaining the why
