### PR TITLE
clients/besu: update name of snap sync flag

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -147,7 +147,7 @@ esac
 FLAGS="$FLAGS --sync-mode=$syncmode"
 
 # Enable Snap Server.
-FLAGS="$FLAGS --Xsnapsync-server-enabled"
+FLAGS="$FLAGS --snapsync-server-enabled"
 
 # Configure RPC.
 RPCFLAGS="--host-allowlist=*"


### PR DESCRIPTION
replace use of deprecated CLI option name with the new one
`--Xsnapsync-server-enabled` removed in besu https://github.com/hyperledger/besu/pull/9385
