### PR TITLE
internal/libdocker: fix empty container IP on Docker Desktop for macOS

### DIFF
--- a/internal/libdocker/container.go
+++ b/internal/libdocker/container.go
@@ -174,6 +174,29 @@ func (b *ContainerBackend) StartContainer(ctx context.Context, containerID strin
 	}
 	info.IP = container.NetworkSettings.IPAddress
 	info.MAC = container.NetworkSettings.MacAddress
+	// On some Docker setups (e.g. Docker Desktop for macOS), the top-level
+	// NetworkSettings.IPAddress field may be empty even though the container
+	// has an IP on the bridge network. Fall back to checking the per-network
+	// endpoint settings.
+	if info.IP == "" {
+		for name, network := range container.NetworkSettings.Networks {
+			if network.IPAddress != "" {
+				logger.Debug("using IP from network endpoint (top-level IPAddress was empty)", "network", name, "ip", network.IPAddress)
+				info.IP = network.IPAddress
+				if info.MAC == "" {
+					info.MAC = network.MacAddress
+				}
+				break
+			}
+		}
+	}
+	if info.IP == "" {
+		waiter.Close()
+		b.DeleteContainer(containerID)
+		info.Wait()
+		info.Wait = nil
+		return info, fmt.Errorf("container has no IP address (check Docker network settings)")
+	}
 
 	// Set up the port check if requested.
 	hasStarted := make(chan struct{})


### PR DESCRIPTION
## Summary

- On newer macOS Docker Desktop versions, `NetworkSettings.IPAddress` from Docker's inspect API returns empty for containers on the default bridge network. This causes hiveproxy to report `addr=:8081` (no IP), resulting in `HIVE_SIMULATOR=http://:8081` which the simulator cannot reach (`connection refused`).
- Falls back to iterating `NetworkSettings.Networks` endpoint map when the top-level IP is empty — the canonical Docker API source for per-network IPs.
- Fails fast with a clear error if no IP is found from either source, instead of silently propagating an empty IP.

## Test plan

- [ ] Run hive on macOS Docker Desktop and verify the simulator connects successfully
- [ ] Run hive on Linux Docker to confirm no behavioral change (fallback is gated on empty IP)