### PR TITLE
feat: add names and labels to containers

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/hive/internal/libdocker"
 	"github.com/ethereum/hive/internal/libhive"
 	"github.com/lmittmann/tint"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 type buildArgs map[string]string
@@ -66,6 +67,14 @@ Otherwise, it looks for files in the $HOME directory:
 		simDevMode            = flag.Bool("dev", false, "Only starts the simulator API endpoint (listening at 127.0.0.1:3000 by default) without starting any simulators.")
 		simDevModeAPIEndpoint = flag.String("dev.addr", "127.0.0.1:3000", "Endpoint that the simulator API listens on")
 		useCredHelper         = flag.Bool("docker.cred-helper", false, "(DEPRECATED) Use --docker.auth instead.")
+
+		// Cleanup flags
+		cleanupContainers = flag.Bool("cleanup", false, "Clean up Hive containers instead of running simulations")
+		cleanupDryRun     = flag.Bool("cleanup.dry-run", false, "Show what containers would be cleaned up without actually removing them")
+		cleanupInstance   = flag.String("cleanup.instance", "", "Clean up containers from specific Hive instance ID only")
+		cleanupType       = flag.String("cleanup.type", "", "Clean up specific container type only (client, simulator, proxy)")
+		cleanupOlderThan  = flag.Duration("cleanup.older-than", 0, "Clean up containers older than specified duration (e.g., 1h, 24h)")
+		listContainers    = flag.Bool("list", false, "List Hive containers instead of running simulations")
 
 		clientsFile = flag.String("client-file", "", `YAML `+"`file`"+` containing client configurations.`)
 
@@ -140,6 +149,41 @@ Otherwise, it looks for files in the $HOME directory:
 	builder, cb, err := libdocker.Connect(*dockerEndpoint, dockerConfig)
 	if err != nil {
 		fatal(err)
+	}
+
+	// Handle cleanup/list operations if requested.
+	if *cleanupContainers || *listContainers {
+		dockerClient := cb.GetDockerClient()
+		if dockerClient == nil {
+			fatal("Docker client not available for cleanup operations")
+		}
+		
+		client, ok := dockerClient.(*docker.Client)
+		if !ok {
+			fatal("Invalid Docker client type")
+		}
+		
+		if *listContainers {
+			err := libhive.ListHiveContainers(context.Background(), client, *cleanupInstance)
+			if err != nil {
+				fatal("Failed to list containers:", err)
+			}
+			return
+		}
+
+		if *cleanupContainers {
+			cleanupOpts := libhive.CleanupOptions{
+				InstanceID:    *cleanupInstance,
+				OlderThan:     *cleanupOlderThan,
+				DryRun:        *cleanupDryRun,
+				ContainerType: *cleanupType,
+			}
+			err := libhive.CleanupHiveContainers(context.Background(), client, cleanupOpts)
+			if err != nil {
+				fatal("Failed to cleanup containers:", err)
+			}
+			return
+		}
 	}
 
 	// Set up the context for CLI interrupts.

--- a/internal/fakes/container.go
+++ b/internal/fakes/container.go
@@ -67,6 +67,15 @@ func (b *fakeBackend) Build(context.Context, libhive.Builder) error {
 	return nil
 }
 
+func (b *fakeBackend) SetHiveInstanceInfo(instanceID, version string) {
+	// No-op for fake backend
+}
+
+func (b *fakeBackend) GetDockerClient() interface{} {
+	// Return nil for fake backend since it doesn't use real Docker
+	return nil
+}
+
 func (b *fakeBackend) ServeAPI(ctx context.Context, h http.Handler) (libhive.APIServer, error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -26,6 +26,10 @@ type ContainerBackend struct {
 	logger *slog.Logger
 
 	proxy *hiveproxy.Proxy
+
+	// Hive instance information for labeling
+	hiveInstanceID string
+	hiveVersion    string
 }
 
 func NewContainerBackend(c *docker.Client, cfg *Config) *ContainerBackend {
@@ -34,6 +38,17 @@ func NewContainerBackend(c *docker.Client, cfg *Config) *ContainerBackend {
 		b.logger = slog.Default()
 	}
 	return b
+}
+
+// SetHiveInstanceInfo sets the hive instance information for container labeling.
+func (b *ContainerBackend) SetHiveInstanceInfo(instanceID, version string) {
+	b.hiveInstanceID = instanceID
+	b.hiveVersion = version
+}
+
+// GetDockerClient returns the underlying Docker client for cleanup operations.
+func (b *ContainerBackend) GetDockerClient() interface{} {
+	return b.client
 }
 
 // RunProgram runs a /hive-bin script in a container.
@@ -80,9 +95,11 @@ func (b *ContainerBackend) CreateContainer(ctx context.Context, imageName string
 	}
 	createOpts := docker.CreateContainerOptions{
 		Context: ctx,
+		Name:    opt.Name,
 		Config: &docker.Config{
-			Image: imageName,
-			Env:   vars,
+			Image:  imageName,
+			Env:    vars,
+			Labels: opt.Labels,
 		},
 	}
 

--- a/internal/libdocker/proxy.go
+++ b/internal/libdocker/proxy.go
@@ -24,7 +24,14 @@ func (cb *ContainerBackend) ServeAPI(ctx context.Context, h http.Handler) (libhi
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
 
-	opts := libhive.ContainerOptions{Output: outW, Input: inR}
+	// Create labels for hiveproxy container.
+	proxyLabels := libhive.NewBaseLabels(cb.hiveInstanceID, cb.hiveVersion)
+	proxyLabels[libhive.LabelHiveType] = libhive.ContainerTypeProxy
+
+	// Generate container name.
+	containerName := libhive.GenerateProxyContainerName()
+
+	opts := libhive.ContainerOptions{Output: outW, Input: inR, Labels: proxyLabels, Name: containerName}
 	id, err := cb.CreateContainer(ctx, hiveproxyTag, opts)
 	if err != nil {
 		return nil, err

--- a/internal/libhive/cleanup.go
+++ b/internal/libhive/cleanup.go
@@ -1,0 +1,159 @@
+package libhive
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+// CleanupOptions configures cleanup behavior
+type CleanupOptions struct {
+	InstanceID    string        // Clean specific instance, empty for all
+	OlderThan     time.Duration // Clean containers older than duration
+	DryRun        bool          // Show what would be cleaned without doing it
+	ContainerType string        // Filter by container type (client, simulator, proxy)
+}
+
+// CleanupHiveContainers finds and removes Hive containers based on labels
+func CleanupHiveContainers(ctx context.Context, client *docker.Client, opts CleanupOptions) error {
+	// Build label filter
+	filters := map[string][]string{
+		"label": {"hive.instance"}, // All containers with hive.instance label
+	}
+
+	if opts.InstanceID != "" {
+		filters["label"] = append(filters["label"], "hive.instance="+opts.InstanceID)
+	}
+
+	if opts.ContainerType != "" {
+		filters["label"] = append(filters["label"], "hive.type="+opts.ContainerType)
+	}
+
+	containers, err := client.ListContainers(docker.ListContainersOptions{
+		Context: ctx,
+		All:     true,
+		Filters: filters,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	for _, container := range containers {
+		if opts.OlderThan > 0 {
+			createdTimeStr, exists := container.Labels[LabelHiveCreated]
+			if !exists {
+				continue // Skip containers without creation timestamp
+			}
+			createdTime, err := time.Parse(time.RFC3339, createdTimeStr)
+			if err != nil || time.Since(createdTime) < opts.OlderThan {
+				continue
+			}
+		}
+
+		containerType := container.Labels[LabelHiveType]
+		if containerType == "" {
+			containerType = "unknown"
+		}
+
+		if opts.DryRun {
+			fmt.Printf("Would remove container %s (%s)\n", container.ID[:12], containerType)
+			continue
+		}
+
+		err := client.RemoveContainer(docker.RemoveContainerOptions{
+			ID:    container.ID,
+			Force: true,
+		})
+		if err != nil {
+			fmt.Printf("Failed to remove container %s: %v\n", container.ID[:12], err)
+		} else {
+			fmt.Printf("Removed container %s (%s)\n", container.ID[:12], containerType)
+		}
+	}
+
+	return nil
+}
+
+// ListHiveContainers lists all Hive containers with their metadata
+func ListHiveContainers(ctx context.Context, client *docker.Client, instanceID string) error {
+	// Build label filter
+	filters := map[string][]string{
+		"label": {"hive.instance"}, // All containers with hive.instance label
+	}
+
+	if instanceID != "" {
+		filters["label"] = append(filters["label"], "hive.instance="+instanceID)
+	}
+
+	containers, err := client.ListContainers(docker.ListContainersOptions{
+		Context: ctx,
+		All:     true,
+		Filters: filters,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	if len(containers) == 0 {
+		fmt.Println("No Hive containers found")
+		return nil
+	}
+
+	fmt.Printf("%-12s %-20s %-12s %-12s %-20s %-10s %s\n", 
+		"CONTAINER ID", "NAME", "TYPE", "STATUS", "CREATED", "INSTANCE", "DETAILS")
+	fmt.Println(strings.Repeat("-", 120))
+
+	for _, container := range containers {
+		containerType := container.Labels[LabelHiveType]
+		if containerType == "" {
+			containerType = "unknown"
+		}
+
+		instanceID := container.Labels[LabelHiveInstance]
+		if len(instanceID) > 10 {
+			instanceID = instanceID[:10] + "..."
+		}
+
+		createdStr := container.Labels[LabelHiveCreated]
+		if createdStr != "" {
+			if createdTime, err := time.Parse(time.RFC3339, createdStr); err == nil {
+				createdStr = createdTime.Format("2006-01-02 15:04")
+			}
+		}
+
+		details := ""
+		switch containerType {
+		case ContainerTypeClient:
+			if clientName := container.Labels[LabelHiveClientName]; clientName != "" {
+				details = "client:" + clientName
+			}
+		case ContainerTypeSimulator:
+			if simName := container.Labels[LabelHiveSimulator]; simName != "" {
+				details = "sim:" + simName
+			}
+		case ContainerTypeProxy:
+			details = "hiveproxy"
+		}
+
+		containerName := ""
+		if len(container.Names) > 0 {
+			containerName = container.Names[0]
+			// Remove the leading "/" that Docker adds to container names
+			if strings.HasPrefix(containerName, "/") {
+				containerName = containerName[1:]
+			}
+			// Truncate long names
+			if len(containerName) > 18 {
+				containerName = containerName[:18] + "..."
+			}
+		}
+
+		fmt.Printf("%-12s %-20s %-12s %-12s %-20s %-10s %s\n",
+			container.ID[:12], containerName, containerType, container.Status, createdStr, instanceID, details)
+	}
+
+	return nil
+}

--- a/internal/libhive/cleanup_test.go
+++ b/internal/libhive/cleanup_test.go
@@ -1,0 +1,53 @@
+package libhive
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCleanupOptions(t *testing.T) {
+	opts := CleanupOptions{
+		InstanceID:    "test-instance",
+		OlderThan:     time.Hour,
+		DryRun:        true,
+		ContainerType: ContainerTypeClient,
+	}
+
+	// Verify options are set correctly
+	if opts.InstanceID != "test-instance" {
+		t.Errorf("Expected InstanceID 'test-instance', got %s", opts.InstanceID)
+	}
+
+	if opts.OlderThan != time.Hour {
+		t.Errorf("Expected OlderThan 1h, got %v", opts.OlderThan)
+	}
+
+	if !opts.DryRun {
+		t.Error("Expected DryRun to be true")
+	}
+
+	if opts.ContainerType != ContainerTypeClient {
+		t.Errorf("Expected ContainerType %s, got %s", ContainerTypeClient, opts.ContainerType)
+	}
+}
+
+func TestCleanupOptionsDefaults(t *testing.T) {
+	opts := CleanupOptions{}
+
+	// Verify default values
+	if opts.InstanceID != "" {
+		t.Errorf("Expected empty InstanceID, got %s", opts.InstanceID)
+	}
+
+	if opts.OlderThan != 0 {
+		t.Errorf("Expected OlderThan 0, got %v", opts.OlderThan)
+	}
+
+	if opts.DryRun {
+		t.Error("Expected DryRun to be false by default")
+	}
+
+	if opts.ContainerType != "" {
+		t.Errorf("Expected empty ContainerType, got %s", opts.ContainerType)
+	}
+}

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -1,10 +1,107 @@
 package libhive
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"time"
 )
+
+// Docker label keys used by Hive
+const (
+	LabelHiveInstance    = "hive.instance"       // Unique Hive instance ID
+	LabelHiveVersion     = "hive.version"        // Hive version/commit
+	LabelHiveType        = "hive.type"           // container type: client|simulator|proxy
+	LabelHiveTestSuite   = "hive.test.suite"     // test suite ID
+	LabelHiveTestCase    = "hive.test.case"      // test case ID
+	LabelHiveClientName  = "hive.client.name"    // client name (go-ethereum, etc)
+	LabelHiveClientImage = "hive.client.image"   // Docker image name
+	LabelHiveCreated     = "hive.created"        // RFC3339 timestamp
+	LabelHiveSimulator   = "hive.simulator"      // simulator name
+)
+
+// Container types
+const (
+	ContainerTypeClient    = "client"
+	ContainerTypeSimulator = "simulator"
+	ContainerTypeProxy     = "proxy"
+)
+
+// GenerateHiveInstanceID creates a unique identifier for this Hive run
+func GenerateHiveInstanceID() string {
+	return fmt.Sprintf("hive-%d-%s", os.Getpid(), time.Now().Format("20060102-150405.000"))
+}
+
+// NewBaseLabels creates base labels for all containers
+func NewBaseLabels(instanceID, hiveVersion string) map[string]string {
+	return map[string]string{
+		LabelHiveInstance: instanceID,
+		LabelHiveVersion:  hiveVersion,
+		LabelHiveCreated:  time.Now().Format(time.RFC3339),
+	}
+}
+
+// SanitizeContainerNameComponent sanitizes a string for use in Docker container names
+// Docker names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*
+func SanitizeContainerNameComponent(s string) string {
+	if s == "" {
+		return s
+	}
+	
+	// Replace invalid characters with dashes
+	sanitized := ""
+	for i, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			sanitized += string(r)
+		} else if i > 0 && (r == '_' || r == '.' || r == '-') {
+			// Allow these characters after the first character
+			sanitized += string(r)
+		} else {
+			// Replace invalid characters with dash
+			sanitized += "-"
+		}
+	}
+	
+	// Ensure first character is alphanumeric
+	if len(sanitized) > 0 && !((sanitized[0] >= 'a' && sanitized[0] <= 'z') || 
+		(sanitized[0] >= 'A' && sanitized[0] <= 'Z') || 
+		(sanitized[0] >= '0' && sanitized[0] <= '9')) {
+		if len(sanitized) > 1 {
+			sanitized = sanitized[1:]
+		} else {
+			sanitized = "container"
+		}
+	}
+	
+	return sanitized
+}
+
+// GenerateContainerName generates a Hive-prefixed container name
+func GenerateContainerName(containerType, identifier string) string {
+	timestamp := time.Now().Format("20060102-150405")
+	sanitizedType := SanitizeContainerNameComponent(containerType)
+	if identifier != "" {
+		sanitizedIdentifier := SanitizeContainerNameComponent(identifier)
+		return fmt.Sprintf("hive-%s-%s-%s", sanitizedType, sanitizedIdentifier, timestamp)
+	}
+	return fmt.Sprintf("hive-%s-%s", sanitizedType, timestamp)
+}
+
+// GenerateClientContainerName generates a name for client containers
+func GenerateClientContainerName(clientName string, suiteID TestSuiteID, testID TestID) string {
+	identifier := fmt.Sprintf("%s-s%s-t%s", clientName, suiteID.String(), testID.String())
+	return GenerateContainerName("client", identifier)
+}
+
+// GenerateSimulatorContainerName generates a name for simulator containers
+func GenerateSimulatorContainerName(simulatorName string) string {
+	return GenerateContainerName("simulator", simulatorName)
+}
+
+// GenerateProxyContainerName generates a name for hiveproxy containers
+func GenerateProxyContainerName() string {
+	return GenerateContainerName("proxy", "")
+}
 
 // TestSuiteID identifies a test suite context.
 type TestSuiteID uint32

--- a/internal/libhive/data_test.go
+++ b/internal/libhive/data_test.go
@@ -1,0 +1,202 @@
+package libhive
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateHiveInstanceID(t *testing.T) {
+	id1 := GenerateHiveInstanceID()
+	
+	// Sleep briefly to ensure different timestamp
+	time.Sleep(time.Millisecond)
+	id2 := GenerateHiveInstanceID()
+
+	if id1 == id2 {
+		t.Error("GenerateHiveInstanceID should generate unique IDs")
+	}
+
+	if len(id1) == 0 {
+		t.Error("GenerateHiveInstanceID should not return empty string")
+	}
+
+	// Should start with "hive-"
+	if len(id1) < 5 || id1[:5] != "hive-" {
+		t.Errorf("GenerateHiveInstanceID should start with 'hive-', got: %s", id1)
+	}
+}
+
+func TestNewBaseLabels(t *testing.T) {
+	instanceID := "test-instance-123"
+	version := "commit-abc123"
+
+	labels := NewBaseLabels(instanceID, version)
+
+	// Check that all required base labels are present
+	requiredLabels := []string{LabelHiveInstance, LabelHiveVersion, LabelHiveCreated}
+	for _, label := range requiredLabels {
+		if _, exists := labels[label]; !exists {
+			t.Errorf("NewBaseLabels should include label %s", label)
+		}
+	}
+
+	// Check values
+	if labels[LabelHiveInstance] != instanceID {
+		t.Errorf("Expected instance ID %s, got %s", instanceID, labels[LabelHiveInstance])
+	}
+
+	if labels[LabelHiveVersion] != version {
+		t.Errorf("Expected version %s, got %s", version, labels[LabelHiveVersion])
+	}
+
+	// Check that created timestamp is valid RFC3339
+	createdStr := labels[LabelHiveCreated]
+	_, err := time.Parse(time.RFC3339, createdStr)
+	if err != nil {
+		t.Errorf("Created timestamp should be valid RFC3339 format: %v", err)
+	}
+}
+
+func TestContainerTypeConstants(t *testing.T) {
+	// Verify container type constants have expected values
+	expectedTypes := map[string]string{
+		ContainerTypeClient:    "client",
+		ContainerTypeSimulator: "simulator",
+		ContainerTypeProxy:     "proxy",
+	}
+
+	for constant, expected := range expectedTypes {
+		if constant != expected {
+			t.Errorf("Expected %s to equal %s", constant, expected)
+		}
+	}
+}
+
+func TestLabelConstants(t *testing.T) {
+	// Verify all label constants have the expected hive prefix
+	labels := []string{
+		LabelHiveInstance,
+		LabelHiveVersion,
+		LabelHiveType,
+		LabelHiveTestSuite,
+		LabelHiveTestCase,
+		LabelHiveClientName,
+		LabelHiveClientImage,
+		LabelHiveCreated,
+		LabelHiveSimulator,
+	}
+
+	for _, label := range labels {
+		if len(label) < 5 || label[:5] != "hive." {
+			t.Errorf("Label %s should start with 'hive.' prefix", label)
+		}
+	}
+}
+
+func TestGenerateContainerName(t *testing.T) {
+	name1 := GenerateContainerName("client", "go-ethereum")
+	name2 := GenerateContainerName("simulator", "devp2p")
+	name3 := GenerateContainerName("proxy", "")
+
+	// All names should start with "hive-"
+	names := []string{name1, name2, name3}
+	for _, name := range names {
+		if len(name) < 5 || name[:5] != "hive-" {
+			t.Errorf("Container name %s should start with 'hive-'", name)
+		}
+	}
+
+	// Names should be different
+	if name1 == name2 {
+		t.Error("Different container types should generate different names")
+	}
+
+	// Proxy name should not have identifier
+	if len(name3) < len("hive-proxy-") {
+		t.Errorf("Proxy name too short: %s", name3)
+	}
+}
+
+func TestGenerateClientContainerName(t *testing.T) {
+	name := GenerateClientContainerName("go-ethereum", TestSuiteID(1), TestID(2))
+	
+	if len(name) < 5 || name[:5] != "hive-" {
+		t.Errorf("Client container name should start with 'hive-', got: %s", name)
+	}
+
+	// Should contain client name and IDs
+	if !strings.Contains(name, "client") {
+		t.Errorf("Client container name should contain 'client', got: %s", name)
+	}
+	if !strings.Contains(name, "go-ethereum") {
+		t.Errorf("Client container name should contain client name, got: %s", name)
+	}
+}
+
+func TestGenerateSimulatorContainerName(t *testing.T) {
+	name := GenerateSimulatorContainerName("devp2p")
+	
+	if len(name) < 5 || name[:5] != "hive-" {
+		t.Errorf("Simulator container name should start with 'hive-', got: %s", name)
+	}
+
+	if !strings.Contains(name, "simulator") {
+		t.Errorf("Simulator container name should contain 'simulator', got: %s", name)
+	}
+	if !strings.Contains(name, "devp2p") {
+		t.Errorf("Simulator container name should contain simulator name, got: %s", name)
+	}
+}
+
+func TestGenerateProxyContainerName(t *testing.T) {
+	name := GenerateProxyContainerName()
+	
+	if len(name) < 5 || name[:5] != "hive-" {
+		t.Errorf("Proxy container name should start with 'hive-', got: %s", name)
+	}
+
+	if !strings.Contains(name, "proxy") {
+		t.Errorf("Proxy container name should contain 'proxy', got: %s", name)
+	}
+}
+
+func TestSanitizeContainerNameComponent(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"ethereum/rpc-compat", "ethereum-rpc-compat"},
+		{"go-ethereum", "go-ethereum"},
+		{"test_123", "test_123"},
+		{"test.version", "test.version"},
+		{"/invalid", "invalid"},
+		{"_invalid", "invalid"},
+		{".invalid", "invalid"},
+		{"", ""},
+		{"123valid", "123valid"},
+		{"special@chars#", "special-chars-"},
+		{"a", "a"},
+		{"_", "container"},
+	}
+
+	for _, test := range tests {
+		result := SanitizeContainerNameComponent(test.input)
+		if result != test.expected {
+			t.Errorf("SanitizeContainerNameComponent(%q) = %q, expected %q", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestSanitizedContainerNames(t *testing.T) {
+	// Test that names with slashes get properly sanitized
+	name := GenerateSimulatorContainerName("ethereum/rpc-compat")
+	
+	if strings.Contains(name, "/") {
+		t.Errorf("Container name should not contain '/', got: %s", name)
+	}
+	
+	if !strings.Contains(name, "ethereum-rpc-compat") {
+		t.Errorf("Container name should contain sanitized simulator name, got: %s", name)
+	}
+}

--- a/internal/libhive/dockerface.go
+++ b/internal/libhive/dockerface.go
@@ -16,6 +16,12 @@ type ContainerBackend interface {
 	// This is called before anything else in the simulation run.
 	Build(context.Context, Builder) error
 
+	// SetHiveInstanceInfo sets the hive instance information for container labeling.
+	SetHiveInstanceInfo(instanceID, version string)
+
+	// GetDockerClient returns the underlying Docker client for cleanup operations.
+	GetDockerClient() interface{}
+
 	// This is for launching the simulation API server.
 	ServeAPI(context.Context, http.Handler) (APIServer, error)
 
@@ -63,6 +69,12 @@ type ContainerOptions struct {
 
 	// Input: if set, container stdin draws from the given reader.
 	Input io.ReadCloser
+
+	// Labels: Docker labels to apply to container
+	Labels map[string]string
+
+	// Name: Docker container name (optional)
+	Name string
 }
 
 // ContainerInfo is returned by StartContainer.

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -76,6 +76,10 @@ type TestManager struct {
 	simContainerID string
 	simLogFile     string
 
+	// Hive instance information for labeling
+	hiveInstanceID string
+	hiveVersion    string
+
 	// all networks started by a specific test suite, where key
 	// is network name and value is network ID
 	networks     map[TestSuiteID]map[string]string
@@ -99,6 +103,8 @@ func NewTestManager(config SimEnv, b ContainerBackend, clients []*ClientDefiniti
 		config:            config,
 		backend:           b,
 		hiveInfo:          hiveInfo,
+		hiveInstanceID:    GenerateHiveInstanceID(),
+		hiveVersion:       hiveInfo.Commit,
 		runningTestSuites: make(map[TestSuiteID]*TestSuite),
 		runningTestCases:  make(map[TestID]*TestCase),
 		results:           make(map[TestSuiteID]*TestSuite),


### PR DESCRIPTION

This PR implements container labeling and naming system for Hive, enabling easier cleanup, monitoring, and management of containers. The system provides persistent metadata that survives Hive crashes and allows for background cleanup operations.

## Key Features

### Comprehensive Container Labeling
- **Standardized label schema**: All containers get consistent labels with `hive.` prefix
- **Rich metadata**: Labels include instance ID, version, container type, test context, and timestamps
- **Unique instance tracking**: Each Hive run gets a unique instance ID for identification
- **Context-aware labeling**: Client, simulator, and proxy containers get type-specific labels

### Descriptive Container Names
- **Hive-prefixed names**: All containers now have descriptive names starting with `hive-`
- **Context inclusion**: Names include container type, client/simulator names, and test IDs
- **Name sanitization**: Automatic handling of invalid characters (e.g., `/` → `-`) for Docker compatibility

### Cleanup Tools
- **List containers**: `./hive --list` shows all Hive containers with metadata
- **Cleanup operations**: `./hive --cleanup` removes Hive containers with flexible filtering
- **Dry-run mode**: `./hive --cleanup.dry-run` previews cleanup operations
- **Targeted cleanup**: Filter by instance ID, container type, or age

## Container Examples

### Labels Applied
```json
{
  "hive.instance": "hive-12345-20250611-175335",
  "hive.version": "commit-abc123",
  "hive.type": "client",
  "hive.test.suite": "1",
  "hive.test.case": "2",
  "hive.client.name": "go-ethereum",
  "hive.client.image": "ethereum/client-go:latest",
  "hive.created": "2025-06-11T17:53:35Z"
}
```

### Container Names Generated
- **Client**: `hive-client-go-ethereum-s1-t2-20250611-175335`
- **Simulator**: `hive-simulator-ethereum-engine-20250611-175335`
- **Proxy**: `hive-proxy-20250611-175335`

## CLI Usage Examples

```bash
# List all Hive containers
./hive --list

# Clean up all Hive containers (dry run)
./hive --cleanup.dry-run

# Clean up containers from specific instance
./hive --cleanup --cleanup.instance=hive-12345-20250611-175335

# Clean up only client containers
./hive --cleanup --cleanup.type=client

# Clean up containers older than 1 hour
./hive --cleanup --cleanup.older-than=1h
```

### Label Schema
- `hive.instance` - Unique Hive instance ID
- `hive.version` - Hive version/commit
- `hive.type` - Container type: `client`, `simulator`, or `proxy`
- `hive.test.suite` - Test suite ID (clients only)
- `hive.test.case` - Test case ID (clients only)
- `hive.client.name` - Client name (clients only)
- `hive.client.image` - Docker image name (clients only)
- `hive.simulator` - Simulator name (simulators only)
- `hive.created` - RFC3339 timestamp

