### PR TITLE
refactor(nethermind): Refactor enode parsing to not use logs

### DIFF
--- a/clients/nethermind/Dockerfile
+++ b/clients/nethermind/Dockerfile
@@ -3,7 +3,7 @@ ARG baseimage=nethermindeth/nethermind
 ARG tag=master
 FROM $baseimage:$tag
 
-RUN apt-get update && apt-get install -y jq && \
+RUN apt-get update && apt-get install -y jq curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -18,7 +18,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble
 COPY --from=build /nethermind/src/Nethermind/artifacts/bin/Nethermind.Runner/release /nethermind
 WORKDIR /nethermind
 
-RUN apt-get update && apt-get install -y jq libsnappy-dev libc6-dev libc6 && \
+RUN apt-get update && apt-get install -y jq curl libsnappy-dev libc6-dev libc6 && \
     rm -rf /var/lib/apt/lists/*
 
 # Create version.txt

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -17,7 +17,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble
 COPY --from=build /nethermind/src/Nethermind/artifacts/bin/Nethermind.Runner/release /nethermind
 WORKDIR /nethermind
 
-RUN apt-get update && apt-get install -y jq libsnappy-dev libc6-dev libc6 && \
+RUN apt-get update && apt-get install -y jq curl libsnappy-dev libc6-dev libc6 && \
     rm -rf /var/lib/apt/lists/*
 
 # Create version.txt

--- a/clients/nethermind/enode.sh
+++ b/clients/nethermind/enode.sh
@@ -8,9 +8,9 @@
 
 # Immediately abort the script on any error encountered
 
-
 set -e
 
-TARGET_ENODE=$(sed -n -e 's/^.*This node.*: //p' /log.txt)
-echo ${TARGET_ENODE/|/}
+TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}' "localhost:8545" )
 
+TARGET_ENODE=$(echo ${TARGET_RESPONSE}| jq -r '.result.enode')
+echo "$TARGET_ENODE"

--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -46,14 +46,14 @@ def json_rpc_config:
     {
       "JsonRpc": {
         "JwtSecretFile": "/jwt.secret",
-        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health"],
-        "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|debug;net;eth;subscribe;engine;web3;client|no-auth", "http://0.0.0.0:8551|http;ws|debug;net;eth;subscribe;engine;web3;client"]
+        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin"],
+        "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|debug;net;eth;subscribe;engine;web3;client;admin|no-auth", "http://0.0.0.0:8551|http;ws|debug;net;eth;subscribe;engine;web3;client;admin"]
       }
     }
   else
     {
       "JsonRpc": {
-        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health"]
+        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin"]
       }
     }
   end

--- a/clients/nethermind/nethermind.sh
+++ b/clients/nethermind/nethermind.sh
@@ -93,5 +93,4 @@ if [ "$HIVE_LOGLEVEL" != "" ]; then
     LOG_FLAG="--log $LOG"
 fi
 echo "Running Nethermind..."
-# The output is tee:d, via /log.txt, because the enode script uses that logfile to parse out the enode id
-dotnet /nethermind/nethermind.dll --config /configs/test.cfg $LOG_FLAG 2>&1 | tee /log.txt
+dotnet /nethermind/nethermind.dll --config /configs/test.cfg $LOG_FLAG


### PR DESCRIPTION
Using logs is too fragile. It's not ideal to get the enode from the logs in the first place - and, as in my case, if the log level is set lower it's never able to parse the `enode` from the logs as it never shows up. All other clients use the `admin_nodeInfo` request for this purpose and we should do so for Nethermind as well.

This also turns on `admin` module as this was necessary for this change.