### PR TITLE
clients/erigon: no-downloader flag

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -146,6 +146,6 @@ fi
 FLAGS="$FLAGS --externalcl"
 
 # Launch the main client.
-FLAGS="$FLAGS --nat=none"
+FLAGS="$FLAGS --nat=none --no-downloader"
 echo "Running erigon with flags $FLAGS"
 $erigon $FLAGS


### PR DESCRIPTION
This (plus https://github.com/erigontech/erigon/pull/17005) should help with Hive tests [stalling](https://hive.ethpandaops.io/#/logs/fusaka-devnet-5/1756909285-d08347bf9c588e2468e0a2ba0b7f6095/erigon_default%2Fclient-95ef2ede0647544c78467104edb84cd67ad67638ef1cd5d175a2e4cab53fd6e6.log) on "Loading remote snapshot hashes".