### PR TITLE
simulators/lean: integrate Gean into the lean devnet sim

### DIFF
--- a/simulators/lean/README.md
+++ b/simulators/lean/README.md
@@ -24,8 +24,9 @@ or:
 `./hive --sim lean --client-file simulators/lean/clients/devnet4.yaml --client ream`
 
 The lean simulator resolves the active devnet from the selected client name
-(`ream_devnet4`, `ethlambda_devnet3`, and so on) and validates it against the
-central support matrix in `simulators/lean/config/lean-devnets.txt`.
+(`ream_devnet4`, `ethlambda_devnet3`, `gean_devnet3`, and so on) and validates
+it against the central support matrix in
+`simulators/lean/config/lean-devnets.txt`.
 
 This gives us a simple onboarding path for new lean clients while leaving a clear place to grow:
 

--- a/simulators/lean/clients/devnet3.yaml
+++ b/simulators/lean/clients/devnet3.yaml
@@ -1,5 +1,7 @@
 - client: ethlambda
   nametag: devnet3
+- client: gean
+  nametag: devnet3
 - client: lantern
   nametag: devnet3
 - client: ream

--- a/simulators/lean/clients/devnet4.yaml
+++ b/simulators/lean/clients/devnet4.yaml
@@ -1,5 +1,7 @@
 - client: ethlambda
   nametag: devnet4
+- client: gean
+  nametag: devnet4
 - client: ream
   nametag: devnet4
 - client: zeam

--- a/simulators/lean/config/lean-devnets.txt
+++ b/simulators/lean/config/lean-devnets.txt
@@ -5,6 +5,7 @@
 default=devnet3
 
 ethlambda=devnet3,devnet4
+gean=devnet3,devnet4
 lantern=devnet3
 ream=devnet3,devnet4
 zeam=devnet3,devnet4

--- a/simulators/lean/helper/prepare_lean_client_assets.py
+++ b/simulators/lean/helper/prepare_lean_client_assets.py
@@ -12,7 +12,7 @@ import time
 import urllib.request
 from pathlib import Path
 
-SUPPORTED_CLIENTS = {"ethlambda", "lantern", "ream", "zeam"}
+SUPPORTED_CLIENTS = {"ethlambda", "gean", "lantern", "ream", "zeam"}
 FALLBACK_BOOTNODES = [
     "enr:-IW4QA0pljjdLfxS_EyUxNAxJSoGCwmOVNJauYWsTiYHyWG5Bky-7yCEktSvu_w-PWUrmzbc8vYL_Mx5pgsAix2OfOMBgmlkgnY0gmlwhKwUAAGEcXVpY4IfkIlzZWNwMjU2azGhA6mw8mfwe-3TpjMMSk7GHe3cURhOn9-ufyAqy40wEyui",
 ]
@@ -190,6 +190,8 @@ def render_config(validators: list[dict[str, str]]) -> str:
                     f'    proposal_public_key: "{format_genesis_pubkey(validator["proposal_public"])}"'
                 )
             else:
+                # ethlambda / lantern / zeam / gean-devnet4 all accept the
+                # attestation_pubkey + proposal_pubkey nested shape.
                 lines.append(
                     f'  - attestation_pubkey: "{format_genesis_pubkey(validator["attestation_public"])}"'
                 )
@@ -425,6 +427,59 @@ def write_ream_assignments(
     write_text(asset_root / "hash-sig-keys" / manifest_name, "\n".join(manifest_lines) + "\n")
 
 
+def write_gean_assignments(
+    asset_root: Path,
+    specs: list[dict[str, object]],
+    validators: list[dict[str, str]],
+) -> None:
+    # gean reads annotated_validators.yaml with entries of shape
+    # {index, pubkey_hex, privkey_file} and expects the raw XMSS secret
+    # key bytes under hash-sig-keys/<privkey_file>. On devnet4 we emit two
+    # entries per validator (attestation + proposal) so both keys are
+    # available; gean itself only consumes one pubkey per entry today.
+    lines: list[str] = []
+    for spec in specs:
+        lines.append(f'{spec["name"]}:')
+        for index in spec["indices"]:
+            validator = validators[index]
+            if uses_dual_key_genesis():
+                attestation_file = f"validator_{index}_attester_sk.ssz"
+                proposal_file = f"validator_{index}_proposer_sk.ssz"
+                write_bytes(
+                    asset_root / "hash-sig-keys" / attestation_file,
+                    bytes.fromhex(validator["attestation_secret"]),
+                )
+                write_bytes(
+                    asset_root / "hash-sig-keys" / proposal_file,
+                    bytes.fromhex(validator["proposal_secret"]),
+                )
+                lines.extend(
+                    [
+                        f"  - index: {index}",
+                        f'    pubkey_hex: "{validator["attestation_public"]}"',
+                        f'    privkey_file: "{attestation_file}"',
+                        f"  - index: {index}",
+                        f'    pubkey_hex: "{validator["proposal_public"]}"',
+                        f'    privkey_file: "{proposal_file}"',
+                    ]
+                )
+                continue
+
+            filename = f"validator_{index}_sk.ssz"
+            write_bytes(
+                asset_root / "hash-sig-keys" / filename,
+                bytes.fromhex(validator["attestation_secret"]),
+            )
+            lines.extend(
+                [
+                    f"  - index: {index}",
+                    f'    pubkey_hex: "{validator["attestation_public"]}"',
+                    f'    privkey_file: "{filename}"',
+                ]
+            )
+    write_text(asset_root / "annotated_validators.yaml", "\n".join(lines) + "\n")
+
+
 def write_client_specific_assets(
     asset_root: Path,
     specs: list[dict[str, object]],
@@ -432,6 +487,12 @@ def write_client_specific_assets(
 ) -> None:
     if CLIENT_KIND == "ethlambda":
         write_ethlambda_assignments(asset_root, specs, validators)
+        return
+    if CLIENT_KIND == "gean":
+        # gean.sh verifies /tmp/gean-runtime/validators.yaml exists; write the
+        # shared registry even though gean itself reads annotated_validators.yaml.
+        write_text(asset_root / "validators.yaml", render_validator_registry(specs))
+        write_gean_assignments(asset_root, specs, validators)
         return
     if CLIENT_KIND == "zeam":
         write_zeam_assignments(asset_root, specs, validators)

--- a/simulators/lean/src/scenarios/sync.rs
+++ b/simulators/lean/src/scenarios/sync.rs
@@ -392,7 +392,7 @@ fn minimum_source_checkpoint_slot(test_data: &PostGenesisSyncTestData) -> u64 {
 }
 
 fn lean_client_kind(client_type: &str) -> Result<&'static str, String> {
-    for candidate in ["ethlambda", "zeam", "lantern", "ream"] {
+    for candidate in ["ethlambda", "zeam", "lantern", "ream", "gean"] {
         if client_type.starts_with(candidate) {
             return Ok(candidate);
         }


### PR DESCRIPTION
## Summary                                                                                                                                                                                        
  - Recognise `gean` in `lean_client_kind` and render its runtime assets in `prepare_lean_client_assets.py`.
  - Add `gean` to the `devnet3` and `devnet4` client profiles and the lean devnet support matrix (`lean-devnets.txt`).
  - Update `sync.rs` and the README example to include `gean` in client-name resolution.       