### PR TITLE
simulators/eels: fix `execute-blobs` simulator

### DIFF
--- a/simulators/ethereum/eels/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eels/execute-blobs/Dockerfile
@@ -7,7 +7,7 @@ ARG fork=Osaka
 ENV FORK=${fork}
 
 ## Clone and install EELS
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git cmake g++ libclang-dev
 
 # Clone repo and use the default branch if none specified
 RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
@@ -17,8 +17,8 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
         git checkout FETCH_HEAD; \
     fi
 
-WORKDIR /execution-specs/packages/testing
-RUN uv sync
+WORKDIR /execution-specs/
+RUN uv sync --all-extras
 
 ## Define `consume engine` entry point using the local fixtures
 ENTRYPOINT uv run execute hive --fork=$FORK -v -m blob_transaction_test

--- a/simulators/ethereum/eels/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eels/execute-blobs/Dockerfile
@@ -1,4 +1,4 @@
-# Builds and runs the EELS (execution-specs) consume engine simulator
+# Builds and runs the EELS (execution-specs) execute-blobs simulator
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default git-ref/fork
@@ -20,5 +20,7 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
 WORKDIR /execution-specs/
 RUN uv sync --all-extras
 
-## Define `consume engine` entry point using the local fixtures
-ENTRYPOINT uv run execute hive --fork=$FORK -v -m blob_transaction_test
+## Define `execute hive` entry point for the blob transaction tests
+# --no-sync skips re-syncing the environment on container start; the image
+# build already ran `uv sync --all-extras`.
+ENTRYPOINT exec uv run --no-sync execute hive --fork=$FORK -v -m blob_transaction_test

--- a/simulators/ethereum/eels/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eels/execute-blobs/Dockerfile
@@ -7,7 +7,7 @@ ARG fork=Osaka
 ENV FORK=${fork}
 
 ## Clone and install EELS
-RUN apt-get update && apt-get install -y git cmake g++ libclang-dev
+RUN apt-get update && apt-get install -y git
 
 # Clone repo and use the default branch if none specified
 RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
@@ -18,9 +18,9 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/
-RUN uv sync --all-extras
+RUN uv sync
 
 ## Define `execute hive` entry point for the blob transaction tests
 # --no-sync skips re-syncing the environment on container start; the image
-# build already ran `uv sync --all-extras`.
+# build already ran `uv sync`.
 ENTRYPOINT exec uv run --no-sync execute hive --fork=$FORK -v -m blob_transaction_test


### PR DESCRIPTION
## Description

The EEST execute command must be ran at the root of the EELS project following the Weld as that is where the `./tests` are. This PR contains fixes for the latter.

Note `cmake g++ libclang-dev` are required to run `uv sync --all-extras`, note we are running this for the entire EELS repo now for execute and not just the EEST package.

Additionally the entrypoint now uses `exec uv run --no-sync`, matching #1577: the environment is synced once at image build, so container start skips the re-sync (a plain `uv run` would also re-sync without `--all-extras`, stripping packages installed at build).

This simulator runs the `blob_transaction_test` execute tests (`engine_getBlobsV*`), including the EIP-8070 `getBlobsV4` tests from ethereum/execution-specs#2948 when built with `fork=Amsterdam`.
