### PR TITLE
internal/libdocker: handle build of hiveproxy docker image if it already exists

### DIFF
--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -86,6 +86,13 @@ func (b *Builder) BuildImage(ctx context.Context, name string, fsys fs.FS) error
 	return nil
 }
 
+// imageAlreadyExists reports whether a build failed only because a concurrent
+// hive process already produced the identical image, a benign cross-process
+// race when multiple simulations share one Docker daemon.
+func imageAlreadyExists(err error) bool {
+	return strings.Contains(err.Error(), "AlreadyExists")
+}
+
 func (b *Builder) buildConfig(ctx context.Context, name string) docker.BuildImageOptions {
 	nocache := false
 	if b.config.NoCachePattern != nil {

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -80,7 +80,11 @@ func (b *Builder) BuildImage(ctx context.Context, name string, fsys fs.FS) error
 
 	b.logger.Info("building image", "image", name, "nocache", opts.NoCache, "pull", b.config.PullEnabled)
 	if err := b.client.BuildImage(opts); err != nil {
-		b.logger.Error("image build failed", "image", name, "err", err)
+		if imageAlreadyExists(err) {
+			b.logger.Info("image already exists", "image", name)
+		} else {
+			b.logger.Error("image build failed", "image", name, "err", err)
+		}
 		return err
 	}
 	return nil

--- a/internal/libdocker/builder.go
+++ b/internal/libdocker/builder.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -94,7 +95,8 @@ func (b *Builder) BuildImage(ctx context.Context, name string, fsys fs.FS) error
 // hive process already produced the identical image, a benign cross-process
 // race when multiple simulations share one Docker daemon.
 func imageAlreadyExists(err error) bool {
-	return strings.Contains(err.Error(), "AlreadyExists")
+	ok, _ := regexp.MatchString("\\bAlreadyExists: ", err.Error())
+	return ok
 }
 
 func (b *Builder) buildConfig(ctx context.Context, name string) docker.BuildImageOptions {

--- a/internal/libdocker/proxy.go
+++ b/internal/libdocker/proxy.go
@@ -16,7 +16,11 @@ const hiveproxyTag = "hive/hiveproxy"
 
 // Build builds the hiveproxy image.
 func (cb *ContainerBackend) Build(ctx context.Context, b libhive.Builder) error {
-	return b.BuildImage(ctx, hiveproxyTag, hiveproxy.Source)
+	err := b.BuildImage(ctx, hiveproxyTag, hiveproxy.Source)
+	if err != nil && !imageAlreadyExists(err) {
+		return err
+	}
+	return nil
 }
 
 // ServeAPI starts the API server.


### PR DESCRIPTION
Else we see race conditions like this when running parallel simulations
```

[2026-04-08T06:54:05.058Z] Apr  8 06:54:04.610 ERR image build failed
image=hive/hiveproxy err="failed to create an image
docker.io/hive/hiveproxy:latest with target
sha256:d7c16d655368a6901ca972aa6ef30e2cfd77458cdf54b9d861e89a354980011d
after deleting the existing one: AlreadyExists: image
\"docker.io/hive/hiveproxy:latest\": already exists"

[2026-04-08T06:54:05.058Z] failed to create an image
docker.io/hive/hiveproxy:latest with target
sha256:d7c16d655368a6901ca972aa6ef30e2cfd77458cdf54b9d861e89a354980011d
after deleting the existing one: AlreadyExists: image
"docker.io/hive/hiveproxy:latest": already exists
```