### PR TITLE
simulators/ethereum/rpc-compat: ignore error.message and error.data

### DIFF
--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -104,12 +104,14 @@ func runTest(t *hivesim.T, c *hivesim.Client, test *rpcTest) error {
 				return fmt.Errorf("invalid JSON response")
 			}
 
-			// Patch JSON to remove error messages. We only do this in the specific case
+			// Patch JSON to remove error messages and data. We only do this in the specific case
 			// where an error is expected AND returned by the client.
 			var errorRedacted bool
 			if gjson.Get(resp, "error").Exists() && gjson.Get(expectedData, "error").Exists() {
 				resp, _ = sjson.Delete(resp, "error.message")
 				expectedData, _ = sjson.Delete(expectedData, "error.message")
+				resp, _ = sjson.Delete(resp, "error.data")
+				expectedData, _ = sjson.Delete(expectedData, "error.data")
 				errorRedacted = true
 			}
 


### PR DESCRIPTION
In https://hive.ethpandaops.io/#/test/generic/1757905445-5dbeb2cee294848d1644ba209e476bef?testnumber=7

<img width="1063" height="342" alt="image" src="https://github.com/user-attachments/assets/f81f571e-d2e1-4895-b9f8-589b28073308" />


the expected response:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32602,
        "message": "invalid argument 0: hex string without 0x prefix"
    }
}
```

Actually response:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32602,
        "message": "Invalid params",
        "data": "hex string without 0x prefix at line 1 column 3"
    }
}
```


I found some reth tests failed of the `error.data` not matched, from https://www.jsonrpc.org/specification#error_object, I found the error jsonrpc response will return `error.message | error.data`, So I think we can just ignore the `error.data` along with `error.message`, as the client maybe has it's own logic to handle error cases. 

Let's focus on the `error.code`