### PR TITLE
simulators/ethereum/eest: avoid github api calls when retrieving eest releases

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -24,7 +24,7 @@ RUN uv sync
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$FIXTURES"
+RUN uv run consume cache --no-api-calls --input "$FIXTURES"
 
 ## Define `consume engine` entry point using the local fixtures
-ENTRYPOINT uv run consume engine -v --input "$FIXTURES"
+ENTRYPOINT uv run consume engine -v --no-api-calls --input "$FIXTURES"

--- a/simulators/ethereum/eest/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eest/consume-rlp/Dockerfile
@@ -24,7 +24,7 @@ RUN uv sync
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$FIXTURES"
+RUN uv run consume cache --no-api-calls --input "$FIXTURES"
 
 ## Define `consume rlp` entry point using the local fixtures
-ENTRYPOINT uv run consume rlp -v --input "$FIXTURES"
+ENTRYPOINT uv run consume rlp -v --no-api-calls --input "$FIXTURES"


### PR DESCRIPTION
- **This PR requires: https://github.com/ethereum/execution-spec-tests/pull/1788**
- **Please don't merge until the above PR is merged**

Use the `--no-api-calls` flag in `consume` commands to avoid potentially rate limiting issues with the Github API when retrieving EEST releases using URLs:

- ✅ Direct URLs will avoid API calls, e.g.`--input=https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_stable.tar.gz`.
- ❌ Version specifiers always require API calls, e.g. `--input=stable@latest` (the flag is ignored).