### PR TITLE
feat(simulators): Add ``eest/consume-sync`` simulator

### DIFF
--- a/simulators/ethereum/eest/consume-sync/Dockerfile
+++ b/simulators/ethereum/eest/consume-sync/Dockerfile
@@ -1,0 +1,30 @@
+# Builds and runs the EEST (execution-spec-tests) consume sync simulator
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+## Default fixtures/git-ref
+ARG fixtures=stable@latest
+ENV FIXTURES=${fixtures}
+ARG branch=main
+ENV GIT_REF=${branch}
+
+## Clone and install EEST
+RUN apt-get update && apt-get install -y git
+
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD;
+
+WORKDIR /execution-spec-tests
+RUN uv sync
+
+# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
+# the container starts.
+# If newer version of the fixtures is needed, the image needs to be rebuilt.
+# Use `--docker.nocache` flag to force rebuild.
+RUN uv run consume cache --input "$FIXTURES"
+
+## Define `consume sync` entry point using the local fixtures
+ENTRYPOINT uv run consume sync -v --input "$FIXTURES"


### PR DESCRIPTION
Add a simulator for the new ``consume sync`` eest command for testing engine API with subsequent client sync.