### PR TITLE
clients/erigon: Update Dockerfile

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -8,6 +8,12 @@ FROM $baseimage:$tag
 USER root
 
 RUN apk add --no-cache bash curl jq
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    jq && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt


### PR DESCRIPTION
With https://github.com/erigontech/erigon/pull/15757 erigon is switching to Debian based docker image.

Please, approve it in order to keep your workflow running fine.

This change redo https://github.com/ethereum/hive/pull/1251.