### PR TITLE
Add jwtsecret to right path

### DIFF
--- a/clients/ethereumjs/Dockerfile
+++ b/clients/ethereumjs/Dockerfile
@@ -14,7 +14,7 @@ ADD genesis.json /genesis.json
 ADD mapper.jq /mapper.jq
 ADD ethereumjs.sh /ethereumjs.sh
 ADD enode.sh /hive-bin/enode.sh
-ADD jwtsecret /jwtsecret
+ADD jwtsecret /ethereumjs-monorepo/jwtsecret
 
 # Set execute permissions for scripts
 RUN chmod +x /ethereumjs.sh /hive-bin/enode.sh


### PR DESCRIPTION
This change updates the jwtsecret path in the ethereumjs dockerfile to be where the entry point shell script expects it to be, fixing an issue where the client doesn't start up during test runs.