### PR TITLE
clients/erigon: install iproute2 for ip command

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     git \
+    iproute2 \
     jq && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt

--- a/clients/erigon/Dockerfile.git
+++ b/clients/erigon/Dockerfile.git
@@ -22,7 +22,7 @@ FROM debian:13-slim
 # Copy compiled binary from builder
 COPY --from=builder /usr/local/bin/erigon /usr/local/bin/
 
-RUN apt-get update && apt-get install -y bash curl gcc jq libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash curl gcc iproute2 jq libstdc++6 && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt

--- a/clients/erigon/Dockerfile.local
+++ b/clients/erigon/Dockerfile.local
@@ -18,7 +18,7 @@ FROM debian:13-slim
 # Copy compiled binary from builder
 COPY --from=builder /usr/local/bin/erigon /usr/local/bin/
 
-RUN apt-get update && apt-get install -y bash curl jq libstdc++6 libgcc-s1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash curl iproute2 jq libstdc++6 libgcc-s1 && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt


### PR DESCRIPTION
`erigon.sh` invokes `ip addr show eth0` (added in #1427) to compute the container's primary IP for `--nat=extip:$ip`. All three erigon Dockerfiles (`Dockerfile`, `Dockerfile.git`, `Dockerfile.local`) produce a final image based on `debian:13-slim`, which doesn't ship the `ip` command, so the launcher aborts with `ip: command not found` and the discv5 tests fail before erigon starts.

`geth.sh` uses the same idiom and works because its Dockerfile uses `alpine:latest`, whose `busybox` provides `ip` as a built-in applet. On Debian the command lives in the `iproute2` package and has to be installed explicitly.

Example failure: <https://hive.ethpandaops.io/#/test/generic/1776924288-0b13e5d7c0fee37c86413b552cd47a22?testnumber=1>