### PR TITLE
clients/go-ethereum: update git dockerfile to golang 1.24

### DIFF
--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -1,6 +1,6 @@
 ## Pulls geth from a git repository and builds it from source.
 
-FROM golang:1.23-alpine as builder
+FROM golang:1.24-alpine as builder
 ARG github=ethereum/go-ethereum
 ARG tag=master
 ARG GOPROXY


### PR DESCRIPTION
## Description

Updates the go-ethereum `Dockerfile.git` to use the golang image with 1.24.

Without this the bulid fails.