### PR TITLE
clients/besu: enable discv5

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -148,6 +148,8 @@ FLAGS="$FLAGS --sync-mode=$syncmode"
 
 # Enable Snap Server.
 FLAGS="$FLAGS --snapsync-server-enabled"
+# Enable discv5.
+FLAGS="$FLAGS --Xv5-discovery-enabled"
 
 # Configure RPC.
 RPCFLAGS="--host-allowlist=*"


### PR DESCRIPTION
enable discv5 `--Xv5-discovery-enabled` since this is not enabled by default

Note since besu does not concurrently support discv4 and discv5, adding this will cause 5 discv4 tests to fail. Is there a way to have different options for different suites? Otherwise I think we can live with the new discv4 failures since it is deprecated, and focus current development on discv5.