### PR TITLE
simulators/ethereum/eest: Use git clone again

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -7,12 +7,18 @@ ENV FIXTURES=${fixtures}
 ARG branch=main
 ENV GIT_REF=${branch} 
 
-## Install EEST
-## TODO: Remove this line once EEST is published to PyPI
+## Clone and install EEST
 RUN apt-get update && apt-get install -y git
 
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD;
+
 WORKDIR /execution-spec-tests
-RUN uv venv && uv pip install git+https://github.com/ethereum/execution-spec-tests.git@$GIT_REF
+RUN uv sync
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.

--- a/simulators/ethereum/eest/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eest/consume-rlp/Dockerfile
@@ -7,12 +7,18 @@ ENV FIXTURES=${fixtures}
 ARG branch=main
 ENV GIT_REF=${branch}
 
-## Install EEST
-## TODO: Remove this line once EEST is published to PyPI
+## Clone and install EEST
 RUN apt-get update && apt-get install -y git
 
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD
+
 WORKDIR /execution-spec-tests
-RUN uv venv && uv pip install git+https://github.com/ethereum/execution-spec-tests.git@$GIT_REF
+RUN uv sync
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.


### PR DESCRIPTION
Reverts #1319 because this is causing issues on the CI of some clients that are using versions prior to the release where the problematic library was replaced.

See https://github.com/paradigmxyz/reth/actions/runs/16346231258/job/46182718752

cc @shekhirin