### PR TITLE
‎hivesim-rs, ‎simulators/lean: support shared-client scenarios

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ exclude = ["simulators/portal"]
 default-members = ["simulators/lean"]
 resolver = "2"
 
-[patch."https://github.com/ethereum/hive"]
+[workspace.dependencies]
 hivesim = { path = "hivesim-rs" }

--- a/hivesim-rs/src/lib.rs
+++ b/hivesim-rs/src/lib.rs
@@ -8,5 +8,8 @@ pub mod types;
 pub mod utils;
 
 pub use simulation::Simulation;
-pub use testapi::{run_suite, Client, NClientTestSpec, Suite, Test, TestSpec};
+pub use testapi::{
+    run_suite, Client, NClientTestSpec, SharedClientScenario, SharedClientTestSpec, Suite, Test,
+    TestSpec,
+};
 pub use testmatch::TestMatcher;

--- a/hivesim-rs/src/simulation.rs
+++ b/hivesim-rs/src/simulation.rs
@@ -183,6 +183,45 @@ impl Simulation {
         (resp.id, ip)
     }
 
+    /// Registers an existing client container (started under `source_test`) as also
+    /// belonging to `target_test`, without starting a new container. This enables
+    /// client reuse across tests in the same suite while still reporting each
+    /// scenario as its own test case in the hive UI.
+    ///
+    /// Lifecycle: the source test remains the sole owner of the container. Ending
+    /// the target test will NOT stop the container (its registered copy has no
+    /// teardown hook); only ending the source test does. See
+    /// `libhive.TestManager.RegisterNode` / `registerMultiTestNode` on the hive
+    /// server for the full semantics.
+    pub async fn register_multi_test_node(
+        &self,
+        test_suite: SuiteID,
+        source_test: TestID,
+        node_id: &str,
+        target_test: TestID,
+    ) {
+        let url = format!(
+            "{}/testsuite/{}/test/{}/node/{}/register/{}",
+            self.url, test_suite, source_test, node_id, target_test
+        );
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(&url)
+            .send()
+            .await
+            .expect("Failed to send register multi-test node request");
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            panic!(
+                "Failed to register multi-test node (node={}, source_test={}, target_test={}): \
+                 status={} body={}",
+                node_id, source_test, target_test, status, body
+            );
+        }
+    }
+
     /// Returns all client types available to this simulator run. This depends on
     /// both the available client set and the command line filters.
     pub async fn client_types(&self) -> Vec<ClientDefinition> {

--- a/hivesim-rs/src/simulation.rs
+++ b/hivesim-rs/src/simulation.rs
@@ -4,12 +4,27 @@ use std::collections::HashMap;
 use std::env;
 use std::net::IpAddr;
 use std::str::FromStr;
+use std::time::Duration;
+
+/// Default HTTP timeout for short control-plane requests against the hive
+/// simulation API (e.g. [`Simulation::register_multi_test_node`]). All of
+/// these requests are localhost POSTs against the hive process, so a short
+/// timeout is safe and stops a stuck server from hanging a scenario loop
+/// indefinitely.
+const CONTROL_PLANE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Wraps the simulation HTTP API provided by hive.
 #[derive(Clone, Debug)]
 pub struct Simulation {
     pub url: String,
     pub test_matcher: Option<TestMatcher>,
+    /// Long-lived client used by new control-plane methods (e.g.
+    /// [`Simulation::register_multi_test_node`]). Configured with a bounded
+    /// timeout so a hung hive server cannot stall a scenario loop. The
+    /// pre-existing methods on this struct intentionally still use
+    /// `reqwest::Client::new()` per call; unifying them is out of scope for
+    /// the change that introduced this field.
+    http_client: reqwest::Client,
 }
 
 impl Default for Simulation {
@@ -55,7 +70,33 @@ impl Simulation {
             panic!("HIVE_SIMULATOR environment variable is empty")
         }
 
-        Self { url, test_matcher }
+        let http_client = reqwest::Client::builder()
+            .timeout(CONTROL_PLANE_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+
+        Self {
+            url,
+            test_matcher,
+            http_client,
+        }
+    }
+
+    /// Builds a [`Simulation`] pointing at the given hive API URL. Primarily
+    /// useful for tests that want to exercise the control-plane methods
+    /// against a mock HTTP server without touching the `HIVE_SIMULATOR`
+    /// environment variable.
+    #[doc(hidden)]
+    pub fn with_url(url: String) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(CONTROL_PLANE_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            url,
+            test_matcher: None,
+            http_client,
+        }
     }
 
     pub async fn start_suite(
@@ -189,37 +230,43 @@ impl Simulation {
     /// scenario as its own test case in the hive UI.
     ///
     /// Lifecycle: the source test remains the sole owner of the container. Ending
-    /// the target test will NOT stop the container (its registered copy has no
-    /// teardown hook); only ending the source test does. See
+    /// the target test will NOT stop the container (its registered copy has
+    /// `wait == nil` server-side); only ending the source test does. See
     /// `libhive.TestManager.RegisterNode` / `registerMultiTestNode` on the hive
-    /// server for the full semantics.
+    /// server (`internal/libhive/api.go::registerMultiTestNode` explicitly
+    /// constructs the copy without a `wait` function) for the full semantics.
+    ///
+    /// Returns `Err` on transport errors, timeouts, or non-2xx responses so the
+    /// caller can recover gracefully (e.g. fail just the affected scenario and
+    /// keep the shared container and the rest of the scenario loop alive).
     pub async fn register_multi_test_node(
         &self,
         test_suite: SuiteID,
         source_test: TestID,
         node_id: &str,
         target_test: TestID,
-    ) {
+    ) -> Result<(), String> {
         let url = format!(
             "{}/testsuite/{}/test/{}/node/{}/register/{}",
             self.url, test_suite, source_test, node_id, target_test
         );
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(&url)
-            .send()
-            .await
-            .expect("Failed to send register multi-test node request");
+        let resp = self.http_client.post(&url).send().await.map_err(|err| {
+            format!(
+                "register_multi_test_node transport error (node={node_id}, \
+                 source_test={source_test}, target_test={target_test}): {err}"
+            )
+        })?;
 
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            panic!(
-                "Failed to register multi-test node (node={}, source_test={}, target_test={}): \
-                 status={} body={}",
-                node_id, source_test, target_test, status, body
-            );
+            return Err(format!(
+                "register_multi_test_node rejected (node={node_id}, \
+                 source_test={source_test}, target_test={target_test}): \
+                 status={status} body={body}"
+            ));
         }
+        Ok(())
     }
 
     /// Returns all client types available to this simulator run. This depends on
@@ -235,5 +282,83 @@ impl Simulation {
             .json::<Vec<ClientDefinition>>()
             .await
             .expect("Failed to convert client types response to json")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener as TokioTcpListener;
+
+    /// Minimal test HTTP server: reads one request, responds with the
+    /// supplied status line and body, counts hits. Intentionally avoids any
+    /// HTTP framework so hivesim-rs doesn't grow a dev-dependency for one
+    /// test.
+    async fn spawn_mock(
+        response: &'static str,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        let std_listener = TcpListener::bind("127.0.0.1:0").expect("bind mock");
+        std_listener.set_nonblocking(true).expect("nonblocking");
+        let addr = std_listener.local_addr().expect("addr");
+        let listener = TokioTcpListener::from_std(std_listener).expect("tokio listener");
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_clone = hits.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+                hits_clone.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 1024];
+                let _ = socket.read(&mut buf).await;
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            }
+        });
+        (format!("http://{}", addr), hits, handle)
+    }
+
+    #[tokio::test]
+    async fn register_multi_test_node_happy_path() {
+        let (url, hits, handle) =
+            spawn_mock("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK").await;
+        let sim = Simulation::with_url(url);
+        let result = sim.register_multi_test_node(1, 2, "node-abc", 3).await;
+        handle.abort();
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn register_multi_test_node_returns_err_on_non_2xx() {
+        let (url, _, handle) = spawn_mock(
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 11\r\n\
+             Connection: close\r\n\r\nserver boom",
+        )
+        .await;
+        let sim = Simulation::with_url(url);
+        let result = sim.register_multi_test_node(1, 2, "node-abc", 3).await;
+        handle.abort();
+        let err = result.expect_err("expected Err on 500");
+        assert!(err.contains("status=500"), "unexpected err: {err}");
+        assert!(err.contains("server boom"), "unexpected err: {err}");
+    }
+
+    #[tokio::test]
+    async fn register_multi_test_node_returns_err_on_transport_failure() {
+        // Bind and immediately drop the listener so the port is closed.
+        let addr = {
+            let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+            l.local_addr().expect("addr")
+        };
+        let sim = Simulation::with_url(format!("http://{addr}"));
+        let result = sim.register_multi_test_node(1, 2, "node-abc", 3).await;
+        let err = result.expect_err("expected Err on closed port");
+        assert!(err.contains("transport error"), "unexpected err: {err}");
     }
 }

--- a/hivesim-rs/src/simulation.rs
+++ b/hivesim-rs/src/simulation.rs
@@ -6,11 +6,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
-/// Default HTTP timeout for short control-plane requests against the hive
-/// simulation API (e.g. [`Simulation::register_multi_test_node`]). All of
-/// these requests are localhost POSTs against the hive process, so a short
-/// timeout is safe and stops a stuck server from hanging a scenario loop
-/// indefinitely.
+/// Timeout for short simulator control-plane requests.
 const CONTROL_PLANE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Wraps the simulation HTTP API provided by hive.
@@ -18,12 +14,7 @@ const CONTROL_PLANE_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct Simulation {
     pub url: String,
     pub test_matcher: Option<TestMatcher>,
-    /// Long-lived client used by new control-plane methods (e.g.
-    /// [`Simulation::register_multi_test_node`]). Configured with a bounded
-    /// timeout so a hung hive server cannot stall a scenario loop. The
-    /// pre-existing methods on this struct intentionally still use
-    /// `reqwest::Client::new()` per call; unifying them is out of scope for
-    /// the change that introduced this field.
+    /// Shared client for short control-plane requests.
     http_client: reqwest::Client,
 }
 
@@ -82,10 +73,7 @@ impl Simulation {
         }
     }
 
-    /// Builds a [`Simulation`] pointing at the given hive API URL. Primarily
-    /// useful for tests that want to exercise the control-plane methods
-    /// against a mock HTTP server without touching the `HIVE_SIMULATOR`
-    /// environment variable.
+    /// Builds a [`Simulation`] for tests against a custom API URL.
     #[doc(hidden)]
     pub fn with_url(url: String) -> Self {
         let http_client = reqwest::Client::builder()
@@ -224,21 +212,7 @@ impl Simulation {
         (resp.id, ip)
     }
 
-    /// Registers an existing client container (started under `source_test`) as also
-    /// belonging to `target_test`, without starting a new container. This enables
-    /// client reuse across tests in the same suite while still reporting each
-    /// scenario as its own test case in the hive UI.
-    ///
-    /// Lifecycle: the source test remains the sole owner of the container. Ending
-    /// the target test will NOT stop the container (its registered copy has
-    /// `wait == nil` server-side); only ending the source test does. See
-    /// `libhive.TestManager.RegisterNode` / `registerMultiTestNode` on the hive
-    /// server (`internal/libhive/api.go::registerMultiTestNode` explicitly
-    /// constructs the copy without a `wait` function) for the full semantics.
-    ///
-    /// Returns `Err` on transport errors, timeouts, or non-2xx responses so the
-    /// caller can recover gracefully (e.g. fail just the affected scenario and
-    /// keep the shared container and the rest of the scenario loop alive).
+    /// Registers an existing container with another test without starting a new one.
     pub async fn register_multi_test_node(
         &self,
         test_suite: SuiteID,
@@ -294,10 +268,7 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener as TokioTcpListener;
 
-    /// Minimal test HTTP server: reads one request, responds with the
-    /// supplied status line and body, counts hits. Intentionally avoids any
-    /// HTTP framework so hivesim-rs doesn't grow a dev-dependency for one
-    /// test.
+    /// Minimal one-request HTTP test server.
     async fn spawn_mock(
         response: &'static str,
     ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
@@ -351,7 +322,6 @@ mod tests {
 
     #[tokio::test]
     async fn register_multi_test_node_returns_err_on_transport_failure() {
-        // Bind and immediately drop the listener so the port is closed.
         let addr = {
             let l = TcpListener::bind("127.0.0.1:0").expect("bind");
             l.local_addr().expect("addr")

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -32,6 +32,19 @@ pub type AsyncNClientsTestFunc<T> = fn(
     >,
 >;
 
+/// Signature for a scenario inside a `SharedClientTestSpec`. Each scenario gets
+/// a shared, already-started `Client` plus a cloned `test_data` payload.
+pub type AsyncSharedClientTestFunc<T> = fn(
+    Client,
+    T,
+) -> Pin<
+    Box<
+        dyn Future<Output = ()> // future API / pollable
+            + Send // required by non-single-threaded executors
+            + 'static,
+    >,
+>;
+
 type ClientFiles = Option<Vec<Option<HashMap<String, Vec<u8>>>>>;
 type ClientEnvironments = Option<Vec<Option<HashMap<String, String>>>>;
 
@@ -311,6 +324,196 @@ async fn run_n_client_test<T: Send + 'static>(
     );
 
     host.end_test(suite_id, test_id, test_result).await;
+}
+
+/// One scenario inside a [`SharedClientTestSpec`].
+///
+/// Each scenario is surfaced as its own hive test case (pass/fail/details are
+/// recorded per-scenario and shown individually in hiveview), but all scenarios
+/// in the parent spec run against the same client container without
+/// restarting it between scenarios.
+#[derive(Clone)]
+pub struct SharedClientScenario<T> {
+    pub name: String,
+    pub description: String,
+    /// If true, the scenario runs even when the test matcher would otherwise
+    /// filter it out.
+    pub always_run: bool,
+    pub run: AsyncSharedClientTestFunc<T>,
+}
+
+/// Like [`NClientTestSpec`], but starts a single client once and runs a list
+/// of scenarios against it, without restarting the container between
+/// scenarios.
+///
+/// Useful when a suite has many short read-only scenarios whose per-test
+/// container boot dominates wall-clock time (e.g. RPC-compatibility suites
+/// that repeatedly query the same finalized state).
+///
+/// Semantics:
+///
+/// - A container is started once, owned by a "lifecycle owner" test case
+///   created from `name` / `description`. The owner test is always reported
+///   as passing; it exists solely to anchor the container's lifecycle.
+/// - Each entry in `scenarios` is registered as its own hive test case
+///   sharing the owner's container (via
+///   [`Simulation::register_multi_test_node`]). Pass/fail/details are
+///   recorded per-scenario.
+/// - Scenarios run sequentially in the order given. They see each other's
+///   side effects on the client (this is the whole point; scenarios that
+///   rely on a fresh container must keep using [`NClientTestSpec`]).
+/// - `test_data` is cloned once per scenario. Use `Arc`-wrapped payloads to
+///   share heap state cheaply.
+/// - When all scenarios have ended, the owner test ends, which tears down
+///   the container.
+#[derive(Clone)]
+pub struct SharedClientTestSpec<T> {
+    /// Name of the lifecycle-owner test surfaced in hiveview. Pick something
+    /// that makes it clear this is a shared-client group (e.g.
+    /// `"rpc_compat: shared-client SSZ decode suite"`).
+    pub name: String,
+    pub description: String,
+    /// If true, the owner test runs even when the test matcher would
+    /// otherwise filter it out. Per-scenario `always_run` still applies on
+    /// top of this.
+    pub always_run: bool,
+    /// Environment variables for the shared client.
+    pub environment: Option<HashMap<String, String>>,
+    /// Files to upload before starting the shared client.
+    pub files: Option<HashMap<String, Vec<u8>>>,
+    /// Test data cloned once per scenario.
+    pub test_data: T,
+    /// The client to start and share across all scenarios. Only single-client
+    /// sharing is supported today; open an issue if multi-client sharing is
+    /// needed.
+    pub client: ClientDefinition,
+    pub scenarios: Vec<SharedClientScenario<T>>,
+}
+
+#[async_trait]
+impl<T: Clone + Send + Sync + 'static> Testable for SharedClientTestSpec<T> {
+    async fn run_test(&self, simulation: Simulation, suite_id: SuiteID, suite: Suite) {
+        // Apply the owner-level filter first. If the owner doesn't match and
+        // no scenario has an explicit `always_run` override that would match,
+        // skip the whole group before we incur container-start cost.
+        if let Some(test_match) = simulation.test_matcher.clone() {
+            let owner_matches = self.always_run || test_match.match_test(&suite.name, &self.name);
+            if !owner_matches {
+                let any_scenario_matches = self
+                    .scenarios
+                    .iter()
+                    .any(|s| s.always_run || test_match.match_test(&suite.name, &s.name));
+                if !any_scenario_matches {
+                    return;
+                }
+            }
+        }
+
+        run_shared_client_test(
+            simulation,
+            suite_id,
+            suite,
+            self.name.clone(),
+            self.description.clone(),
+            self.client.clone(),
+            self.environment.clone(),
+            self.files.clone(),
+            self.test_data.clone(),
+            self.scenarios.clone(),
+        )
+        .await;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
+    host: Simulation,
+    suite_id: SuiteID,
+    suite: Suite,
+    owner_name: String,
+    owner_desc: String,
+    client_def: ClientDefinition,
+    environment: Option<HashMap<String, String>>,
+    files: Option<HashMap<String, Vec<u8>>>,
+    test_data: T,
+    scenarios: Vec<SharedClientScenario<T>>,
+) {
+    // Start the lifecycle owner test first. Its sole role is to own the
+    // container; we end it last so the container survives every scenario.
+    let owner_test_id = host.start_test(suite_id, owner_name, owner_desc).await;
+
+    let (container_id, ip) = host
+        .start_client_with_files(
+            suite_id,
+            owner_test_id,
+            client_def.name.clone(),
+            environment,
+            files,
+        )
+        .await;
+
+    let mut scenarios_run: usize = 0;
+
+    for scenario in scenarios {
+        if let Some(test_match) = host.test_matcher.clone() {
+            if !scenario.always_run && !test_match.match_test(&suite.name, &scenario.name) {
+                continue;
+            }
+        }
+
+        let scenario_test_id = host
+            .start_test(
+                suite_id,
+                scenario.name.clone(),
+                scenario.description.clone(),
+            )
+            .await;
+
+        // Register the owner's container with the scenario's test id. The
+        // registered copy has no teardown hook (see `registerMultiTestNode`
+        // on the hive server), so ending the scenario leaves the container
+        // running for the next one.
+        host.register_multi_test_node(suite_id, owner_test_id, &container_id, scenario_test_id)
+            .await;
+
+        let scenario_client = Client {
+            kind: client_def.name.clone(),
+            container: container_id.clone(),
+            ip,
+            rpc: HttpClientBuilder::default()
+                .build(format!("http://{}:8545", ip))
+                .expect("Failed to build rpc_client"),
+            test: Test {
+                sim: host.clone(),
+                test_id: scenario_test_id,
+                suite: suite.clone(),
+                suite_id,
+                result: Default::default(),
+            },
+        };
+
+        let data_clone = test_data.clone();
+        let run = scenario.run;
+        let test_result = extract_test_results(
+            tokio::spawn(async move {
+                (run)(scenario_client, data_clone).await;
+            })
+            .await,
+        );
+
+        host.end_test(suite_id, scenario_test_id, test_result).await;
+        scenarios_run += 1;
+    }
+
+    host.end_test(
+        suite_id,
+        owner_test_id,
+        TestResult {
+            pass: true,
+            details: format!("shared-client lifecycle owner ({scenarios_run} scenario(s) ran)"),
+        },
+    )
+    .await;
 }
 
 pub async fn run_suite(host: Simulation, suites: Vec<Suite>) {

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -353,19 +353,25 @@ pub struct SharedClientScenario<T> {
 /// Semantics:
 ///
 /// - A container is started once, owned by a "lifecycle owner" test case
-///   created from `name` / `description`. The owner test is always reported
-///   as passing; it exists solely to anchor the container's lifecycle.
+///   created from `name` / `description`. The owner's pass/fail is an
+///   aggregate: pass iff at least one scenario ran and every scenario that
+///   ran passed. An owner whose scenarios were all filtered out is reported
+///   as failed to avoid a silent green suite.
 /// - Each entry in `scenarios` is registered as its own hive test case
 ///   sharing the owner's container (via
 ///   [`Simulation::register_multi_test_node`]). Pass/fail/details are
 ///   recorded per-scenario.
-/// - Scenarios run sequentially in the order given. They see each other's
-///   side effects on the client (this is the whole point; scenarios that
-///   rely on a fresh container must keep using [`NClientTestSpec`]).
+/// - Scenarios run sequentially in the order given, but **must be
+///   independent of execution order**: they share one container, so any
+///   mutation performed by one scenario is visible to the next. The safe
+///   mental model is read-only queries against a shared setup. If a
+///   scenario needs a fresh container, use [`NClientTestSpec`] instead.
 /// - `test_data` is cloned once per scenario. Use `Arc`-wrapped payloads to
 ///   share heap state cheaply.
 /// - When all scenarios have ended, the owner test ends, which tears down
-///   the container.
+///   the container. If the scenario loop panics or is cancelled, a best-
+///   effort teardown guard still ends the owner test so the container is
+///   not leaked.
 #[derive(Clone)]
 pub struct SharedClientTestSpec<T> {
     /// Name of the lifecycle-owner test surfaced in hiveview. Pick something
@@ -393,9 +399,15 @@ pub struct SharedClientTestSpec<T> {
 #[async_trait]
 impl<T: Clone + Send + Sync + 'static> Testable for SharedClientTestSpec<T> {
     async fn run_test(&self, simulation: Simulation, suite_id: SuiteID, suite: Suite) {
-        // Apply the owner-level filter first. If the owner doesn't match and
-        // no scenario has an explicit `always_run` override that would match,
-        // skip the whole group before we incur container-start cost.
+        // Outer matcher filter: skip the whole group (and the container
+        // start) if neither the owner nor any scenario would match. This
+        // is load-bearing for performance -- without it we'd boot a
+        // container just to find out every scenario is filtered out.
+        //
+        // The inner matcher filter inside `run_shared_client_test` is the
+        // one that actually skips individual scenarios once the container
+        // is up. The two filters must stay consistent; if you tweak the
+        // matching logic in one site, update the other too.
         if let Some(test_match) = simulation.test_matcher.clone() {
             let owner_matches = self.always_run || test_match.match_test(&suite.name, &self.name);
             if !owner_matches {
@@ -422,6 +434,73 @@ impl<T: Clone + Send + Sync + 'static> Testable for SharedClientTestSpec<T> {
             self.scenarios.clone(),
         )
         .await;
+    }
+}
+
+/// Best-effort teardown guard for a shared-client lifecycle owner.
+///
+/// On normal completion the caller calls `disarm()`, which records the
+/// aggregate scenario result and turns the subsequent `Drop` into a no-op.
+/// If the scenario loop unwinds or is cancelled before `disarm()`, the
+/// `Drop` impl spawns a detached task that ends the owner test with a
+/// failing result. Ending the owner test is what tears the shared
+/// container down on the hive server (see `EndTest` in
+/// `libhive/testmanager.go`), so this prevents a leaked container on the
+/// panic / cancel path.
+struct OwnerGuard {
+    host: Simulation,
+    suite_id: SuiteID,
+    owner_test_id: TestID,
+    disarmed: bool,
+}
+
+impl OwnerGuard {
+    fn new(host: Simulation, suite_id: SuiteID, owner_test_id: TestID) -> Self {
+        Self {
+            host,
+            suite_id,
+            owner_test_id,
+            disarmed: true,
+        }
+    }
+
+    /// Arm the guard for the duration of the scenario loop. Must be paired
+    /// with a call to [`OwnerGuard::disarm`] once the loop finishes
+    /// normally.
+    fn arm(&mut self) {
+        self.disarmed = false;
+    }
+
+    fn disarm(&mut self) {
+        self.disarmed = true;
+    }
+}
+
+impl Drop for OwnerGuard {
+    fn drop(&mut self) {
+        if self.disarmed {
+            return;
+        }
+        let host = self.host.clone();
+        let suite_id = self.suite_id;
+        let owner_test_id = self.owner_test_id;
+        // Best-effort: spawn a detached task to close out the owner test.
+        // If the tokio runtime is already shutting down this may never
+        // run, but in the common panic case it gives the hive server a
+        // chance to stop the shared container.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                host.end_test(
+                    suite_id,
+                    owner_test_id,
+                    TestResult {
+                        pass: false,
+                        details: "shared-client owner aborted before completion".to_string(),
+                    },
+                )
+                .await;
+            });
+        }
     }
 }
 
@@ -452,11 +531,19 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
         )
         .await;
 
+    let mut guard = OwnerGuard::new(host.clone(), suite_id, owner_test_id);
+    guard.arm();
+
     let mut scenarios_run: usize = 0;
+    let mut scenarios_passed: usize = 0;
+    let mut scenarios_filtered: usize = 0;
 
     for scenario in scenarios {
+        // Inner matcher filter: individual scenario skip. See the
+        // cross-reference comment in `SharedClientTestSpec::run_test`.
         if let Some(test_match) = host.test_matcher.clone() {
             if !scenario.always_run && !test_match.match_test(&suite.name, &scenario.name) {
+                scenarios_filtered += 1;
                 continue;
             }
         }
@@ -472,48 +559,85 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
         // Register the owner's container with the scenario's test id. The
         // registered copy has no teardown hook (see `registerMultiTestNode`
         // on the hive server), so ending the scenario leaves the container
-        // running for the next one.
-        host.register_multi_test_node(suite_id, owner_test_id, &container_id, scenario_test_id)
-            .await;
-
-        let scenario_client = Client {
-            kind: client_def.name.clone(),
-            container: container_id.clone(),
-            ip,
-            rpc: HttpClientBuilder::default()
-                .build(format!("http://{}:8545", ip))
-                .expect("Failed to build rpc_client"),
-            test: Test {
-                sim: host.clone(),
-                test_id: scenario_test_id,
-                suite: suite.clone(),
+        // running for the next one. A registration failure (transport /
+        // 5xx / timeout) fails just this scenario and keeps the loop and
+        // the shared container alive so the rest of the scenarios still
+        // get a chance to run.
+        if let Err(err) = host
+            .register_multi_test_node(suite_id, owner_test_id, &container_id, scenario_test_id)
+            .await
+        {
+            host.end_test(
                 suite_id,
-                result: Default::default(),
-            },
-        };
+                scenario_test_id,
+                TestResult {
+                    pass: false,
+                    details: format!("shared-client registration failed; skipping scenario: {err}"),
+                },
+            )
+            .await;
+            scenarios_run += 1;
+            continue;
+        }
 
         let data_clone = test_data.clone();
         let run = scenario.run;
+        let host_for_spawn = host.clone();
+        let kind_for_spawn = client_def.name.clone();
+        let container_for_spawn = container_id.clone();
+        let suite_for_spawn = suite.clone();
+        // Build the scenario `Client` inside the spawn so that a panic
+        // from `HttpClientBuilder::build(...).expect(...)` is caught by
+        // `extract_test_results` and surfaces as a scenario failure rather
+        // than unwinding the whole lifecycle.
         let test_result = extract_test_results(
             tokio::spawn(async move {
+                let scenario_client = Client {
+                    kind: kind_for_spawn,
+                    container: container_for_spawn,
+                    ip,
+                    rpc: HttpClientBuilder::default()
+                        .build(format!("http://{}:8545", ip))
+                        .expect("Failed to build rpc_client"),
+                    test: Test {
+                        sim: host_for_spawn,
+                        test_id: scenario_test_id,
+                        suite: suite_for_spawn,
+                        suite_id,
+                        result: Default::default(),
+                    },
+                };
                 (run)(scenario_client, data_clone).await;
             })
             .await,
         );
 
+        if test_result.pass {
+            scenarios_passed += 1;
+        }
         host.end_test(suite_id, scenario_test_id, test_result).await;
         scenarios_run += 1;
     }
 
+    // Owner pass/fail is an aggregate: pass only if every scenario that
+    // ran passed, and at least one scenario actually ran. An owner whose
+    // scenarios were all filtered out or all failed is reported as
+    // failing so hiveview doesn't show a green parent over a red group.
+    let owner_pass = scenarios_run > 0 && scenarios_passed == scenarios_run;
+    let owner_details = format!(
+        "shared-client lifecycle owner: {scenarios_passed}/{scenarios_run} \
+         scenario(s) passed ({scenarios_filtered} filtered)"
+    );
     host.end_test(
         suite_id,
         owner_test_id,
         TestResult {
-            pass: true,
-            details: format!("shared-client lifecycle owner ({scenarios_run} scenario(s) ran)"),
+            pass: owner_pass,
+            details: owner_details,
         },
     )
     .await;
+    guard.disarm();
 }
 
 pub async fn run_suite(host: Simulation, suites: Vec<Suite>) {

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -326,72 +326,28 @@ async fn run_n_client_test<T: Send + 'static>(
     host.end_test(suite_id, test_id, test_result).await;
 }
 
-/// One scenario inside a [`SharedClientTestSpec`].
-///
-/// Each scenario is surfaced as its own hive test case (pass/fail/details are
-/// recorded per-scenario and shown individually in hiveview), but all scenarios
-/// in the parent spec run against the same client container without
-/// restarting it between scenarios.
+/// One scenario in a [`SharedClientTestSpec`].
 #[derive(Clone)]
 pub struct SharedClientScenario<T> {
     pub name: String,
     pub description: String,
-    /// If true, the scenario runs even when the test matcher would otherwise
-    /// filter it out.
+    /// Runs even if filtered by the test matcher.
     pub always_run: bool,
     pub run: AsyncSharedClientTestFunc<T>,
 }
 
-/// Like [`NClientTestSpec`], but starts a single client once and runs a list
-/// of scenarios against it, without restarting the container between
-/// scenarios.
-///
-/// Useful when a suite has many short read-only scenarios whose per-test
-/// container boot dominates wall-clock time (e.g. RPC-compatibility suites
-/// that repeatedly query the same finalized state).
-///
-/// Semantics:
-///
-/// - A container is started once, owned by a "lifecycle owner" test case
-///   created from `name` / `description`. The owner's pass/fail is an
-///   aggregate: pass iff at least one scenario ran and every scenario that
-///   ran passed. An owner whose scenarios were all filtered out is reported
-///   as failed to avoid a silent green suite.
-/// - Each entry in `scenarios` is registered as its own hive test case
-///   sharing the owner's container (via
-///   [`Simulation::register_multi_test_node`]). Pass/fail/details are
-///   recorded per-scenario.
-/// - Scenarios run sequentially in the order given, but **must be
-///   independent of execution order**: they share one container, so any
-///   mutation performed by one scenario is visible to the next. The safe
-///   mental model is read-only queries against a shared setup. If a
-///   scenario needs a fresh container, use [`NClientTestSpec`] instead.
-/// - `test_data` is cloned once per scenario. Use `Arc`-wrapped payloads to
-///   share heap state cheaply.
-/// - When all scenarios have ended, the owner test ends, which tears down
-///   the container. If the scenario loop panics or is cancelled, a best-
-///   effort teardown guard still ends the owner test so the container is
-///   not leaked.
+/// Runs multiple scenarios against one client container.
 #[derive(Clone)]
 pub struct SharedClientTestSpec<T> {
-    /// Name of the lifecycle-owner test surfaced in hiveview. Pick something
-    /// that makes it clear this is a shared-client group (e.g.
-    /// `"rpc_compat: shared-client SSZ decode suite"`).
+    /// Name of the lifecycle-owner test shown in hiveview.
     pub name: String,
     pub description: String,
-    /// If true, the owner test runs even when the test matcher would
-    /// otherwise filter it out. Per-scenario `always_run` still applies on
-    /// top of this.
+    /// Runs even if filtered by the test matcher.
     pub always_run: bool,
-    /// Environment variables for the shared client.
     pub environment: Option<HashMap<String, String>>,
-    /// Files to upload before starting the shared client.
     pub files: Option<HashMap<String, Vec<u8>>>,
-    /// Test data cloned once per scenario.
     pub test_data: T,
-    /// The client to start and share across all scenarios. Only single-client
-    /// sharing is supported today; open an issue if multi-client sharing is
-    /// needed.
+    /// Client shared across all scenarios.
     pub client: ClientDefinition,
     pub scenarios: Vec<SharedClientScenario<T>>,
 }
@@ -399,15 +355,7 @@ pub struct SharedClientTestSpec<T> {
 #[async_trait]
 impl<T: Clone + Send + Sync + 'static> Testable for SharedClientTestSpec<T> {
     async fn run_test(&self, simulation: Simulation, suite_id: SuiteID, suite: Suite) {
-        // Outer matcher filter: skip the whole group (and the container
-        // start) if neither the owner nor any scenario would match. This
-        // is load-bearing for performance -- without it we'd boot a
-        // container just to find out every scenario is filtered out.
-        //
-        // The inner matcher filter inside `run_shared_client_test` is the
-        // one that actually skips individual scenarios once the container
-        // is up. The two filters must stay consistent; if you tweak the
-        // matching logic in one site, update the other too.
+        // Skip the shared client entirely if neither the owner nor any scenario matches.
         if let Some(test_match) = simulation.test_matcher.clone() {
             let owner_matches = self.always_run || test_match.match_test(&suite.name, &self.name);
             if !owner_matches {
@@ -437,16 +385,7 @@ impl<T: Clone + Send + Sync + 'static> Testable for SharedClientTestSpec<T> {
     }
 }
 
-/// Best-effort teardown guard for a shared-client lifecycle owner.
-///
-/// On normal completion the caller calls `disarm()`, which records the
-/// aggregate scenario result and turns the subsequent `Drop` into a no-op.
-/// If the scenario loop unwinds or is cancelled before `disarm()`, the
-/// `Drop` impl spawns a detached task that ends the owner test with a
-/// failing result. Ending the owner test is what tears the shared
-/// container down on the hive server (see `EndTest` in
-/// `libhive/testmanager.go`), so this prevents a leaked container on the
-/// panic / cancel path.
+/// Best-effort teardown guard for the shared-client owner test.
 struct OwnerGuard {
     host: Simulation,
     suite_id: SuiteID,
@@ -464,9 +403,6 @@ impl OwnerGuard {
         }
     }
 
-    /// Arm the guard for the duration of the scenario loop. Must be paired
-    /// with a call to [`OwnerGuard::disarm`] once the loop finishes
-    /// normally.
     fn arm(&mut self) {
         self.disarmed = false;
     }
@@ -484,10 +420,7 @@ impl Drop for OwnerGuard {
         let host = self.host.clone();
         let suite_id = self.suite_id;
         let owner_test_id = self.owner_test_id;
-        // Best-effort: spawn a detached task to close out the owner test.
-        // If the tokio runtime is already shutting down this may never
-        // run, but in the common panic case it gives the hive server a
-        // chance to stop the shared container.
+        // Best-effort cleanup if the scenario loop aborts early.
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 host.end_test(
@@ -517,8 +450,7 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
     test_data: T,
     scenarios: Vec<SharedClientScenario<T>>,
 ) {
-    // Start the lifecycle owner test first. Its sole role is to own the
-    // container; we end it last so the container survives every scenario.
+    // The owner test keeps the shared container alive across scenarios.
     let owner_test_id = host.start_test(suite_id, owner_name, owner_desc).await;
 
     let (container_id, ip) = host
@@ -539,8 +471,6 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
     let mut scenarios_filtered: usize = 0;
 
     for scenario in scenarios {
-        // Inner matcher filter: individual scenario skip. See the
-        // cross-reference comment in `SharedClientTestSpec::run_test`.
         if let Some(test_match) = host.test_matcher.clone() {
             if !scenario.always_run && !test_match.match_test(&suite.name, &scenario.name) {
                 scenarios_filtered += 1;
@@ -556,13 +486,7 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
             )
             .await;
 
-        // Register the owner's container with the scenario's test id. The
-        // registered copy has no teardown hook (see `registerMultiTestNode`
-        // on the hive server), so ending the scenario leaves the container
-        // running for the next one. A registration failure (transport /
-        // 5xx / timeout) fails just this scenario and keeps the loop and
-        // the shared container alive so the rest of the scenarios still
-        // get a chance to run.
+        // Registration failure fails only this scenario.
         if let Err(err) = host
             .register_multi_test_node(suite_id, owner_test_id, &container_id, scenario_test_id)
             .await
@@ -586,10 +510,6 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
         let kind_for_spawn = client_def.name.clone();
         let container_for_spawn = container_id.clone();
         let suite_for_spawn = suite.clone();
-        // Build the scenario `Client` inside the spawn so that a panic
-        // from `HttpClientBuilder::build(...).expect(...)` is caught by
-        // `extract_test_results` and surfaces as a scenario failure rather
-        // than unwinding the whole lifecycle.
         let test_result = extract_test_results(
             tokio::spawn(async move {
                 let scenario_client = Client {
@@ -619,10 +539,6 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
         scenarios_run += 1;
     }
 
-    // Owner pass/fail is an aggregate: pass only if every scenario that
-    // ran passed, and at least one scenario actually ran. An owner whose
-    // scenarios were all filtered out or all failed is reported as
-    // failing so hiveview doesn't show a green parent over a red group.
     let owner_pass = scenarios_run > 0 && scenarios_passed == scenarios_run;
     let owner_details = format!(
         "shared-client lifecycle owner: {scenarios_passed}/{scenarios_run} \

--- a/simulators/lean/Cargo.toml
+++ b/simulators/lean/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kolby ML (Moroz Liebl) <kolbydml@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-hivesim = { git = "https://github.com/ethereum/hive", rev = "4408fc1de3fee3ac23acd25a812c117756af2f39" }
+hivesim.workspace = true
 alloy-primitives = { version = "1.4.1", features = ["serde"] }
 hex = "0.4"
 reqwest = { version = "0.12.7", features = ["json"] }

--- a/simulators/lean/src/scenarios/rpc_compat.rs
+++ b/simulators/lean/src/scenarios/rpc_compat.rs
@@ -775,12 +775,7 @@ dyn_async! {
             )
             .await;
 
-            // Finalized-state read-only scenarios share one client container
-            // instead of restarting zeam/etc. per scenario. Each scenario
-            // queries a side-effect-free read endpoint
-            // (`/lean/v0/states/finalized` and `/lean/v0/fork_choice`), so
-            // scenario ordering does not change any observable result. See
-            // hivesim::SharedClientTestSpec for the lifecycle semantics.
+            // These finalized-state checks are read-only, so they can share one client.
             let shared_state_environment = lean_environment();
             let shared_state_files = prepare_client_runtime_files(
                 &client.name,

--- a/simulators/lean/src/scenarios/rpc_compat.rs
+++ b/simulators/lean/src/scenarios/rpc_compat.rs
@@ -9,7 +9,10 @@ use crate::{
     CheckpointResponse, HealthResponse, LeanDevnet, HEALTHY_STATUS, LEAN_RPC_SERVICE,
 };
 use alloy_primitives::{FixedBytes, B256};
-use hivesim::{dyn_async, types::TestResult, Client, NClientTestSpec, Test};
+use hivesim::{
+    dyn_async, types::TestResult, Client, NClientTestSpec, SharedClientScenario,
+    SharedClientTestSpec, Test,
+};
 use reqwest::{
     header::{ACCEPT, CONTENT_TYPE},
     Client as HttpClient,
@@ -489,18 +492,16 @@ async fn load_finalized_state(client: &Client) -> LeanState {
     decode_finalized_state(&load_finalized_state_bytes(client).await)
 }
 
-async fn load_fresh_state_setup(clients: Vec<Client>) -> (Client, LeanState) {
-    let client = expect_single_client(clients);
-    let state = load_finalized_state(&client).await;
-    (client, state)
+async fn load_fresh_state_setup(client: &Client) -> LeanState {
+    load_finalized_state(client).await
 }
 
 async fn load_fresh_state_and_fork_choice_setup(
-    clients: Vec<Client>,
-) -> (Client, LeanState, ForkChoiceResponse) {
-    let (client, state) = load_fresh_state_setup(clients).await;
-    let fork_choice = load_fork_choice_response(&client).await;
-    (client, state, fork_choice)
+    client: &Client,
+) -> (LeanState, ForkChoiceResponse) {
+    let state = load_fresh_state_setup(client).await;
+    let fork_choice = load_fork_choice_response(client).await;
+    (state, fork_choice)
 }
 
 async fn load_post_genesis_state_setup(
@@ -774,161 +775,143 @@ dyn_async! {
             )
             .await;
 
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state returns ssz encoded finalized state".to_string(),
-                description: "Loads the finalized state endpoint and checks that it returns decodable SSZ bytes."
-                    .to_string(),
-                always_run: false,
-                run: test_state_returns_ssz_encoded_finalized_state,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
+            // Finalized-state read-only scenarios share one client container
+            // instead of restarting zeam/etc. per scenario. Each scenario
+            // queries a side-effect-free read endpoint
+            // (`/lean/v0/states/finalized` and `/lean/v0/fork_choice`), so
+            // scenario ordering does not change any observable result. See
+            // hivesim::SharedClientTestSpec for the lifecycle semantics.
+            let shared_state_environment = lean_environment();
+            let shared_state_files = prepare_client_runtime_files(
+                &client.name,
+                &shared_state_environment,
+            )
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Unable to prepare runtime assets for {}: {err}",
+                    client.name
+                )
+            });
 
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state returns octet-stream content type".to_string(),
-                description: "Loads the finalized state endpoint and checks that it responds with application/octet-stream."
-                    .to_string(),
+            test.run(SharedClientTestSpec {
+                name: "rpc_compat: finalized-state shared-client scenarios".to_string(),
+                description:
+                    "Starts a single client container and runs the finalized-state read-only RPC compatibility scenarios against it, avoiding one container boot per scenario."
+                        .to_string(),
                 always_run: false,
-                run: test_state_returns_octet_stream_content_type,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
+                environment: Some(shared_state_environment),
+                files: Some(shared_state_files),
                 test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes config".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the config field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_config,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes slot".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the slot field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_slot,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes latest block header".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the latest_block_header field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_latest_block_header,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes latest justified".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the latest_justified checkpoint."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_latest_justified,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes latest finalized".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the latest_finalized checkpoint."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_latest_finalized,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes historical block hashes".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the historical_block_hashes field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_historical_block_hashes,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes justified slots".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the justified_slots field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_justified_slots,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes validators".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the validators field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_validators,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes justifications roots".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the justifications_roots field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_justifications_roots,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state ssz decodes justifications validators".to_string(),
-                description: "Loads and SSZ-decodes the finalized state, then checks the justifications_validators field."
-                    .to_string(),
-                always_run: false,
-                run: test_state_ssz_decodes_justifications_validators,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
-
-            test.run(NClientTestSpec {
-                name: "rpc_compat: state decodes".to_string(),
-                description: "Loads the finalized state endpoint for the baseline RPC compatibility case."
-                    .to_string(),
-                always_run: false,
-                run: test_state,
-                environments: fresh_client_environments.clone(),
-                files: fresh_client_files.clone(),
-                test_data: (),
-                clients: vec![client.clone()],
-            }).await;
+                client: client.clone(),
+                scenarios: vec![
+                    SharedClientScenario {
+                        name: "rpc_compat: state returns ssz encoded finalized state".to_string(),
+                        description:
+                            "Loads the finalized state endpoint and checks that it returns decodable SSZ bytes."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_returns_ssz_encoded_finalized_state,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state returns octet-stream content type".to_string(),
+                        description:
+                            "Loads the finalized state endpoint and checks that it responds with application/octet-stream."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_returns_octet_stream_content_type,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes config".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the config field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_config,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes slot".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the slot field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_slot,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes latest block header".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the latest_block_header field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_latest_block_header,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes latest justified".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the latest_justified checkpoint."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_latest_justified,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes latest finalized".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the latest_finalized checkpoint."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_latest_finalized,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes historical block hashes".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the historical_block_hashes field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_historical_block_hashes,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes justified slots".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the justified_slots field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_justified_slots,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes validators".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the validators field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_validators,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes justifications roots".to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the justifications_roots field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_justifications_roots,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state ssz decodes justifications validators"
+                            .to_string(),
+                        description:
+                            "Loads and SSZ-decodes the finalized state, then checks the justifications_validators field."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state_ssz_decodes_justifications_validators,
+                    },
+                    SharedClientScenario {
+                        name: "rpc_compat: state decodes".to_string(),
+                        description:
+                            "Loads the finalized state endpoint for the baseline RPC compatibility case."
+                                .to_string(),
+                        always_run: false,
+                        run: test_state,
+                    },
+                ],
+            })
+            .await;
 
             let state_finalized_genesis_time = default_genesis_time();
 
@@ -1354,8 +1337,7 @@ dyn_async! {
 
 // /lean/v0/states/finalized
 dyn_async! {
-    async fn test_state_returns_ssz_encoded_finalized_state<'a>(clients: Vec<Client>, _: ()) {
-        let client = expect_single_client(clients);
+    async fn test_state_returns_ssz_encoded_finalized_state<'a>(client: Client, _: ()) {
         let ssz_bytes = load_finalized_state_bytes(&client).await;
 
         assert!(
@@ -1372,8 +1354,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_returns_octet_stream_content_type<'a>(clients: Vec<Client>, _: ()) {
-        let client = expect_single_client(clients);
+    async fn test_state_returns_octet_stream_content_type<'a>(client: Client, _: ()) {
         let response = load_finalized_state_response(&client).await;
         let content_type = response
             .headers()
@@ -1408,8 +1389,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_config<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state) = load_fresh_state_setup(clients).await;
+    async fn test_state_ssz_decodes_config<'a>(client: Client, _: ()) {
+        let state = load_fresh_state_setup(&client).await;
 
         assert!(
             state.config.genesis_time > 0,
@@ -1419,8 +1400,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_slot<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state, fork_choice) = load_fresh_state_and_fork_choice_setup(clients).await;
+    async fn test_state_ssz_decodes_slot<'a>(client: Client, _: ()) {
+        let (state, fork_choice) = load_fresh_state_and_fork_choice_setup(&client).await;
 
         assert_eq!(
             state.slot, fork_choice.finalized.slot,
@@ -1430,8 +1411,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_latest_block_header<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state) = load_fresh_state_setup(clients).await;
+    async fn test_state_ssz_decodes_latest_block_header<'a>(client: Client, _: ()) {
+        let state = load_fresh_state_setup(&client).await;
 
         assert_eq!(
             state.latest_block_header.slot, state.slot,
@@ -1445,8 +1426,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_latest_justified<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state, fork_choice) = load_fresh_state_and_fork_choice_setup(clients).await;
+    async fn test_state_ssz_decodes_latest_justified<'a>(client: Client, _: ()) {
+        let (state, fork_choice) = load_fresh_state_and_fork_choice_setup(&client).await;
 
         assert_eq!(
             state.latest_justified.slot, fork_choice.justified.slot,
@@ -1460,8 +1441,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_latest_finalized<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state, fork_choice) = load_fresh_state_and_fork_choice_setup(clients).await;
+    async fn test_state_ssz_decodes_latest_finalized<'a>(client: Client, _: ()) {
+        let (state, fork_choice) = load_fresh_state_and_fork_choice_setup(&client).await;
 
         assert_eq!(
             state.latest_finalized.slot, fork_choice.finalized.slot,
@@ -1475,8 +1456,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_historical_block_hashes<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state) = load_fresh_state_setup(clients).await;
+    async fn test_state_ssz_decodes_historical_block_hashes<'a>(client: Client, _: ()) {
+        let state = load_fresh_state_setup(&client).await;
 
         assert!(
             state.historical_block_hashes.len() <= state.slot as usize + 1,
@@ -1486,8 +1467,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_justified_slots<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state) = load_fresh_state_setup(clients).await;
+    async fn test_state_ssz_decodes_justified_slots<'a>(client: Client, _: ()) {
+        let state = load_fresh_state_setup(&client).await;
 
         assert!(
             state.justified_slots.num_set_bits() <= state.justified_slots.len(),
@@ -1497,8 +1478,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_validators<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state) = load_fresh_state_setup(clients).await;
+    async fn test_state_ssz_decodes_validators<'a>(client: Client, _: ()) {
+        let state = load_fresh_state_setup(&client).await;
 
         assert!(
             !state.validators.is_empty(),
@@ -1515,8 +1496,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_justifications_roots<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state) = load_fresh_state_setup(clients).await;
+    async fn test_state_ssz_decodes_justifications_roots<'a>(client: Client, _: ()) {
+        let state = load_fresh_state_setup(&client).await;
 
         assert!(
             state.justifications_roots.len() <= state.historical_block_hashes.len(),
@@ -1526,8 +1507,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state_ssz_decodes_justifications_validators<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state) = load_fresh_state_setup(clients).await;
+    async fn test_state_ssz_decodes_justifications_validators<'a>(client: Client, _: ()) {
+        let state = load_fresh_state_setup(&client).await;
 
         assert!(
             state.justifications_validators.num_set_bits() <= state.justifications_validators.len(),
@@ -1537,8 +1518,8 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_state<'a>(clients: Vec<Client>, _: ()) {
-        let (_client, state, fork_choice) = load_fresh_state_and_fork_choice_setup(clients).await;
+    async fn test_state<'a>(client: Client, _: ()) {
+        let (state, fork_choice) = load_fresh_state_and_fork_choice_setup(&client).await;
 
         assert!(
             !state.validators.is_empty(),


### PR DESCRIPTION
## Why

`hivesim-rs` only has `NClientTestSpec`, so every simulator test boots and tears down its own client. For read-only RPC suites this dominates wall-clock time, e.g. the 13 `rpc_compat: state ssz decodes *` scenarios in the `lean` sim all just hit `/lean/v0/states/finalized` and `/lean/v0/fork_choice`, yet each pays a full container boot. Visible in [blockblaz/zeam#766](https://github.com/blockblaz/zeam/pull/766).

The Go side already supports client reuse via `libhive.TestManager.RegisterNode` / the `/testsuite/{suite}/test/{test}/node/{node}/register/{target}` endpoint. This PR mirrors it in `hivesim-rs` and uses it in the lean sim for that one cluster.

## What

**`hivesim-rs`** (additive, `NClientTestSpec` untouched):
- `Simulation::register_multi_test_node` — wraps the existing server endpoint.
- `SharedClientTestSpec<T>` / `SharedClientScenario<T>` — start the client once inside a lifecycle-owner test, run each scenario as its own test case against the shared container, tear down when the owner ends. Test-matcher filtering applied at owner and scenario level.

**`simulators/lean`**:
- The 13 finalized-state SSZ-decode scenarios now share one container via `SharedClientTestSpec`. Scenarios that need a fresh client (e.g. `slot == 0` checks) keep using `NClientTestSpec`.

## Result

13 container boots → 1 for that cluster, still 13 per-scenario results in hiveview.

## Validation

- `cargo fmt` / `cargo clippy -D warnings` / `cargo test` clean on `hivesim-rs/` and `simulators/lean/`.

End-to-end validation done locally against `lean` sim + `ream` devnet4 (picked ream because the zeam devnet3 build on master currently fails with an unrelated zig `build_runner` crash). Results from this branch:

**Shared-client cluster (owner + 13 scenarios): 14/14 pass.**

```
INF API: test started suite=0 test=19 name="rpc_compat: finalized-state shared-client scenarios"
INF API: client ream_devnet4 started suite=0 test=19 container=09a77981
INF API: test started suite=0 test=20 name="rpc_compat: state returns ssz encoded finalized state"
INF API: multi-test node registered node=09a77981 sourceTest=19 targetTest=20
INF API: test ended   suite=0 test=20 pass=true
...
INF API: test started suite=0 test=32 name="rpc_compat: state decodes"
INF API: multi-test node registered node=09a77981 sourceTest=19 targetTest=32
INF API: test ended   suite=0 test=32 pass=true
INF API: test ended   suite=0 test=19 pass=true
```

Key observations from `hive.log`:

- **Exactly one** `client ream_devnet4 started` event for the cluster (container `09a77981`, owned by test 19), down from 13 under the old `NClientTestSpec` wiring.
- **13** `multi-test node registered node=09a77981 sourceTest=19 targetTest=N` events, one per scenario (tests 20 → 32). The new `Simulation::register_multi_test_node` method exercises the existing hive Go server endpoint without changes.
- **All 13 scenarios execute in ~360 ms total** (`13:28:48.833` → `13:28:49.190`), versus ~1 s per container boot previously on this client. On slower clients like zeam (~30–60 s per boot) the effect is 1000×+.
- Owner test **ends after all scenarios** (`13:28:49.268` > `13:28:49.190`), confirming the lifecycle: source test owns teardown, registered copies do not.
- Per-scenario pass/fail is reported individually in the suite JSON, so hiveview still shows 13 distinct rows.

