### PR TITLE
simulators/ethereum/eest: bump base image to python 3.12

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EEST (execution-spec-tests) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest

--- a/simulators/ethereum/eest/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eest/consume-rlp/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EEST (execution-spec-tests) consume rlp simulator
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest

--- a/simulators/ethereum/eest/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eest/execute-blobs/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EEST (execution-spec-tests) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default git-ref/fork
 ARG branch=main


### PR DESCRIPTION
Bump base image used by EEST simulators from Python 3.10 to 3.12. Python 3.10 support is planned for removal, cf https://github.com/ethereum/execution-spec-tests/pull/1808.
