### PR TITLE
.circleci: bump ci rust version

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -78,7 +78,7 @@ jobs:
   # this makes sure the rust code is good
   hivesim-rs:
     docker:
-      - image: cimg/rust:1.85
+      - image: cimg/rust:1.92
     steps:
       - checkout
       - run:
@@ -101,7 +101,7 @@ jobs:
           command: "cd hivesim-rs && cargo test --workspace -- --nocapture"    
   rust-simulators:
     docker:
-      - image: cimg/rust:1.85
+      - image: cimg/rust:1.92
     steps:
       - checkout
       - run:


### PR DESCRIPTION
We need to bump the version to compile latest crate versions