### PR TITLE
clients/erigon: fix apk error

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -7,7 +7,6 @@ FROM $baseimage:$tag
 # to install additional commands, so switch back to root.
 USER root
 
-RUN apk add --no-cache bash curl jq
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \


### PR DESCRIPTION
related to https://github.com/ethereum/hive/pull/1312 

Error

```
Step 5/14 : RUN apk add --no-cache bash curl jq
 ---> Running in 10199a9f416c
/bin/bash: line 1: apk: command not found
```