### PR TITLE
clients/lantern: Add lantern devnet-4 support

### DIFF
--- a/clients/lantern/Dockerfile
+++ b/clients/lantern/Dockerfile
@@ -1,12 +1,21 @@
 ARG baseimage=piertwo/lantern
-ARG tag=v0.0.3
+ARG devnet3_tag=v0.0.3
+ARG devnet4_tag=v0.0.4
 
-FROM $baseimage:$tag
+FROM ${baseimage}:${devnet3_tag} AS devnet3-binary
+FROM ${baseimage}:${devnet4_tag} AS devnet4-binary
+FROM ${baseimage}:${devnet4_tag}
+
+COPY --from=devnet3-binary /opt/lantern /opt/lantern-devnet3
 
 ADD lantern.sh /lantern.sh
 
 RUN chmod +x /lantern.sh \
-    && (lantern --version || lantern_cli --version) | head -1 > /version.txt
+    && (LD_LIBRARY_PATH=/opt/lantern-devnet3/lib /opt/lantern-devnet3/bin/lantern --version || echo "lantern-devnet3") | head -1 > /version-devnet3.txt \
+    && (/opt/lantern/bin/lantern --version || echo "lantern-devnet4") | head -1 > /version-devnet4.txt \
+    && printf "lantern devnet3: %s\nlantern devnet4: %s\n" \
+        "$(cat /version-devnet3.txt)" \
+        "$(cat /version-devnet4.txt)" > /version.txt
 
 EXPOSE 5052 9000/udp 8080
 

--- a/clients/lantern/lantern.sh
+++ b/clients/lantern/lantern.sh
@@ -2,10 +2,25 @@
 
 set -euo pipefail
 
-LANTERN_BIN="${LANTERN_BIN:-$(command -v lantern || command -v lantern_cli)}"
+DEVNET_LABEL="${HIVE_LEAN_DEVNET_LABEL:-devnet3}"
 NODE_ID="${HIVE_NODE_ID:-lantern_0}"
 ASSET_ROOT="/tmp/lantern-runtime"
-DEVNET_LABEL="${HIVE_LEAN_DEVNET_LABEL:-devnet3}"
+
+case "$DEVNET_LABEL" in
+    devnet3)
+        DEFAULT_LANTERN_BIN="/opt/lantern-devnet3/bin/lantern"
+        export LD_LIBRARY_PATH="/opt/lantern-devnet3/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        ;;
+    devnet4)
+        DEFAULT_LANTERN_BIN="/opt/lantern/bin/lantern"
+        ;;
+    *)
+        echo "Unsupported Lean devnet label: $DEVNET_LABEL" >&2
+        exit 1
+        ;;
+esac
+
+LANTERN_BIN="${LANTERN_BIN:-$DEFAULT_LANTERN_BIN}"
 
 cleanup() {
     if [ -d "$ASSET_ROOT" ]; then

--- a/simulators/lean/clients/devnet4.yaml
+++ b/simulators/lean/clients/devnet4.yaml
@@ -4,6 +4,8 @@
   nametag: devnet4
 - client: grandine_lean
   nametag: devnet4
+- client: lantern
+  nametag: devnet4
 - client: ream
   nametag: devnet4
 - client: zeam

--- a/simulators/lean/config/lean-devnets.txt
+++ b/simulators/lean/config/lean-devnets.txt
@@ -7,6 +7,6 @@ default=devnet3
 ethlambda=devnet3,devnet4
 gean=devnet3,devnet4
 grandine_lean=devnet3,devnet4
-lantern=devnet3
+lantern=devnet3,devnet4
 ream=devnet3,devnet4
 zeam=devnet3,devnet4

--- a/simulators/lean/helper/prepare_lean_client_assets.py
+++ b/simulators/lean/helper/prepare_lean_client_assets.py
@@ -347,8 +347,8 @@ def write_lantern_assignments(
         lines.append(f'{spec["name"]}:')
         for index in spec["indices"]:
             validator = validators[index]
-            attestation_file = f"validator_{index}_att_sk.ssz"
-            proposal_file = f"validator_{index}_prop_sk.ssz"
+            attestation_file = f"validator_{index}_attester_key_sk.ssz"
+            proposal_file = f"validator_{index}_proposer_key_sk.ssz"
             write_bytes(
                 asset_root / "hash-sig-keys" / attestation_file,
                 bytes.fromhex(validator["attestation_secret"]),
@@ -360,11 +360,11 @@ def write_lantern_assignments(
             lines.extend(
                 [
                     f"  - index: {index}",
-                    f'    pubkey_hex: "{validator["attestation_public"]}"',
-                    f'    privkey_file: "{attestation_file}"',
+                    f"    pubkey_hex: {validator['attestation_public']}",
+                    f"    privkey_file: {attestation_file}",
                     f"  - index: {index}",
-                    f'    pubkey_hex: "{validator["proposal_public"]}"',
-                    f'    privkey_file: "{proposal_file}"',
+                    f"    pubkey_hex: {validator['proposal_public']}",
+                    f"    privkey_file: {proposal_file}",
                 ]
             )
     write_text(asset_root / "annotated_validators.yaml", "\n".join(lines) + "\n")


### PR DESCRIPTION
- Packages both `piertwo/lantern:v0.0.3` and `:v0.0.4` in the lantern client image and selects the binary at startup based on `HIVE_LEAN_DEVNET_LABEL`.
- Adds a `prepare_lean_client_assets.py` tweak so lantern v0.0.4's YAML parser accepts the `annotated_validators.yaml` the simulator generates.