### PR TITLE
simulators/eest/consume-engine: disable exception mapper for nimbus-el

### DIFF
--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -26,5 +26,9 @@ RUN uv sync
 # Use `--docker.nocache` flag to force rebuild.
 RUN uv run consume cache --input "$FIXTURES"
 
+
 ## Define `consume engine` entry point using the local fixtures
-ENTRYPOINT uv run consume engine -v --input "$FIXTURES"
+# TODO: remove when fixed on nimbus-el side.
+ARG disable_strict_exception_matching=nimbus-el
+ENV DISABLE_STRICT_EXCEPTION_MATCHING=${disable_strict_exception_matching} 
+ENTRYPOINT uv run consume engine -v --input "$FIXTURES" --disable-strict-exception-matching "$DISABLE_STRICT_EXCEPTION_MATCHING"


### PR DESCRIPTION
### Description

Nimbus-EL don't currently return appropriate messages for exceptions via `consume-engine` due to there pre validation logic. This PR disables the exception mapper usage temporarily (to clean up hive), until this is updated on the Nimbus-EL side.