### PR TITLE
clients, simulators: Leanspec helper stability and cleanup

### DIFF
--- a/clients/ethlambda/Dockerfile
+++ b/clients/ethlambda/Dockerfile
@@ -1,8 +1,7 @@
-FROM ghcr.io/lambdaclass/ethlambda:devnet3 AS devnet3
 FROM ghcr.io/lambdaclass/ethlambda:devnet4 AS devnet4
 FROM ghcr.io/lambdaclass/ethlambda:devnet3
 
-COPY --from=devnet3 /usr/local/bin/ethlambda /usr/local/bin/ethlambda-devnet3
+RUN cp /usr/local/bin/ethlambda /usr/local/bin/ethlambda-devnet3
 COPY --from=devnet4 /usr/local/bin/ethlambda /usr/local/bin/ethlambda-devnet4
 ADD ethlambda.sh /ethlambda.sh
 

--- a/clients/ream/Dockerfile
+++ b/clients/ream/Dockerfile
@@ -3,12 +3,11 @@ ARG devnet3_tag=latest-devnet3
 ARG devnet4_baseimage=ghcr.io/reamlabs/ream
 ARG devnet4_tag=latest-devnet4
 
-FROM $devnet3_baseimage:$devnet3_tag AS devnet3
 FROM $devnet4_baseimage:$devnet4_tag AS devnet4
 FROM $devnet3_baseimage:$devnet3_tag
 
 COPY validators.yaml /assets/lean/validators.yaml
-COPY --from=devnet3 /usr/local/bin/ream /usr/local/bin/ream-devnet3
+RUN cp /usr/local/bin/ream /usr/local/bin/ream-devnet3
 COPY --from=devnet4 /usr/local/bin/ream /usr/local/bin/ream-devnet4
 ADD ream.sh /ream.sh
 

--- a/hive.go
+++ b/hive.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/ethereum/hive/internal/libdocker"
 	"github.com/ethereum/hive/internal/libhive"
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/lmittmann/tint"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 type buildArgs map[string]string

--- a/hive.go
+++ b/hive.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/ethereum/hive/internal/libdocker"
 	"github.com/ethereum/hive/internal/libhive"
-	"github.com/lmittmann/tint"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/lmittmann/tint"
 )
 
 type buildArgs map[string]string

--- a/simulators/lean/src/main.rs
+++ b/simulators/lean/src/main.rs
@@ -2,9 +2,10 @@
 
 mod scenarios;
 
-use std::{collections::HashMap, env, fs, time::Duration};
+use std::{collections::HashMap, env, fmt, fs, time::Duration};
 
 use crate::scenarios::rpc_compat::run_rpc_compat_lean_test_suite;
+use alloy_primitives::B256;
 use hivesim::types::ClientDefinition;
 use hivesim::{run_suite, Client, Simulation, Suite, TestSpec};
 use reqwest::Client as HttpClient;
@@ -27,14 +28,26 @@ pub(crate) enum LeanDevnet {
 }
 
 impl LeanDevnet {
-    fn label(self) -> &'static str {
+    const DEFAULT: Self = Self::Devnet3;
+
+    fn as_str(self) -> &'static str {
         match self {
             Self::Devnet3 => "devnet3",
             Self::Devnet4 => "devnet4",
         }
     }
+}
 
-    fn parse(label: &str) -> Result<Self, String> {
+impl fmt::Display for LeanDevnet {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for LeanDevnet {
+    type Error = String;
+
+    fn try_from(label: &str) -> Result<Self, Self::Error> {
         match label.trim() {
             "devnet3" => Ok(Self::Devnet3),
             "devnet4" => Ok(Self::Devnet4),
@@ -57,7 +70,7 @@ struct HealthResponse {
 #[derive(Debug, Deserialize)]
 struct CheckpointResponse {
     slot: u64,
-    root: String,
+    root: B256,
 }
 
 #[tokio::main]
@@ -65,14 +78,13 @@ async fn main() {
     tracing_subscriber::fmt::init();
     let simulation = Simulation::new();
     let devnet = resolve_selected_lean_devnet(&simulation).await;
-    env::set_var(HIVE_LEAN_DEVNET_LABEL, devnet.label());
-    let devnet_label = devnet.label();
+    env::set_var(HIVE_LEAN_DEVNET_LABEL, devnet.as_str());
 
     let mut rpc_compat = Suite {
         name: "rpc-compat".to_string(),
         description: format!(
             "Runs Lean RPC compatibility tests against the selected lean clients using the {} profile.",
-            devnet_label
+            devnet
         ),
         tests: vec![],
     };
@@ -96,17 +108,13 @@ fn lean_clients(clients: Vec<ClientDefinition>) -> Vec<ClientDefinition> {
 }
 
 pub(crate) fn selected_lean_devnet() -> LeanDevnet {
-    let label = env::var(HIVE_LEAN_DEVNET_LABEL)
-        .unwrap_or_else(|_| LeanDevnet::Devnet3.label().to_string());
-    LeanDevnet::parse(&label).unwrap_or_else(|err| {
+    let label =
+        env::var(HIVE_LEAN_DEVNET_LABEL).unwrap_or_else(|_| LeanDevnet::DEFAULT.to_string());
+    LeanDevnet::try_from(label.as_str()).unwrap_or_else(|err| {
         panic!(
             "Unsupported Lean devnet selection in environment variable {HIVE_LEAN_DEVNET_LABEL}: {err}"
         )
     })
-}
-
-pub(crate) fn selected_lean_devnet_label() -> &'static str {
-    selected_lean_devnet().label()
 }
 
 fn load_lean_devnet_config() -> LeanDevnetConfig {
@@ -138,7 +146,7 @@ fn load_lean_devnet_config() -> LeanDevnetConfig {
         let value = value.trim();
 
         if key == "default" {
-            default_devnet = Some(LeanDevnet::parse(value).unwrap_or_else(|err| {
+            default_devnet = Some(LeanDevnet::try_from(value).unwrap_or_else(|err| {
                 panic!(
                     "Invalid default lean devnet in {} line {}: {}",
                     LEAN_DEVNET_CONFIG_PATH, line_number, err
@@ -150,7 +158,7 @@ fn load_lean_devnet_config() -> LeanDevnetConfig {
         let supported_devnets = value
             .split(',')
             .map(|label| {
-                LeanDevnet::parse(label).unwrap_or_else(|err| {
+                LeanDevnet::try_from(label).unwrap_or_else(|err| {
                     panic!(
                         "Invalid lean devnet in {} line {} for client {}: {}",
                         LEAN_DEVNET_CONFIG_PATH, line_number, key, err
@@ -184,7 +192,7 @@ fn split_client_devnet_name(client_name: &str) -> (&str, Option<LeanDevnet>) {
     let Some((base_name, suffix)) = client_name.rsplit_once('_') else {
         return (client_name, None);
     };
-    match LeanDevnet::parse(suffix) {
+    match LeanDevnet::try_from(suffix) {
         Ok(devnet) => (base_name, Some(devnet)),
         Err(_) => (client_name, None),
     }
@@ -213,19 +221,16 @@ async fn resolve_selected_lean_devnet(simulation: &Simulation) -> LeanDevnet {
         if !supported_devnets.contains(&devnet) {
             let supported = supported_devnets
                 .iter()
-                .map(|candidate| candidate.label())
+                .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(", ");
             panic!(
                 "Lean client {} does not support {} according to {} (supported: {})",
-                client.name,
-                devnet.label(),
-                LEAN_DEVNET_CONFIG_PATH,
-                supported,
+                client.name, devnet, LEAN_DEVNET_CONFIG_PATH, supported,
             );
         }
 
-        selected_labels.push(format!("{}={}", client.name, devnet.label()));
+        selected_labels.push(format!("{}={devnet}", client.name));
         match resolved_devnet {
             Some(previous) if previous != devnet => {
                 panic!(
@@ -244,10 +249,10 @@ async fn resolve_selected_lean_devnet(simulation: &Simulation) -> LeanDevnet {
 }
 
 fn lean_environment() -> HashMap<String, String> {
-    let devnet_label = selected_lean_devnet_label();
+    let devnet_label = selected_lean_devnet().to_string();
     HashMap::from([
         (HIVE_CHECK_LIVE_PORT.to_string(), LEAN_HTTP_PORT.to_string()),
-        (HIVE_LEAN_DEVNET_LABEL.to_string(), devnet_label.to_string()),
+        (HIVE_LEAN_DEVNET_LABEL.to_string(), devnet_label),
     ])
 }
 

--- a/simulators/lean/src/scenarios/rpc_compat.rs
+++ b/simulators/lean/src/scenarios/rpc_compat.rs
@@ -5,11 +5,10 @@ use crate::scenarios::sync::{
     PostGenesisSyncContext, PostGenesisSyncTestData, SourceCheckpointKind,
 };
 use crate::{
-    get_json_with_retry, lean_api_url, lean_clients, lean_environment, selected_lean_devnet_label,
-    CheckpointResponse, HealthResponse, HEALTHY_STATUS, LEAN_RPC_SERVICE,
+    get_json_with_retry, lean_api_url, lean_clients, lean_environment, selected_lean_devnet,
+    CheckpointResponse, HealthResponse, LeanDevnet, HEALTHY_STATUS, LEAN_RPC_SERVICE,
 };
 use alloy_primitives::{FixedBytes, B256};
-use hex::FromHex;
 use hivesim::{dyn_async, types::TestResult, Client, NClientTestSpec, Test};
 use reqwest::{
     header::{ACCEPT, CONTENT_TYPE},
@@ -27,8 +26,6 @@ use tokio::time::sleep;
 const FORK_CHOICE_TIMEOUT_SECS: u64 = 600;
 const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
 
-type RootBytes = B256;
-
 #[derive(Debug, Clone, PartialEq, Eq, Decode)]
 struct LeanPublicKey {
     inner: FixedBytes<52>,
@@ -43,14 +40,14 @@ struct LeanConfig {
 struct LeanBlockHeader {
     slot: u64,
     proposer_index: u64,
-    parent_root: RootBytes,
-    state_root: RootBytes,
-    body_root: RootBytes,
+    parent_root: B256,
+    state_root: B256,
+    body_root: B256,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Decode)]
 struct LeanCheckpoint {
-    root: RootBytes,
+    root: B256,
     slot: u64,
 }
 
@@ -81,10 +78,10 @@ struct LeanStateDevnet3 {
     latest_block_header: LeanBlockHeader,
     latest_justified: LeanCheckpoint,
     latest_finalized: LeanCheckpoint,
-    historical_block_hashes: VariableList<RootBytes, U262144>,
+    historical_block_hashes: VariableList<B256, U262144>,
     justified_slots: BitList<U262144>,
     validators: VariableList<LeanValidatorDevnet3, U4096>,
-    justifications_roots: VariableList<RootBytes, U262144>,
+    justifications_roots: VariableList<B256, U262144>,
     justifications_validators: BitList<U1073741824>,
 }
 
@@ -95,10 +92,10 @@ struct LeanStateDevnet4 {
     latest_block_header: LeanBlockHeader,
     latest_justified: LeanCheckpoint,
     latest_finalized: LeanCheckpoint,
-    historical_block_hashes: VariableList<RootBytes, U262144>,
+    historical_block_hashes: VariableList<B256, U262144>,
     justified_slots: BitList<U262144>,
     validators: VariableList<LeanValidatorDevnet4, U4096>,
-    justifications_roots: VariableList<RootBytes, U262144>,
+    justifications_roots: VariableList<B256, U262144>,
     justifications_validators: BitList<U1073741824>,
 }
 
@@ -109,10 +106,10 @@ struct LeanState {
     latest_block_header: LeanBlockHeader,
     latest_justified: LeanCheckpoint,
     latest_finalized: LeanCheckpoint,
-    historical_block_hashes: VariableList<RootBytes, U262144>,
+    historical_block_hashes: VariableList<B256, U262144>,
     justified_slots: BitList<U262144>,
     validators: Vec<LeanValidator>,
-    justifications_roots: VariableList<RootBytes, U262144>,
+    justifications_roots: VariableList<B256, U262144>,
     justifications_validators: BitList<U1073741824>,
 }
 
@@ -279,34 +276,17 @@ async fn run_data_test<T: Send + 'static>(
     host_test.sim.end_test(suite_id, test_id, test_result).await;
 }
 
-fn assert_hex_root(root: &str, field_name: &str) {
+fn assert_hex_root(root: &B256, field_name: &str) {
+    let encoded = format!("{:#x}", root);
     assert!(
-        root.starts_with("0x"),
-        "{field_name} should be 0x-prefixed, got {root}"
+        encoded.starts_with("0x"),
+        "{field_name} should be 0x-prefixed, got {encoded}"
     );
     assert_eq!(
-        root.len(),
+        encoded.len(),
         66,
         "{field_name} should be 32 bytes of hex plus 0x prefix"
     );
-}
-
-fn assert_hex_root_b256(root: &B256, field_name: &str) {
-    let encoded = format!("{:#x}", root);
-    assert_hex_root(&encoded, field_name);
-}
-
-fn parse_b256_hex(value: &str, field_name: &str) -> B256 {
-    let trimmed = value.strip_prefix("0x").unwrap_or(value);
-    let bytes = Vec::<u8>::from_hex(trimmed)
-        .unwrap_or_else(|err| panic!("Unable to decode {field_name} as hex: {err}"));
-    assert_eq!(
-        bytes.len(),
-        32,
-        "{field_name} should be 32 bytes, got {} bytes",
-        bytes.len()
-    );
-    B256::from_slice(&bytes)
 }
 
 async fn load_fork_choice_response(client: &Client) -> ForkChoiceResponse {
@@ -462,7 +442,7 @@ async fn load_finalized_state_bytes(client: &Client) -> Vec<u8> {
 }
 
 fn decode_finalized_state(ssz_bytes: &[u8]) -> LeanState {
-    if selected_lean_devnet_label() == "devnet4" {
+    if selected_lean_devnet() == LeanDevnet::Devnet4 {
         LeanStateDevnet4::from_ssz_bytes(ssz_bytes)
             .map(Into::into)
             .unwrap_or_else(|err| panic!("Unable to decode SSZ finalized state: {err:?}"))
@@ -497,7 +477,7 @@ async fn load_post_genesis_state_setup(
 ) -> (PostGenesisSyncContext, LeanState, ForkChoiceResponse) {
     let context = load_post_genesis_sync_context(test, test_data).await;
     let state = load_finalized_state(&context.client_under_test).await;
-    let fork_choice = if selected_lean_devnet_label() == "devnet4" {
+    let fork_choice = if selected_lean_devnet() == LeanDevnet::Devnet4 {
         load_fork_choice_response(&context.client_under_test).await
     } else {
         wait_for_non_genesis_fork_choice_response(
@@ -1025,10 +1005,7 @@ dyn_async! {
             client_checkpoint.slot > 0,
             "client under test should report a non-genesis justified checkpoint after the helper mesh reaches justification"
         );
-        assert_hex_root(
-            &client_checkpoint.root,
-            "client justified checkpoint root",
-        );
+        assert_hex_root(&client_checkpoint.root, "client justified checkpoint root");
 
         if client_checkpoint.slot == context.source_fork_choice.justified.slot {
             assert_eq!(
@@ -1068,7 +1045,7 @@ dyn_async! {
             "without a non-genesis justification event, the justified slot should remain at genesis"
         );
         assert_eq!(
-            parse_b256_hex(&fork_choice.justified.root, "justified root"),
+            fork_choice.justified.root,
             fork_choice.head,
             "without a non-genesis justification event, the justified root should remain at the genesis head"
         );
@@ -1084,7 +1061,7 @@ dyn_async! {
             "without a non-genesis finalization event, the finalized slot should remain at genesis"
         );
         assert_eq!(
-            parse_b256_hex(&fork_choice.finalized.root, "finalized root"),
+            fork_choice.finalized.root,
             fork_choice.head,
             "without a non-genesis finalization event, the finalized root should remain at the genesis head"
         );
@@ -1118,7 +1095,7 @@ dyn_async! {
             load_post_genesis_fork_choice_setup(test, test_data, SourceCheckpointKind::Finalized)
                 .await;
         let reference_finalized_slot = context.source_fork_choice.finalized.slot;
-        assert_hex_root_b256(&fork_choice.head, "forkchoice head");
+        assert_hex_root(&fork_choice.head, "forkchoice head");
         assert_hex_root(&fork_choice.finalized.root, "forkchoice finalized root");
         assert!(
             !fork_choice.nodes.is_empty(),
@@ -1144,7 +1121,7 @@ dyn_async! {
             load_post_genesis_fork_choice_setup(test, test_data, SourceCheckpointKind::Finalized)
                 .await;
         let reference_finalized_slot = context.source_fork_choice.finalized.slot;
-        assert_hex_root_b256(&fork_choice.head, "forkchoice head");
+        assert_hex_root(&fork_choice.head, "forkchoice head");
         assert_hex_root(&fork_choice.finalized.root, "forkchoice finalized root");
         assert!(
             !fork_choice.nodes.is_empty(),
@@ -1168,7 +1145,7 @@ dyn_async! {
                 .any(|node| node.slot >= reference_finalized_slot),
             "forkchoice should keep at least one node at or beyond the finalized boundary"
         );
-        assert_hex_root_b256(&fork_choice.safe_target, "forkchoice safe_target");
+        assert_hex_root(&fork_choice.safe_target, "forkchoice safe_target");
     }
 }
 
@@ -1204,14 +1181,14 @@ dyn_async! {
 dyn_async! {
     async fn test_forkchoice_hex_encodes_roots<'a>(clients: Vec<Client>, _: ()) {
         let (_client, fork_choice) = load_fresh_fork_choice_setup(clients).await;
-        assert_hex_root_b256(&fork_choice.head, "forkchoice head");
+        assert_hex_root(&fork_choice.head, "forkchoice head");
         assert_hex_root(&fork_choice.justified.root, "forkchoice justified root");
         assert_hex_root(&fork_choice.finalized.root, "forkchoice finalized root");
-        assert_hex_root_b256(&fork_choice.safe_target, "forkchoice safe_target");
+        assert_hex_root(&fork_choice.safe_target, "forkchoice safe_target");
 
         for node in &fork_choice.nodes {
-            assert_hex_root_b256(&node.root, "forkchoice node root");
-            assert_hex_root_b256(&node.parent_root, "forkchoice node parent_root");
+            assert_hex_root(&node.root, "forkchoice node root");
+            assert_hex_root(&node.parent_root, "forkchoice node parent_root");
         }
     }
 }
@@ -1222,7 +1199,7 @@ dyn_async! {
             load_post_genesis_fork_choice_setup(test, test_data, SourceCheckpointKind::Finalized)
                 .await;
         let reference_finalized_slot = context.source_fork_choice.finalized.slot;
-        assert_hex_root_b256(&fork_choice.head, "forkchoice head");
+        assert_hex_root(&fork_choice.head, "forkchoice head");
         assert!(
             reference_finalized_slot > 0,
             "helper-backed forkchoice setup should sync from a non-genesis finalized boundary"
@@ -1247,7 +1224,7 @@ dyn_async! {
                 || !fork_choice.nodes.is_empty(),
             "checkpoint-synced forkchoice should expose either post-genesis justification or a compact post-finalized node set"
         );
-        assert_hex_root_b256(&fork_choice.safe_target, "forkchoice safe_target");
+        assert_hex_root(&fork_choice.safe_target, "forkchoice safe_target");
     }
 }
 
@@ -1261,8 +1238,8 @@ dyn_async! {
         );
 
         let node = &fork_choice.nodes[0];
-        assert_hex_root_b256(&node.root, "forkchoice node root");
-        assert_hex_root_b256(&node.parent_root, "forkchoice node parent_root");
+        assert_hex_root(&node.root, "forkchoice node root");
+        assert_hex_root(&node.parent_root, "forkchoice node parent_root");
         assert_eq!(node.slot, 0, "fresh forkchoice node slot should decode to genesis");
         assert_eq!(
             node.proposer_index, 0,
@@ -1285,12 +1262,12 @@ dyn_async! {
         );
 
         let node = &fork_choice.nodes[0];
-        assert_hex_root_b256(&node.root, "forkchoice node root");
-        assert_hex_root_b256(&node.parent_root, "forkchoice node parent_root");
-        assert_hex_root_b256(&fork_choice.head, "forkchoice head");
+        assert_hex_root(&node.root, "forkchoice node root");
+        assert_hex_root(&node.parent_root, "forkchoice node parent_root");
+        assert_hex_root(&fork_choice.head, "forkchoice head");
         assert_hex_root(&fork_choice.justified.root, "forkchoice justified root");
         assert_hex_root(&fork_choice.finalized.root, "forkchoice finalized root");
-        assert_hex_root_b256(&fork_choice.safe_target, "forkchoice safe_target");
+        assert_hex_root(&fork_choice.safe_target, "forkchoice safe_target");
         assert_eq!(node.slot, 0, "fresh forkchoice node should be genesis");
         assert_eq!(
             node.parent_root,
@@ -1314,7 +1291,7 @@ dyn_async! {
             "fresh forkchoice justified checkpoint should stay at genesis"
         );
         assert_eq!(
-            parse_b256_hex(&fork_choice.justified.root, "justified root"),
+            fork_choice.justified.root,
             fork_choice.head,
             "fresh forkchoice justified root should match the genesis head"
         );
@@ -1323,7 +1300,7 @@ dyn_async! {
             "fresh forkchoice finalized checkpoint should stay at genesis"
         );
         assert_eq!(
-            parse_b256_hex(&fork_choice.finalized.root, "finalized root"),
+            fork_choice.finalized.root,
             fork_choice.head,
             "fresh forkchoice finalized root should match the genesis head"
         );

--- a/simulators/lean/src/scenarios/sync.rs
+++ b/simulators/lean/src/scenarios/sync.rs
@@ -30,8 +30,10 @@ const LEAN_GENESIS_DELAY_SECS: u64 = 30;
 const POST_GENESIS_TIMEOUT_SECS: u64 = 600;
 const MIN_FINALIZED_SLOT_FOR_CHECKPOINT_SYNC: u64 = 10;
 const LOCAL_HELPER_STARTUP_TIMEOUT_SECS: u64 = 120;
-const LOCAL_HELPER_STARTUP_ATTEMPTS: u64 = 12;
+const LOCAL_HELPER_METADATA_TIMEOUT_SECS: u64 = 60;
+const LOCAL_HELPER_STARTUP_ATTEMPTS: u64 = 3;
 const CLIENT_UNDER_TEST_STARTUP_ATTEMPTS: u64 = 3;
+const CHECKPOINT_SYNC_CLIENT_READY_TIMEOUT_SECS: u64 = 30;
 const HELPER_METADATA_PORT: u16 = 5053;
 const LOCAL_HELPER_API_PORT: u16 = 5052;
 const LOCAL_HELPER_ENTRYPOINT: &str = "/app/hive/leanspec-client.sh";
@@ -144,6 +146,19 @@ pub(crate) struct ForkChoiceSnapshot {
     pub finalized: CheckpointResponse,
 }
 
+#[derive(Debug, Deserialize)]
+struct ForkChoiceNodeSlot {
+    slot: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct CheckpointSyncForkChoiceSnapshot {
+    justified: CheckpointResponse,
+    finalized: CheckpointResponse,
+    #[serde(default)]
+    nodes: Vec<ForkChoiceNodeSlot>,
+}
+
 pub(crate) fn default_genesis_time() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -197,16 +212,17 @@ pub(crate) async fn start_post_genesis_sync_context(
         None
     };
 
-    let mut source_fork_choice = match wait_for_checkpoint_slot(
+    let mut source_fork_choice = match wait_for_checkpoint_slot_with_retry(
         &mut helper,
         test_data.source_checkpoint_kind,
         minimum_source_checkpoint_slot(test_data),
+        test_data.genesis_time,
     )
     .await
     {
         Ok(source_fork_choice) => source_fork_choice,
         Err(err) => {
-            if client_under_test.is_none() {
+            if client_under_test.is_none() && !helper_startup_error_is_retryable(&err) {
                 let files = prepare_client_runtime_files(
                     &test_data.client_under_test.name,
                     &client_under_test_environment,
@@ -597,7 +613,24 @@ async fn start_checkpoint_sync_client_under_test_with_retry(
         })
         .await
         {
-            Ok(client) => return client,
+            Ok(client) => match wait_for_checkpoint_sync_client_post_genesis(&client).await {
+                Ok(()) => return client,
+                Err(error) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
+                    eprintln!(
+                        "Retrying checkpoint-sync client-under-test startup for {} after attempt {} never reached a post-genesis forkchoice state: {}",
+                        params.client_type, attempt, error
+                    );
+                    last_error = Some(error);
+                    drop(client);
+                    sleep(Duration::from_secs(1)).await;
+                }
+                Err(error) => {
+                    panic!(
+                        "Unable to start checkpoint-sync client under test {} after {} attempts: {}",
+                        params.client_type, CLIENT_UNDER_TEST_STARTUP_ATTEMPTS, error
+                    );
+                }
+            },
             Err(error) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
                 let message = if error.is_panic() {
                     panic_payload_to_string(error.into_panic())
@@ -670,8 +703,13 @@ async fn refresh_checkpoint_sync_source(
 ) -> Result<(), String> {
     let (mut restarted_helper, _source_genesis_validator_entries) =
         start_local_lean_spec_helper_with_genesis_metadata(genesis_time).await?;
-    let refreshed_source_fork_choice =
-        wait_for_checkpoint_slot(&mut restarted_helper, checkpoint_kind, minimum_slot).await?;
+    let refreshed_source_fork_choice = wait_for_checkpoint_slot_with_retry(
+        &mut restarted_helper,
+        checkpoint_kind,
+        minimum_slot,
+        genesis_time,
+    )
+    .await?;
     wait_for_checkpoint_sync_state_ready(&mut restarted_helper).await?;
 
     *helper = restarted_helper;
@@ -741,6 +779,45 @@ async fn wait_for_checkpoint_slot(
     ))
 }
 
+async fn wait_for_checkpoint_slot_with_retry(
+    helper: &mut RunningLocalLeanSpecHelper,
+    checkpoint_kind: SourceCheckpointKind,
+    minimum_slot: u64,
+    genesis_time: u64,
+) -> Result<ForkChoiceSnapshot, String> {
+    let checkpoint_name = match checkpoint_kind {
+        SourceCheckpointKind::Justified => "justified",
+        SourceCheckpointKind::Finalized => "finalized",
+    };
+    let mut last_error = None;
+
+    for attempt in 1..=LOCAL_HELPER_STARTUP_ATTEMPTS {
+        match wait_for_checkpoint_slot(helper, checkpoint_kind, minimum_slot).await {
+            Ok(fork_choice) => return Ok(fork_choice),
+            Err(error)
+                if attempt < LOCAL_HELPER_STARTUP_ATTEMPTS
+                    && helper_startup_error_is_retryable(&error) =>
+            {
+                eprintln!(
+                    "Restarting {LOCAL_HELPER_KIND} after {checkpoint_name} checkpoint wait failure on attempt {attempt}: {error}"
+                );
+                let (restarted_helper, _source_genesis_validator_entries) =
+                    start_local_lean_spec_helper_with_genesis_metadata(genesis_time).await?;
+                *helper = restarted_helper;
+                last_error = Some(error);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        format!(
+            "{LOCAL_HELPER_KIND} never reached {checkpoint_name} slot {} after {} attempts",
+            minimum_slot, LOCAL_HELPER_STARTUP_ATTEMPTS
+        )
+    }))
+}
+
 async fn wait_for_non_genesis_justified_checkpoint(
     client: &Client,
 ) -> Result<CheckpointResponse, String> {
@@ -787,6 +864,67 @@ async fn wait_for_non_genesis_justified_checkpoint(
         last_observed_slot
             .map(|slot| slot.to_string())
             .unwrap_or_else(|| "none".to_string()),
+        if last_error.is_empty() {
+            "none".to_string()
+        } else {
+            last_error
+        }
+    ))
+}
+
+async fn wait_for_checkpoint_sync_client_post_genesis(client: &Client) -> Result<(), String> {
+    let http = http_client();
+    let url = lean_api_url(client, "/lean/v0/fork_choice");
+    let mut last_error = String::new();
+    let mut last_observed_state = None;
+
+    for _attempt in 0..CHECKPOINT_SYNC_CLIENT_READY_TIMEOUT_SECS {
+        match http.get(&url).send().await {
+            Ok(response) => {
+                let status = response.status();
+                if !status.is_success() {
+                    last_error = format!("received HTTP {status} from {url}");
+                } else {
+                    match response.json::<CheckpointSyncForkChoiceSnapshot>().await {
+                        Ok(fork_choice) => {
+                            let max_node_slot = fork_choice
+                                .nodes
+                                .iter()
+                                .map(|node| node.slot)
+                                .max()
+                                .unwrap_or(0);
+                            last_observed_state = Some(format!(
+                                "justified_slot={}, finalized_slot={}, max_node_slot={}",
+                                fork_choice.justified.slot,
+                                fork_choice.finalized.slot,
+                                max_node_slot
+                            ));
+                            if fork_choice.justified.slot > 0
+                                || fork_choice.finalized.slot > 0
+                                || max_node_slot > 0
+                            {
+                                return Ok(());
+                            }
+                        }
+                        Err(err) => {
+                            last_error =
+                                format!("Unable to decode fork_choice response from {url}: {err}");
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                last_error = format!("error sending request for url ({url}): {err}");
+            }
+        }
+
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    Err(format!(
+        "Client under test {} never exposed a post-genesis checkpoint-sync forkchoice state (last observed state: {}, last error: {})",
+        client.kind,
+        last_observed_state.unwrap_or_else(|| "none".to_string()),
         if last_error.is_empty() {
             "none".to_string()
         } else {
@@ -855,7 +993,7 @@ async fn load_helper_genesis_metadata(
     let mut last_error = String::new();
     let mut last_observed_genesis_time = None;
 
-    for _attempt in 0..LOCAL_HELPER_STARTUP_TIMEOUT_SECS {
+    for _attempt in 0..LOCAL_HELPER_METADATA_TIMEOUT_SECS {
         helper.ensure_running()?;
         match http.get(&url).send().await {
             Ok(response) => {
@@ -907,6 +1045,9 @@ fn helper_startup_error_is_retryable(error: &str) -> bool {
     error.contains("exited before the test completed")
         || error.contains("SIGSEGV")
         || error.contains("signal: 11")
+        || error.contains("SIGABRT")
+        || error.contains("signal: 6")
+        || error.contains("exit status: 134")
 }
 
 async fn start_local_lean_spec_helper_with_genesis_metadata(
@@ -1082,5 +1223,12 @@ mod tests {
         server_thread
             .join()
             .expect("test metadata server should shut down cleanly");
+    }
+
+    #[test]
+    fn helper_startup_error_is_retryable_for_sigabrt() {
+        assert!(helper_startup_error_is_retryable(
+            "lean-spec-local-helper exited before the test completed with status signal: 6 (SIGABRT) (core dumped)"
+        ));
     }
 }


### PR DESCRIPTION
Added a fix to occasional non-deterministic test fails caused by the leanspec client instability. Additionally Cleaned up client dockerfiles and devnet enum. 