### PR TITLE
clients/ethrex: change default docker tag

### DIFF
--- a/clients/ethrex/Dockerfile
+++ b/clients/ethrex/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=ghcr.io/lambdaclass/ethrex
-ARG tag=unstable
+ARG tag=main
 
 FROM $baseimage:$tag AS builder
 


### PR DESCRIPTION
We renamed our `unstable` tag to `main`