### PR TITLE
chore(clients): update nethermind mapper for fusaka devnet 2

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -172,6 +172,7 @@ def clique_engine:
     "eip7951TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
     "eip7939TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
     "eip7934TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
+    "eip7907TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
     "eip7934MaxRlpBlockSize": "0x800000",
 
     # Other chain parameters


### PR DESCRIPTION
Adds EIP-7907 to the nethermind mapper to activate for fusaka devnet 2.