### PR TITLE
clients/nlean: switch to --custom-network-config-dir

### DIFF
--- a/clients/nlean/nlean.sh
+++ b/clients/nlean/nlean.sh
@@ -55,7 +55,7 @@ else
 fi
 
 FLAGS=(
-    --annotated-validators "$ASSET_ROOT/annotated_validators.yaml"
+    --custom-network-config-dir "$ASSET_ROOT"
     --node "$NODE_ID"
     --data-dir /data
     --fork-digest "$FORK_DIGEST"
@@ -63,7 +63,6 @@ FLAGS=(
     --socket-port 9000
     --metrics-address 0.0.0.0
     --metrics-port 8080
-    --hash-sig-key-dir "$ASSET_ROOT/hash-sig-keys"
     --api-port 5052
 )
 


### PR DESCRIPTION
## Summary

nlean v0.4.0-devnet4 dropped the per-file \`--annotated-validators\` / \`--hash-sig-key-dir\` / \`--validator-config\` flags in favour of a single \`--custom-network-config-dir\` entry point (the convention ethlambda / gean already use). Point \`clients/nlean/nlean.sh\` at \`\$ASSET_ROOT\` directly so the prepared assets (annotated_validators.yaml + hash-sig-keys/) are discovered by canonical filenames.

## Test plan
- [ ] Lean simulator boots nlean and reaches post-genesis finalization