### PR TITLE
clients/erigon: fix discv5 NAT and bootnode handling

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -153,12 +153,14 @@ FLAGS="$FLAGS --externalcl"
 ip=$(ip addr show eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
 FLAGS="$FLAGS --nat=extip:$ip --no-downloader"
 
+# It doesn't make sense to dial out, use only a pre-set bootnode.
+FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
+
 if [ "$HIVE_BOOTNODE" = "" ]; then
-    # Isolate discovery from public peers during devp2p tests. An empty
-    # --bootnodes / --discovery.dns overrides the mainnet defaults erigon
-    # would otherwise fall back to. Without this, the routing table fills
-    # with real peers and drowns out the simulator's bystander nodes.
-    FLAGS="$FLAGS --bootnodes= --discovery.dns= --staticpeers="
+    # Erigon's default --chain is mainnet, so also clear DNS and static peer
+    # defaults that would otherwise fill the routing table with real peers
+    # during devp2p tests (drowning out the simulator's bystander nodes).
+    FLAGS="$FLAGS --discovery.dns= --staticpeers="
 fi
 echo "Running erigon with flags $FLAGS"
 $erigon $FLAGS

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -146,6 +146,19 @@ fi
 FLAGS="$FLAGS --externalcl"
 
 # Launch the main client.
-FLAGS="$FLAGS --nat=none --no-downloader"
+# Use the container's eth0 IP as the external address so the self-node advertised
+# in discv5 is routable from the simulator (which is on the same Docker network).
+# Without this, the p2p server falls back to 127.0.0.1, and the discv5 FINDNODE
+# handler drops the self-node via CheckRelayAddr (loopback from non-loopback).
+ip=$(ip addr show eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
+FLAGS="$FLAGS --nat=extip:$ip --no-downloader"
+
+if [ "$HIVE_BOOTNODE" = "" ]; then
+    # Isolate discovery from public peers during devp2p tests. An empty
+    # --bootnodes / --discovery.dns overrides the mainnet defaults erigon
+    # would otherwise fall back to. Without this, the routing table fills
+    # with real peers and drowns out the simulator's bystander nodes.
+    FLAGS="$FLAGS --bootnodes= --discovery.dns= --staticpeers="
+fi
 echo "Running erigon with flags $FLAGS"
 $erigon $FLAGS

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -155,12 +155,5 @@ FLAGS="$FLAGS --nat=extip:$ip --no-downloader"
 
 # It doesn't make sense to dial out, use only a pre-set bootnode.
 FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
-
-if [ "$HIVE_BOOTNODE" = "" ]; then
-    # Erigon's default --chain is mainnet, so also clear DNS and static peer
-    # defaults that would otherwise fill the routing table with real peers
-    # during devp2p tests (drowning out the simulator's bystander nodes).
-    FLAGS="$FLAGS --discovery.dns= --staticpeers="
-fi
 echo "Running erigon with flags $FLAGS"
 $erigon $FLAGS


### PR DESCRIPTION
## Summary

Fixes two persistent failures in erigon's devp2p/discv5 suite by aligning the launcher with geth.sh:

- Switch from `--nat=none` to `--nat=extip:$eth0_ip`, so erigon's self-node is advertised with a routable IP. Without this, self's IP is the 127.0.0.1 fallback, and the FINDNODE handler's `CheckRelayAddr` drops it for non-loopback senders — breaking **FindnodeZeroDistance**.
- Pass `--bootnodes=$HIVE_BOOTNODE` unconditionally (mirroring geth.sh). When `HIVE_BOOTNODE` is empty (devp2p tests) this becomes `--bootnodes=`, preventing erigon from falling back to mainnet bootnodes that would flood the routing table — breaking **FindnodeResults**.

## Dependency

erigontech/erigon#20630 (merged) — makes erigon honor `--bootnodes=` as "explicitly empty" rather than silently falling back to chain defaults, matching go-ethereum's behavior.