### PR TITLE
feat: add optional GOPROXY build arg and use it as an env var

### DIFF
--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -5,6 +5,9 @@ FROM golang:1.24.1-alpine as builder
 
 ARG github=erigontech/erigon
 ARG tag=main
+ARG GOPROXY
+
+ENV GOPROXY=${GOPROXY}
 
 RUN echo "Cloning: $github - $tag" \
     && apk add bash build-base ca-certificates git jq \

--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -3,6 +3,9 @@
 FROM golang:1.23-alpine as builder
 ARG github=ethereum/go-ethereum
 ARG tag=master
+ARG GOPROXY
+
+ENV GOPROXY=${GOPROXY}
 
 RUN \
   apk add --update bash curl jq git make gcc musl-dev                 \

--- a/clients/shisui/Dockerfile.git
+++ b/clients/shisui/Dockerfile.git
@@ -6,6 +6,8 @@ FROM golang:1.24.2 AS builder
 
 ARG github=zen-eth/shisui
 ARG tag=main
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 
 RUN apt-get update && apt-get install -y libclang-dev pkg-config build-essential \
     && echo "Cloning: $github - $tag" \

--- a/hiveproxy/Dockerfile
+++ b/hiveproxy/Dockerfile
@@ -1,4 +1,6 @@
 FROM golang:1-alpine as builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN apk add --update gcc musl-dev linux-headers
 
 # Get dependencies first. This improves caching behavior since they only need

--- a/simulators/devp2p/Dockerfile
+++ b/simulators/devp2p/Dockerfile
@@ -2,6 +2,8 @@
 
 # Build devp2p tool.
 FROM golang:1-alpine as geth-builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN apk add --update git gcc musl-dev linux-headers
 RUN git clone --depth 1 https://github.com/ethereum/go-ethereum.git /go-ethereum
 WORKDIR /go-ethereum
@@ -9,6 +11,8 @@ RUN go build -v ./cmd/devp2p
 
 # Build the simulator executable.
 FROM golang:1-alpine as sim-builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN apk add --update git gcc musl-dev linux-headers
 WORKDIR /source
 COPY go.mod go.sum ./

--- a/simulators/eth2/dencun/Dockerfile
+++ b/simulators/eth2/dencun/Dockerfile
@@ -1,5 +1,7 @@
 # Build the simulator binary
 FROM golang:1.21-alpine AS builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/eth2/engine/Dockerfile
+++ b/simulators/eth2/engine/Dockerfile
@@ -1,5 +1,8 @@
 # Build the simulator binary
 FROM golang:1.22-alpine AS builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/eth2/testnet/Dockerfile
+++ b/simulators/eth2/testnet/Dockerfile
@@ -1,4 +1,7 @@
 FROM golang:1.22-alpine AS builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/eth2/withdrawals/Dockerfile
+++ b/simulators/eth2/withdrawals/Dockerfile
@@ -1,5 +1,8 @@
 # Build the simulator binary
 FROM golang:1.22-alpine AS builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk --no-cache add gcc musl-dev linux-headers cmake make clang build-base clang-static clang-dev
 
 # Prepare workspace.

--- a/simulators/ethereum/consensus/Dockerfile
+++ b/simulators/ethereum/consensus/Dockerfile
@@ -1,5 +1,7 @@
 # This simulation runs the ethereum consensus tests.
 FROM golang:1-alpine as builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Clone the tests repo.

--- a/simulators/ethereum/engine/Dockerfile
+++ b/simulators/ethereum/engine/Dockerfile
@@ -1,5 +1,8 @@
 # This simulation runs Engine API tests.
 FROM golang:1.22-alpine as builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk add --update gcc musl-dev linux-headers
 
 # Build the simulator executable.

--- a/simulators/ethereum/graphql/Dockerfile
+++ b/simulators/ethereum/graphql/Dockerfile
@@ -1,5 +1,8 @@
 # This simulation runs GraphQL tests.
 FROM golang:1-alpine as builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk add --update git gcc musl-dev linux-headers
 
 # Build the simulator executable.

--- a/simulators/ethereum/rpc-compat/Dockerfile
+++ b/simulators/ethereum/rpc-compat/Dockerfile
@@ -1,5 +1,8 @@
 # This simulation runs JSON-RPC API tests.
 FROM golang:1-alpine as builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Clone the tests repo.

--- a/simulators/ethereum/rpc/Dockerfile
+++ b/simulators/ethereum/rpc/Dockerfile
@@ -1,5 +1,8 @@
 # This simulation runs JSON-RPC API tests.
 FROM golang:1-alpine as builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk add --update gcc musl-dev linux-headers
 
 # Build the simulator executable.

--- a/simulators/ethereum/sync/Dockerfile
+++ b/simulators/ethereum/sync/Dockerfile
@@ -1,4 +1,7 @@
 FROM golang:1-alpine as builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk add --update git gcc musl-dev linux-headers
 
 # Build the simulator executable.

--- a/simulators/smoke/clique/Dockerfile
+++ b/simulators/smoke/clique/Dockerfile
@@ -1,5 +1,8 @@
 # Build the simulator.
 FROM golang:1-alpine AS builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk --no-cache add gcc musl-dev linux-headers
 ADD . /clique
 WORKDIR /clique

--- a/simulators/smoke/genesis/Dockerfile
+++ b/simulators/smoke/genesis/Dockerfile
@@ -1,5 +1,7 @@
 # Build the simulator.
 FROM golang:1-alpine AS builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN apk --no-cache add gcc musl-dev linux-headers
 ADD . /genesis
 WORKDIR /genesis

--- a/simulators/smoke/network/Dockerfile
+++ b/simulators/smoke/network/Dockerfile
@@ -1,5 +1,7 @@
 # Build the simulator.
 FROM golang:1-alpine AS builder
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN apk --no-cache add gcc musl-dev linux-headers
 ADD . /
 WORKDIR /


### PR DESCRIPTION
Sometimes we have some CI runs that get blocked by the default proxy. This changed makes it possible to define our own proxy when fetching go packages.