### PR TITLE
clients/nimbus-el: activate admin rpc

### DIFF
--- a/clients/nimbus-el/nimbus.sh
+++ b/clients/nimbus-el/nimbus.sh
@@ -107,8 +107,8 @@ set -e
 
 # Configure RPC
 FLAGS="$FLAGS --http-address:0.0.0.0 --http-port:8545"
-FLAGS="$FLAGS --rpc --rpc-api:eth,debug"
-FLAGS="$FLAGS --ws --ws-api:eth,debug"
+FLAGS="$FLAGS --rpc --rpc-api:eth,debug,admin"
+FLAGS="$FLAGS --ws --ws-api:eth,debug,admin"
 
 # Configure graphql
 if [ "$HIVE_GRAPHQL_ENABLED" != "" ]; then


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth1/pull/3431 add a new namespace for rpc. And it is not activated by default. This PR fix it.
The admin rpc required when calling `admin_nodeInfo`. Previous version always enable it without tied to any namespace configuration.