### PR TITLE
clients(erigon): disable caplin in hive

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -142,6 +142,9 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.jwtsecret=/jwt.secret"
 fi
 
+# Disable Caplin
+FLAGS="$FLAGS --externalcl"
+
 # Launch the main client.
 FLAGS="$FLAGS --nat=none"
 echo "Running erigon with flags $FLAGS"


### PR DESCRIPTION
### Description

 Disable Caplin in Erigon. Allows RPC calls from simulators. Prevents the following error from EEST simulators:
 
 ```bash
 ethereum_test_rpc.types.JSONRPCError: JSONRPCError(code=-38005, message=caplin is enabled)
 ```