### PR TITLE
clients/go-ethereum: reduce overhead of local build

### DIFF
--- a/clients/go-ethereum/Dockerfile.local
+++ b/clients/go-ethereum/Dockerfile.local
@@ -6,8 +6,8 @@ RUN apk add --update bash curl jq git make gcc libc-dev linux-headers
 # Default local client path: clients/go-ethereum/<go-ethereum>
 ARG local_path=go-ethereum
 
-# Copy the go.mod file and download dependencies in a separate layer
-COPY $local_path/go.mod go-ethereum/
+# Copy go.mod and go.sum and download dependencies in a separate layer
+COPY $local_path/go.mod $local_path/go.sum go-ethereum/
 RUN cd go-ethereum && go mod download
 
 # Copy the source code


### PR DESCRIPTION
Make local development use docker cache better
- move apk command to beginning, so it can be reused in later builds
- download go deps in a separate layer, so it can be reused if not changed

Before: ~1.2 GB layer created, which is then recreated on every single change to sources
After:
- ~300 MB layer for apk, cached
- ~600 MB layer for dependencies, cached
- ~600 MB layer redone each time

Downside: go build can't parallelise download and build, so there is a slight time increase (113sec vs 120sec on my M1).