### PR TITLE
clients/ethrex: update Dockerfile

### DIFF
--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,7 +1,12 @@
 ARG baseimage=ghcr.io/lambdaclass/ethrex
 ARG tag=latest
 
-FROM $baseimage:$tag as builder
+FROM $baseimage:$tag AS builder
+
+FROM ubuntu:24.04
+
+WORKDIR /usr/local/bin
+COPY --from=builder /usr/local/bin/ethrex .
 
 # Install script tools.
 RUN apt-get update -y

--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=ghcr.io/lambdaclass/ethrex
-ARG tag=latest
+ARG tag=unstable
 
 FROM $baseimage:$tag AS builder
 


### PR DESCRIPTION
Ethrex's Docker image [is being refactored](https://github.com/lambdaclass/ethrex/pull/3826) and will have a minimalist distroless image as base, instead of the current Ubuntu. This change breaks Hive tests running as the new image doesn't have some tools and commands.
In this PR, the binary from the official image is copied into an Ubuntu image to keep compatibility