### PR TITLE
libhive: optional warm-daemon client pool

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/ethereum/hive/internal/libdocker"
 	"github.com/ethereum/hive/internal/libhive"
-	"github.com/lmittmann/tint"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/lmittmann/tint"
 )
 
 type buildArgs map[string]string
@@ -89,6 +89,14 @@ Otherwise, it looks for files in the $HOME directory:
 			"If a very long chain is imported, this timeout may need to be quite large.\n"+
 			"A lower value means that hive won't wait as long in case the node crashes and\n"+
 			"never opens the RPC port.")
+
+		clientPoolSize = flag.Int("client.pool.size", 0, "Max `number` of running client containers retained globally between tests.\n"+
+			"When set, hive keeps client daemons running across tests in a pool keyed by\n"+
+			"(image, sanitized HIVE_* env, files), and resets chain state between tests via\n"+
+			"a JSON-RPC `debug_setHead(0)` call rather than restarting the container. This\n"+
+			"saves the docker create + tar upload + erigon init + daemon boot cost on every\n"+
+			"pool hit. The cap is global (LRU across all buckets), not per-bucket. Default 0\n"+
+			"disables pooling — every test gets a fresh container as before.")
 	)
 
 	// Add the sim.buildarg flag multiple times to allow multiple build arguments.
@@ -209,6 +217,7 @@ Otherwise, it looks for files in the $HOME directory:
 		SimRandomSeed:      *simRandomSeed,
 		SimDurationLimit:   *simTimeLimit,
 		ClientStartTimeout: *clientTimeout,
+		ClientPoolSize:     *clientPoolSize,
 	}
 	runner := libhive.NewRunner(inv, builder, cb)
 

--- a/hive.go
+++ b/hive.go
@@ -92,11 +92,16 @@ Otherwise, it looks for files in the $HOME directory:
 
 		clientPoolSize = flag.Int("client.pool.size", 0, "Max `number` of running client containers retained globally between tests.\n"+
 			"When set, hive keeps client daemons running across tests in a pool keyed by\n"+
-			"(image, sanitized HIVE_* env, files), and resets chain state between tests via\n"+
-			"a JSON-RPC `debug_setHead(0)` call rather than restarting the container. This\n"+
-			"saves the docker create + tar upload + erigon init + daemon boot cost on every\n"+
-			"pool hit. The cap is global (LRU across all buckets), not per-bucket. Default 0\n"+
-			"disables pooling — every test gets a fresh container as before.")
+			"(image, sanitized HIVE_* env, files, networks), and resets chain state between\n"+
+			"tests via a JSON-RPC debug_setHead(0) call rather than restarting the container.\n"+
+			"This saves the docker create + tar upload + client init + daemon boot cost on\n"+
+			"every pool hit. The cap is global (LRU across all buckets), not per-bucket.\n"+
+			"Caveat: debug_setHead(0) only rewinds the canonical chain head. It does NOT\n"+
+			"clear txpool entries, RPC subscriptions/filters, miner state, peer lists, or\n"+
+			"in-memory caches. The pool is therefore safe for near-stateless workloads (e.g.\n"+
+			"EEST consume-engine, single-newPayload-from-genesis) and unsafe for tests that\n"+
+			"mutate any of those. Workloads that don't fit should keep this at 0.\n"+
+			"Default 0 disables pooling — every test gets a fresh container as before.")
 	)
 
 	// Add the sim.buildarg flag multiple times to allow multiple build arguments.

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -247,6 +247,20 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
 
+	// Compute pool key from the inputs that define a "fresh state" for this
+	// client run. Empty string means pooling is disabled.
+	pool := api.tm.ClientPool()
+	var poolKey string
+	if pool.Enabled() {
+		k, err := ComputePoolKey(clientDef.Image, env, files)
+		if err != nil {
+			slog.Warn("API: pool key computation failed; falling back to fresh container",
+				"client", clientDef.Name, "err", err)
+		} else {
+			poolKey = k
+		}
+	}
+
 	// Create labels for client container.
 	labels := NewBaseLabels(api.tm.hiveInstanceID, api.tm.hiveVersion)
 	labels[LabelHiveType] = ContainerTypeClient
@@ -254,18 +268,38 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	labels[LabelHiveTestCase] = testID.String()
 	labels[LabelHiveClientName] = clientDef.Name
 	labels[LabelHiveClientImage] = clientDef.Image
+	if poolKey != "" {
+		labels[LabelHivePoolKey] = poolKey
+	}
 
 	// Generate container name.
 	containerName := GenerateClientContainerName(clientDef.Name, suiteID, testID)
 
-	// Create the client container.
+	// Acquire from the pool first. On a hit, the container is already
+	// running with its chain reset to genesis (done at Release time);
+	// we skip CreateContainer + StartContainer entirely.
 	options := ContainerOptions{Env: env, Files: files, Labels: labels, Name: containerName}
-	containerID, err := api.backend.CreateContainer(ctx, clientDef.Image, options)
-	if err != nil {
-		slog.Error("API: client container create failed", "client", clientDef.Name, "error", err)
-		err := fmt.Errorf("client container create failed (%v)", err)
-		serveError(w, err, http.StatusInternalServerError)
-		return
+	var (
+		containerID string
+		poolEntry   *PoolEntry
+		fromPool    bool
+	)
+	if poolKey != "" {
+		if entry := pool.Acquire(poolKey); entry != nil {
+			containerID = entry.ID
+			poolEntry = entry
+			fromPool = true
+		}
+	}
+	if !fromPool {
+		var err error
+		containerID, err = api.backend.CreateContainer(ctx, clientDef.Image, options)
+		if err != nil {
+			slog.Error("API: client container create failed", "client", clientDef.Name, "error", err)
+			err := fmt.Errorf("client container create failed (%v)", err)
+			serveError(w, err, http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Set the log file. We need the container ID for this,
@@ -273,12 +307,15 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	logPath, logFilePath := api.clientLogFilePaths(clientDef.Name, containerID)
 	options.LogFile = logFilePath
 
-	// Connect to the networks if requested, so it is started already joined to each one.
-	for _, network := range networks {
-		if err := api.tm.ConnectContainer(suiteID, network, containerID); err != nil {
-			slog.Error("API: failed to connect container", "network", network, "container", containerID, "error", err)
-			serveError(w, err, http.StatusInternalServerError)
-			return
+	// Connect to the networks if requested. For pool reuse the container
+	// is already on its networks from the original creation, so skip.
+	if !fromPool {
+		for _, network := range networks {
+			if err := api.tm.ConnectContainer(suiteID, network, containerID); err != nil {
+				slog.Error("API: failed to connect container", "network", network, "container", containerID, "error", err)
+				serveError(w, err, http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 
@@ -294,8 +331,24 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		options.CheckLive = uint16(v)
 	}
 
-	// Start it!
-	info, err := api.backend.StartContainer(ctx, containerID, options)
+	// Start it (or, on pool reuse, synthesise a ContainerInfo from the
+	// pool entry — the daemon is already up).
+	var info *ContainerInfo
+	if fromPool {
+		info = &ContainerInfo{
+			ID:      containerID[:8],
+			IP:      poolEntry.IP,
+			LogFile: logFilePath,
+			// No-op wait: the daemon stays up across tests; the container is
+			// only torn down at pool drain, where its original create-time
+			// wait goroutine fires. EndTest only checks for non-nil so any
+			// callable works.
+			Wait: func() {},
+		}
+		err = nil
+	} else {
+		info, err = api.backend.StartContainer(ctx, containerID, options)
+	}
 	if info != nil {
 		// Capture the current log file size as the starting offset for this test.
 		logBegin := logFileSize(logFilePath)
@@ -307,6 +360,7 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 			LogFile:        logPath,
 			LogOffsets:     &TestLogOffsets{Begin: logBegin},
 			wait:           info.Wait,
+			poolKey:        poolKey,
 		}
 
 		// Add client version to the test suite.
@@ -328,7 +382,11 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// It's started.
-	slog.Info("API: client "+clientDef.Name+" started", "suite", suiteID, "test", testID, "container", containerID[:8])
+	if fromPool {
+		slog.Info("API: client "+clientDef.Name+" started (pool reuse)", "suite", suiteID, "test", testID, "container", containerID[:8])
+	} else {
+		slog.Info("API: client "+clientDef.Name+" started", "suite", suiteID, "test", testID, "container", containerID[:8])
+	}
 	serveJSON(w, &simapi.StartNodeResponse{ID: info.ID, IP: info.IP})
 }
 

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -248,11 +248,13 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Compute pool key from the inputs that define a "fresh state" for this
-	// client run. Empty string means pooling is disabled.
+	// client run. Empty string means pooling is disabled. Networks are part
+	// of the key because the warm path skips ConnectContainer — two tests
+	// requesting different network sets must not share a container.
 	pool := api.tm.ClientPool()
 	var poolKey string
 	if pool.Enabled() {
-		k, err := ComputePoolKey(clientDef.Image, env, files)
+		k, err := ComputePoolKey(clientDef.Image, env, files, networks)
 		if err != nil {
 			slog.Warn("API: pool key computation failed; falling back to fresh container",
 				"client", clientDef.Name, "err", err)
@@ -302,13 +304,24 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Set the log file. We need the container ID for this,
-	// so it can only be set after creating the container.
-	logPath, logFilePath := api.clientLogFilePaths(clientDef.Name, containerID)
+	// Set the log file path. On the cold path the path is derived from the
+	// (full) container ID so each container gets its own file. On pool reuse
+	// we MUST keep using the original path: the docker attach goroutine was
+	// wired up at first start-time and continues to write there. Recomputing
+	// from the (short) reused ID would point per-test offsets at an empty
+	// file while the real output piles up at the original path.
+	var logPath, logFilePath string
+	if fromPool {
+		logPath = poolEntry.LogFile
+		logFilePath = filepath.Join(api.env.LogDir, filepath.FromSlash(logPath))
+	} else {
+		logPath, logFilePath = api.clientLogFilePaths(clientDef.Name, containerID)
+	}
 	options.LogFile = logFilePath
 
 	// Connect to the networks if requested. For pool reuse the container
-	// is already on its networks from the original creation, so skip.
+	// is already on its networks from the original creation (and networks
+	// are part of the pool key, so the set matches), so skip.
 	if !fromPool {
 		for _, network := range networks {
 			if err := api.tm.ConnectContainer(suiteID, network, containerID); err != nil {
@@ -336,7 +349,7 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 	var info *ContainerInfo
 	if fromPool {
 		info = &ContainerInfo{
-			ID:      containerID[:8],
+			ID:      containerID,
 			IP:      poolEntry.IP,
 			LogFile: logFilePath,
 			// No-op wait: the daemon stays up across tests; the container is
@@ -361,6 +374,7 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 			LogOffsets:     &TestLogOffsets{Begin: logBegin},
 			wait:           info.Wait,
 			poolKey:        poolKey,
+			resetPort:      options.CheckLive,
 		}
 
 		// Add client version to the test suite.

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -389,7 +389,7 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		api.tm.RegisterNode(testID, info.ID, clientInfo)
 	}
 	if err != nil {
-		slog.Error("API: could not start client", "client", clientDef.Name, "container", containerID[:8], "error", err)
+		slog.Error("API: could not start client", "client", clientDef.Name, "container", shortID(containerID), "error", err)
 		err := fmt.Errorf("client did not start: %v", err)
 		serveError(w, err, http.StatusInternalServerError)
 		return
@@ -397,9 +397,9 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 
 	// It's started.
 	if fromPool {
-		slog.Info("API: client "+clientDef.Name+" started (pool reuse)", "suite", suiteID, "test", testID, "container", containerID[:8])
+		slog.Info("API: client "+clientDef.Name+" started (pool reuse)", "suite", suiteID, "test", testID, "container", shortID(containerID))
 	} else {
-		slog.Info("API: client "+clientDef.Name+" started", "suite", suiteID, "test", testID, "container", containerID[:8])
+		slog.Info("API: client "+clientDef.Name+" started", "suite", suiteID, "test", testID, "container", shortID(containerID))
 	}
 	serveJSON(w, &simapi.StartNodeResponse{ID: info.ID, IP: info.IP})
 }

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -344,6 +344,22 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 		options.CheckLive = uint16(v)
 	}
 
+	// Reset port for the pool's debug_setHead RPC. Defaults to the standard
+	// JSON-RPC port (8545) — distinct from CheckLive, which a simulator may
+	// set to e.g. the JWT-protected engine API port (8551). debug_setHead
+	// lives on the public RPC port; pointing at the engine port returns
+	// "403: missing token" and every Release fails.
+	resetPort := uint16(8545)
+	if portStr := env["HIVE_RESET_PORT"]; portStr != "" {
+		v, err := strconv.ParseUint(portStr, 10, 16)
+		if err != nil {
+			slog.Error("API: could not parse reset port", "error", err)
+			serveError(w, err, http.StatusBadRequest)
+			return
+		}
+		resetPort = uint16(v)
+	}
+
 	// Start it (or, on pool reuse, synthesise a ContainerInfo from the
 	// pool entry — the daemon is already up).
 	var info *ContainerInfo
@@ -374,7 +390,7 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 			LogOffsets:     &TestLogOffsets{Begin: logBegin},
 			wait:           info.Wait,
 			poolKey:        poolKey,
-			resetPort:      options.CheckLive,
+			resetPort:      resetPort,
 		}
 
 		// Add client version to the test suite.

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -182,6 +182,10 @@ type ClientInfo struct {
 	LogOffsets *TestLogOffsets `json:"logOffsets,omitempty"`
 
 	wait func()
+
+	// poolKey, when non-empty, marks this container as a candidate for return
+	// to the client pool at end-of-test. Empty for unpooled (legacy) containers.
+	poolKey string
 }
 
 // HiveInstance contains information about hive itself.

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -186,6 +186,11 @@ type ClientInfo struct {
 	// poolKey, when non-empty, marks this container as a candidate for return
 	// to the client pool at end-of-test. Empty for unpooled (legacy) containers.
 	poolKey string
+
+	// resetPort is captured at start-time so disposeClient can build a
+	// PoolEntry without re-parsing HIVE_CHECK_LIVE_PORT. Same value as the
+	// cold path's options.CheckLive (default 8545).
+	resetPort uint16
 }
 
 // HiveInstance contains information about hive itself.

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -187,9 +187,10 @@ type ClientInfo struct {
 	// to the client pool at end-of-test. Empty for unpooled (legacy) containers.
 	poolKey string
 
-	// resetPort is captured at start-time so disposeClient can build a
-	// PoolEntry without re-parsing HIVE_CHECK_LIVE_PORT. Same value as the
-	// cold path's options.CheckLive (default 8545).
+	// resetPort is the JSON-RPC port the pool's debug_setHead reset RPC
+	// targets. Defaults to 8545; overridable per-suite via HIVE_RESET_PORT.
+	// Distinct from options.CheckLive, which a simulator may set to a
+	// different (e.g. JWT-protected engine) port for liveness purposes.
 	resetPort uint16
 }
 

--- a/internal/libhive/pool.go
+++ b/internal/libhive/pool.go
@@ -27,6 +27,11 @@ const LabelHivePoolKey = "hive.pool.key"
 // sub-millisecond inside Erigon; this is a generous safety net for HTTP.
 const poolResetTimeout = 5 * time.Second
 
+// poolProbeTimeout caps the TCP liveness probe Acquire runs against a
+// parked entry before handing it back. The daemon's listen socket is
+// either up or it isn't — this isn't waiting on app logic.
+const poolProbeTimeout = 500 * time.Millisecond
+
 // PoolEntry is a single parked container.
 //
 // LogFile carries the JSON-relative log path that was set when the container
@@ -36,12 +41,15 @@ const poolResetTimeout = 5 * time.Second
 //
 // ResetPort is the JSON-RPC port the reset RPC targets — the same value the
 // cold path puts in options.CheckLive (HIVE_CHECK_LIVE_PORT, default 8545).
+//
+// Key is the bucket the entry is filed under (sha256 of image/env/files/
+// networks); callers must populate it before calling Release.
 type PoolEntry struct {
 	ID        string
 	IP        string
 	LogFile   string
 	ResetPort uint16
-	key       string // bucket key, set by Release
+	Key       string
 }
 
 // ClientPool retains running client containers across tests. After a
@@ -72,17 +80,21 @@ type ClientPool struct {
 	// reset performs the inter-test chain reset. Production uses
 	// defaultReset (HTTP debug_setHead); tests inject a stub.
 	reset func(ip string, port uint16) error
+	// probe is the cheap liveness check Acquire runs before handing an
+	// entry back; defaultProbe does a short TCP dial. Tests inject a stub.
+	probe func(ip string, port uint16) error
 
 	mu     sync.Mutex
 	list   *list.List // *PoolEntry, oldest at front
 	closed bool
 
 	// deleting tracks async DeleteContainer goroutines spawned by
-	// eviction; Drain waits on it so shutdown sees all cleanup through.
+	// eviction or stale-probe rejection; Drain waits on it so shutdown
+	// sees all cleanup through.
 	deleting sync.WaitGroup
 
 	// Counters for the end-of-run summary log line.
-	hits, misses, evicted, resetFailed uint64
+	hits, misses, evicted, resetFailed, staleRejected uint64
 }
 
 // NewClientPool returns a pool that holds at most maxIdle entries
@@ -94,6 +106,7 @@ func NewClientPool(backend ContainerBackend, maxIdle int) *ClientPool {
 		list:    list.New(),
 	}
 	p.reset = p.defaultReset
+	p.probe = defaultProbe
 	return p
 }
 
@@ -152,37 +165,86 @@ func ComputePoolKey(image string, env map[string]string, files map[string]*multi
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// Acquire returns a parked entry whose key matches, or nil if none.
-// On a hit the daemon is already running with chain state reset to
-// genesis (done at Release), so the caller can use ID/IP directly.
+// Acquire returns a parked entry whose key matches and whose daemon
+// answers a TCP probe, or nil if neither is true. On a hit the daemon
+// is already running with chain state reset to genesis (done at
+// Release) so the caller can use ID/IP directly.
+//
+// If a candidate fails the probe (daemon died between Release and now),
+// the entry is dropped from the pool, its container scheduled for async
+// DeleteContainer, and we look for the next candidate in the same
+// bucket. Without this check Acquire would silently hand out dead
+// containers and the caller would learn only when subsequent RPCs time
+// out — the cold-path CheckLive wait that catches this is skipped on
+// pool reuse.
 func (p *ClientPool) Acquire(key string) *PoolEntry {
 	if !p.Enabled() {
 		return nil
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.closed {
-		return nil
-	}
-	// Scan from the back (newest) so we return hot entries first.
-	for e := p.list.Back(); e != nil; e = e.Prev() {
-		entry := e.Value.(*PoolEntry)
-		if entry.key == key {
-			p.list.Remove(e)
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil
+		}
+		// Scan from the back (newest) so we return hot entries first.
+		var found *list.Element
+		for e := p.list.Back(); e != nil; e = e.Prev() {
+			if e.Value.(*PoolEntry).Key == key {
+				found = e
+				break
+			}
+		}
+		if found == nil {
+			p.misses++
+			p.mu.Unlock()
+			return nil
+		}
+		entry := found.Value.(*PoolEntry)
+		p.list.Remove(found)
+		p.mu.Unlock()
+
+		// Probe outside the lock: TCP dial may take up to poolProbeTimeout
+		// in the failure case, and we don't want to block other
+		// Acquire/Release calls behind it.
+		if err := p.probe(entry.IP, entry.ResetPort); err == nil {
+			p.mu.Lock()
 			p.hits++
+			p.mu.Unlock()
 			return entry
+		} else {
+			slog.Warn("pool: stale entry rejected, deleting",
+				"container", shortID(entry.ID), "ip", entry.IP, "err", err)
+			p.mu.Lock()
+			p.staleRejected++
+			// Add(1) under the lock for the same reason as Release: keeps
+			// Drain.Wait from racing past a not-yet-spawned goroutine.
+			if !p.closed {
+				p.deleting.Add(1)
+			}
+			closed := p.closed
+			p.mu.Unlock()
+
+			if !closed {
+				go func(id string) {
+					defer p.deleting.Done()
+					if err := p.backend.DeleteContainer(id); err != nil {
+						slog.Warn("pool: stale delete failed", "container", shortID(id), "err", err)
+					}
+				}(entry.ID)
+			}
+			// Loop: another entry in this bucket might still be alive.
 		}
 	}
-	p.misses++
-	return nil
 }
 
 // Release sends debug_setHead(0) to revert the daemon to genesis, then
-// parks the entry. If the global cap is exceeded the oldest entry is
-// evicted (DeleteContainer in a background goroutine). On reset failure
-// returns false; caller is expected to delete the container.
-func (p *ClientPool) Release(entry PoolEntry, key string) bool {
-	if !p.Enabled() || entry.ID == "" || entry.IP == "" || key == "" || entry.ResetPort == 0 {
+// parks the entry under entry.Key. If the global cap is exceeded the
+// oldest entry is evicted (DeleteContainer in a background goroutine).
+// On reset failure returns false; caller is expected to delete the
+// container.
+func (p *ClientPool) Release(entry PoolEntry) bool {
+	if !p.Enabled() || entry.ID == "" || entry.IP == "" || entry.Key == "" || entry.ResetPort == 0 {
 		return false
 	}
 	if err := p.reset(entry.IP, entry.ResetPort); err != nil {
@@ -194,7 +256,6 @@ func (p *ClientPool) Release(entry PoolEntry, key string) bool {
 		return false
 	}
 
-	entry.key = key
 	var victimID string
 	p.mu.Lock()
 	if p.closed {
@@ -278,6 +339,21 @@ func (p *ClientPool) defaultReset(ip string, port uint16) error {
 	return nil
 }
 
+// defaultProbe does a TCP dial against the daemon's listen socket so
+// Acquire can reject entries whose daemons died between Release and now.
+// We don't issue an RPC — the dial succeeding is sufficient evidence the
+// daemon is up; the next reset RPC at end-of-test will exercise the
+// JSON-RPC path.
+func defaultProbe(ip string, port uint16) error {
+	addr := net.JoinHostPort(ip, strconv.FormatUint(uint64(port), 10))
+	conn, err := net.DialTimeout("tcp", addr, poolProbeTimeout)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}
+
 // Drain removes every parked container at hive shutdown.
 func (p *ClientPool) Drain(ctx context.Context) {
 	if !p.Enabled() {
@@ -285,7 +361,7 @@ func (p *ClientPool) Drain(ctx context.Context) {
 	}
 	p.mu.Lock()
 	p.closed = true
-	hits, misses, evicted, resetFailed := p.hits, p.misses, p.evicted, p.resetFailed
+	hits, misses, evicted, resetFailed, staleRejected := p.hits, p.misses, p.evicted, p.resetFailed, p.staleRejected
 	victims := make([]string, 0, p.list.Len())
 	for e := p.list.Front(); e != nil; e = e.Next() {
 		victims = append(victims, e.Value.(*PoolEntry).ID)
@@ -300,7 +376,8 @@ func (p *ClientPool) Drain(ctx context.Context) {
 	slog.Info("pool: summary",
 		"hits", hits, "misses", misses,
 		"hit_rate_pct", fmt.Sprintf("%.1f", hitRate),
-		"evicted", evicted, "reset_failed", resetFailed)
+		"evicted", evicted, "reset_failed", resetFailed,
+		"stale_rejected", staleRejected)
 
 	for _, id := range victims {
 		if err := p.backend.DeleteContainer(id); err != nil {

--- a/internal/libhive/pool.go
+++ b/internal/libhive/pool.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -22,27 +23,41 @@ import (
 // LabelHivePoolKey marks pool-managed containers in their docker labels.
 const LabelHivePoolKey = "hive.pool.key"
 
-// poolResetPort is the JSON-RPC port hive talks to for the inter-test
-// reset RPC. It matches the standard HIVE_CHECK_LIVE_PORT default.
-const poolResetPort = 8545
-
 // poolResetTimeout caps each debug_setHead call. The unwind itself is
 // sub-millisecond inside Erigon; this is a generous safety net for HTTP.
 const poolResetTimeout = 5 * time.Second
 
 // PoolEntry is a single parked container.
+//
+// LogFile carries the JSON-relative log path that was set when the container
+// was first created. The docker attach goroutine wrote the stream to that
+// file once at first start; subsequent reuses must reuse the same path so
+// per-test LogOffsets refer to the file that actually receives output.
+//
+// ResetPort is the JSON-RPC port the reset RPC targets — the same value the
+// cold path puts in options.CheckLive (HIVE_CHECK_LIVE_PORT, default 8545).
 type PoolEntry struct {
-	ID  string
-	IP  string
-	key string // bucket key, set by Release
+	ID        string
+	IP        string
+	LogFile   string
+	ResetPort uint16
+	key       string // bucket key, set by Release
 }
 
 // ClientPool retains running client containers across tests. After a
 // test ends, hive sends the client a JSON-RPC `debug_setHead(0)` to
 // revert chain state to genesis and parks the entry under its
-// (image, env, files) key. The next matching test reuses the
-// already-running daemon — no docker create/start, no client init,
-// no daemon boot.
+// (image, env, files, networks) key. The next matching test reuses
+// the already-running daemon — no docker create/start, no client
+// init, no daemon boot.
+//
+// Suitability: `debug_setHead(0)` rewinds the canonical chain head only.
+// It does NOT clear txpool entries, RPC subscriptions/filters, miner
+// state, peer lists, or in-memory caches. Pooling is therefore safe for
+// near-stateless workloads (e.g. EEST consume-engine, where each test
+// is a single newPayload from genesis) and unsafe for tests that mutate
+// any of the above. Workloads that don't fit should keep
+// --client.pool.size=0.
 //
 // Entries are stored in a single global LRU list rather than per-key
 // buckets: with pool.size bounded (~24 in practice) the linear scan
@@ -56,7 +71,7 @@ type ClientPool struct {
 	maxIdle int
 	// reset performs the inter-test chain reset. Production uses
 	// defaultReset (HTTP debug_setHead); tests inject a stub.
-	reset func(ip string) error
+	reset func(ip string, port uint16) error
 
 	mu     sync.Mutex
 	list   *list.List // *PoolEntry, oldest at front
@@ -89,9 +104,12 @@ func (p *ClientPool) Enabled() bool {
 
 // ComputePoolKey hashes the inputs that determine "this container is
 // interchangeable with another for the next test": the image name, the
-// sanitized HIVE_* environment, and the contents of every file passed
-// in (notably /genesis.json).
-func ComputePoolKey(image string, env map[string]string, files map[string]*multipart.FileHeader) (string, error) {
+// sanitized HIVE_* environment, the contents of every file passed in
+// (notably /genesis.json), and the set of docker networks the container
+// is initially connected to. Two tests with different network sets are
+// not interchangeable — the cold path connects networks at startClient
+// time and the warm path skips that step, so they must hash differently.
+func ComputePoolKey(image string, env map[string]string, files map[string]*multipart.FileHeader, networks []string) (string, error) {
 	h := sha256.New()
 	io.WriteString(h, image)
 	io.WriteString(h, "\x00")
@@ -103,6 +121,14 @@ func ComputePoolKey(image string, env map[string]string, files map[string]*multi
 	sort.Strings(keys)
 	for _, k := range keys {
 		fmt.Fprintf(h, "%s=%s\x00", k, env[k])
+	}
+
+	// Networks are tagged with a "net=" prefix so they can't collide with
+	// HIVE_*-prefixed env entries above. Sorted for iteration-order independence.
+	netNames := append([]string(nil), networks...)
+	sort.Strings(netNames)
+	for _, n := range netNames {
+		fmt.Fprintf(h, "net=%s\x00", n)
 	}
 
 	paths := make([]string, 0, len(files))
@@ -156,10 +182,10 @@ func (p *ClientPool) Acquire(key string) *PoolEntry {
 // evicted (DeleteContainer in a background goroutine). On reset failure
 // returns false; caller is expected to delete the container.
 func (p *ClientPool) Release(entry PoolEntry, key string) bool {
-	if !p.Enabled() || entry.ID == "" || entry.IP == "" || key == "" {
+	if !p.Enabled() || entry.ID == "" || entry.IP == "" || key == "" || entry.ResetPort == 0 {
 		return false
 	}
-	if err := p.reset(entry.IP); err != nil {
+	if err := p.reset(entry.IP, entry.ResetPort); err != nil {
 		slog.Warn("pool: reset failed, not retaining",
 			"container", shortID(entry.ID), "ip", entry.IP, "err", err)
 		p.mu.Lock()
@@ -182,12 +208,20 @@ func (p *ClientPool) Release(entry PoolEntry, key string) bool {
 		p.evicted++
 	}
 	p.list.PushBack(&entry)
+	// Add to the WaitGroup *while still holding p.mu*: Drain takes the
+	// same lock to flip closed=true and read the list, so any Add visible
+	// to a future Release was either accounted for in this critical
+	// section or short-circuited by the closed check above. Without the
+	// lock here, an Add after Drain unlocks but before Drain.Wait could
+	// spawn a goroutine the WaitGroup never observes.
+	if victimID != "" {
+		p.deleting.Add(1)
+	}
 	p.mu.Unlock()
 
 	// DeleteContainer can take 50–200 ms; run it off the test-end hot
 	// path. Drain waits on the WaitGroup at shutdown.
 	if victimID != "" {
-		p.deleting.Add(1)
 		go func() {
 			defer p.deleting.Done()
 			if err := p.backend.DeleteContainer(victimID); err != nil {
@@ -198,16 +232,19 @@ func (p *ClientPool) Release(entry PoolEntry, key string) bool {
 	return true
 }
 
-// defaultReset POSTs debug_setHead(0x0) to ip:8545. Erigon already
+// defaultReset POSTs debug_setHead(0x0) to ip:port. Erigon already
 // exposes this on --http.api=...,debug — the test harness uses
 // --http.api=admin,debug,trace,eth,net,txpool,web3,testing — so no
 // client-side changes are needed for Erigon. Other clients (geth,
 // reth, nethermind, besu) all support debug_setHead.
-func (p *ClientPool) defaultReset(ip string) error {
+//
+// The port is the same one the cold path uses for CheckLive
+// (HIVE_CHECK_LIVE_PORT, default 8545); we don't assume 8545 unconditionally.
+func (p *ClientPool) defaultReset(ip string, port uint16) error {
 	ctx, cancel := context.WithTimeout(context.Background(), poolResetTimeout)
 	defer cancel()
 
-	url := fmt.Sprintf("http://%s/", net.JoinHostPort(ip, fmt.Sprintf("%d", poolResetPort)))
+	url := fmt.Sprintf("http://%s/", net.JoinHostPort(ip, strconv.FormatUint(uint64(port), 10)))
 	body := strings.NewReader(`{"jsonrpc":"2.0","method":"debug_setHead","params":["0x0"],"id":1}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {

--- a/internal/libhive/pool.go
+++ b/internal/libhive/pool.go
@@ -1,0 +1,281 @@
+package libhive
+
+import (
+	"bytes"
+	"container/list"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// LabelHivePoolKey marks pool-managed containers in their docker labels.
+const LabelHivePoolKey = "hive.pool.key"
+
+// poolResetPort is the JSON-RPC port hive talks to for the inter-test
+// reset RPC. It matches the standard HIVE_CHECK_LIVE_PORT default.
+const poolResetPort = 8545
+
+// poolResetTimeout caps each debug_setHead call. The unwind itself is
+// sub-millisecond inside Erigon; this is a generous safety net for HTTP.
+const poolResetTimeout = 5 * time.Second
+
+// PoolEntry is a single parked container.
+type PoolEntry struct {
+	ID  string
+	IP  string
+	key string // bucket key, set by Release
+}
+
+// ClientPool retains running client containers across tests. After a
+// test ends, hive sends the client a JSON-RPC `debug_setHead(0)` to
+// revert chain state to genesis and parks the entry under its
+// (image, env, files) key. The next matching test reuses the
+// already-running daemon — no docker create/start, no client init,
+// no daemon boot.
+//
+// Entries are stored in a single global LRU list rather than per-key
+// buckets: with pool.size bounded (~24 in practice) the linear scan
+// in Acquire is trivially fast vs the docker calls it replaces. Eviction
+// when full pops the LRU front (oldest); insertion appends to the back.
+//
+// Pool is opt-in via --client.pool.size. With size <= 0 every method is
+// a cheap no-op and Acquire returns nothing.
+type ClientPool struct {
+	backend ContainerBackend
+	maxIdle int
+	// reset performs the inter-test chain reset. Production uses
+	// defaultReset (HTTP debug_setHead); tests inject a stub.
+	reset func(ip string) error
+
+	mu     sync.Mutex
+	list   *list.List // *PoolEntry, oldest at front
+	closed bool
+
+	// deleting tracks async DeleteContainer goroutines spawned by
+	// eviction; Drain waits on it so shutdown sees all cleanup through.
+	deleting sync.WaitGroup
+
+	// Counters for the end-of-run summary log line.
+	hits, misses, evicted, resetFailed uint64
+}
+
+// NewClientPool returns a pool that holds at most maxIdle entries
+// globally. maxIdle <= 0 disables the pool.
+func NewClientPool(backend ContainerBackend, maxIdle int) *ClientPool {
+	p := &ClientPool{
+		backend: backend,
+		maxIdle: maxIdle,
+		list:    list.New(),
+	}
+	p.reset = p.defaultReset
+	return p
+}
+
+// Enabled reports whether the pool is active.
+func (p *ClientPool) Enabled() bool {
+	return p != nil && p.maxIdle > 0
+}
+
+// ComputePoolKey hashes the inputs that determine "this container is
+// interchangeable with another for the next test": the image name, the
+// sanitized HIVE_* environment, and the contents of every file passed
+// in (notably /genesis.json).
+func ComputePoolKey(image string, env map[string]string, files map[string]*multipart.FileHeader) (string, error) {
+	h := sha256.New()
+	io.WriteString(h, image)
+	io.WriteString(h, "\x00")
+
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(h, "%s=%s\x00", k, env[k])
+	}
+
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		io.WriteString(h, p)
+		io.WriteString(h, "\x00")
+		f, err := files[p].Open()
+		if err != nil {
+			return "", fmt.Errorf("pool key: open %s: %w", p, err)
+		}
+		_, err = io.Copy(h, f)
+		f.Close()
+		if err != nil {
+			return "", fmt.Errorf("pool key: read %s: %w", p, err)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Acquire returns a parked entry whose key matches, or nil if none.
+// On a hit the daemon is already running with chain state reset to
+// genesis (done at Release), so the caller can use ID/IP directly.
+func (p *ClientPool) Acquire(key string) *PoolEntry {
+	if !p.Enabled() {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil
+	}
+	// Scan from the back (newest) so we return hot entries first.
+	for e := p.list.Back(); e != nil; e = e.Prev() {
+		entry := e.Value.(*PoolEntry)
+		if entry.key == key {
+			p.list.Remove(e)
+			p.hits++
+			return entry
+		}
+	}
+	p.misses++
+	return nil
+}
+
+// Release sends debug_setHead(0) to revert the daemon to genesis, then
+// parks the entry. If the global cap is exceeded the oldest entry is
+// evicted (DeleteContainer in a background goroutine). On reset failure
+// returns false; caller is expected to delete the container.
+func (p *ClientPool) Release(entry PoolEntry, key string) bool {
+	if !p.Enabled() || entry.ID == "" || entry.IP == "" || key == "" {
+		return false
+	}
+	if err := p.reset(entry.IP); err != nil {
+		slog.Warn("pool: reset failed, not retaining",
+			"container", shortID(entry.ID), "ip", entry.IP, "err", err)
+		p.mu.Lock()
+		p.resetFailed++
+		p.mu.Unlock()
+		return false
+	}
+
+	entry.key = key
+	var victimID string
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return false
+	}
+	if p.list.Len() >= p.maxIdle {
+		oldest := p.list.Front()
+		victimID = oldest.Value.(*PoolEntry).ID
+		p.list.Remove(oldest)
+		p.evicted++
+	}
+	p.list.PushBack(&entry)
+	p.mu.Unlock()
+
+	// DeleteContainer can take 50–200 ms; run it off the test-end hot
+	// path. Drain waits on the WaitGroup at shutdown.
+	if victimID != "" {
+		p.deleting.Add(1)
+		go func() {
+			defer p.deleting.Done()
+			if err := p.backend.DeleteContainer(victimID); err != nil {
+				slog.Warn("pool: evict delete failed", "container", shortID(victimID), "err", err)
+			}
+		}()
+	}
+	return true
+}
+
+// defaultReset POSTs debug_setHead(0x0) to ip:8545. Erigon already
+// exposes this on --http.api=...,debug — the test harness uses
+// --http.api=admin,debug,trace,eth,net,txpool,web3,testing — so no
+// client-side changes are needed for Erigon. Other clients (geth,
+// reth, nethermind, besu) all support debug_setHead.
+func (p *ClientPool) defaultReset(ip string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), poolResetTimeout)
+	defer cancel()
+
+	url := fmt.Sprintf("http://%s/", net.JoinHostPort(ip, fmt.Sprintf("%d", poolResetPort)))
+	body := strings.NewReader(`{"jsonrpc":"2.0","method":"debug_setHead","params":["0x0"],"id":1}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		buf, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, bytes.TrimSpace(buf))
+	}
+	// JSON-RPC returns 200 OK with an `error` field on application errors.
+	var rpcResp struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&rpcResp); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	if rpcResp.Error != nil {
+		return fmt.Errorf("rpc error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	return nil
+}
+
+// Drain removes every parked container at hive shutdown.
+func (p *ClientPool) Drain(ctx context.Context) {
+	if !p.Enabled() {
+		return
+	}
+	p.mu.Lock()
+	p.closed = true
+	hits, misses, evicted, resetFailed := p.hits, p.misses, p.evicted, p.resetFailed
+	victims := make([]string, 0, p.list.Len())
+	for e := p.list.Front(); e != nil; e = e.Next() {
+		victims = append(victims, e.Value.(*PoolEntry).ID)
+	}
+	p.list = list.New()
+	p.mu.Unlock()
+
+	hitRate := 0.0
+	if hits+misses > 0 {
+		hitRate = 100 * float64(hits) / float64(hits+misses)
+	}
+	slog.Info("pool: summary",
+		"hits", hits, "misses", misses,
+		"hit_rate_pct", fmt.Sprintf("%.1f", hitRate),
+		"evicted", evicted, "reset_failed", resetFailed)
+
+	for _, id := range victims {
+		if err := p.backend.DeleteContainer(id); err != nil {
+			slog.Warn("pool drain: delete failed", "container", shortID(id), "err", err)
+		}
+	}
+	p.deleting.Wait()
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}

--- a/internal/libhive/pool_test.go
+++ b/internal/libhive/pool_test.go
@@ -49,18 +49,30 @@ func (b *recordingBackend) ContainerIP(string, string) (net.IP, error) { return 
 func (b *recordingBackend) ConnectContainer(string, string) error      { return nil }
 func (b *recordingBackend) DisconnectContainer(string, string) error   { return nil }
 
+// resetCall captures one invocation of the reset stub.
+type resetCall struct {
+	ip   string
+	port uint16
+}
+
 // poolWithStubReset returns a pool whose reset function records calls
 // instead of doing HTTP, so unit tests don't need a live RPC endpoint.
-func poolWithStubReset(t *testing.T, maxPerKey int, resetErr error) (*ClientPool, *recordingBackend, *[]string) {
+func poolWithStubReset(t *testing.T, maxIdle int, resetErr error) (*ClientPool, *recordingBackend, *[]resetCall) {
 	t.Helper()
 	be := &recordingBackend{}
-	p := NewClientPool(be, maxPerKey)
-	var resetIPs []string
-	p.reset = func(ip string) error {
-		resetIPs = append(resetIPs, ip)
+	p := NewClientPool(be, maxIdle)
+	var calls []resetCall
+	p.reset = func(ip string, port uint16) error {
+		calls = append(calls, resetCall{ip: ip, port: port})
 		return resetErr
 	}
-	return p, be, &resetIPs
+	return p, be, &calls
+}
+
+// testEntry builds a PoolEntry with the boilerplate non-zero fields filled
+// in so tests don't have to repeat ResetPort: 8545 everywhere.
+func testEntry(id, ip string) PoolEntry {
+	return PoolEntry{ID: id, IP: ip, ResetPort: 8545}
 }
 
 // waitForEvictions blocks until all async DeleteContainer goroutines
@@ -79,22 +91,22 @@ func TestPoolDisabled(t *testing.T) {
 	if got := p.Acquire("k"); got != nil {
 		t.Fatalf("disabled pool should return nil on Acquire, got %+v", got)
 	}
-	if p.Release(PoolEntry{ID: "c", IP: "1.2.3.4"}, "k") {
+	if p.Release(testEntry("c", "1.2.3.4"), "k") {
 		t.Fatal("disabled pool should not retain on Release")
 	}
 }
 
 func TestPoolAcquireReleaseLIFO(t *testing.T) {
 	// Pool fits all 3 entries; verify Acquire returns LIFO within bucket.
-	p, _, resetIPs := poolWithStubReset(t, 4, nil)
+	p, _, calls := poolWithStubReset(t, 4, nil)
 
 	if got := p.Acquire("k"); got != nil {
 		t.Fatalf("empty bucket should return nil, got %+v", got)
 	}
 
-	e1 := PoolEntry{ID: "c1", IP: "10.0.0.1"}
-	e2 := PoolEntry{ID: "c2", IP: "10.0.0.2"}
-	e3 := PoolEntry{ID: "c3", IP: "10.0.0.3"}
+	e1 := testEntry("c1", "10.0.0.1")
+	e2 := testEntry("c2", "10.0.0.2")
+	e3 := testEntry("c3", "10.0.0.3")
 	for _, e := range []PoolEntry{e1, e2, e3} {
 		if !p.Release(e, "k") {
 			t.Fatalf("Release of %s should succeed under cap", e.ID)
@@ -114,8 +126,8 @@ func TestPoolAcquireReleaseLIFO(t *testing.T) {
 		t.Fatalf("Acquire on drained bucket should return nil, got %+v", got)
 	}
 
-	if len(*resetIPs) != 3 {
-		t.Fatalf("expected 3 reset calls, got %v", *resetIPs)
+	if len(*calls) != 3 {
+		t.Fatalf("expected 3 reset calls, got %v", *calls)
 	}
 }
 
@@ -127,10 +139,10 @@ func TestPoolGlobalCapEvictsOldest(t *testing.T) {
 	p, be, _ := poolWithStubReset(t, 2, nil)
 
 	// Park 2 entries to fill the global cap.
-	if !p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k1") {
+	if !p.Release(testEntry("c1", "10.0.0.1"), "k1") {
 		t.Fatal("first release must succeed")
 	}
-	if !p.Release(PoolEntry{ID: "c2", IP: "10.0.0.2"}, "k2") {
+	if !p.Release(testEntry("c2", "10.0.0.2"), "k2") {
 		t.Fatal("second release must succeed under cap")
 	}
 	if got := len(be.deletes); got != 0 {
@@ -138,7 +150,7 @@ func TestPoolGlobalCapEvictsOldest(t *testing.T) {
 	}
 
 	// Park a 3rd: evicts c1 (oldest in LRU) to make room.
-	if !p.Release(PoolEntry{ID: "c3", IP: "10.0.0.3"}, "k3") {
+	if !p.Release(testEntry("c3", "10.0.0.3"), "k3") {
 		t.Fatal("Release should succeed by evicting oldest")
 	}
 	waitForEvictions(p)
@@ -165,8 +177,8 @@ func TestPoolGlobalCapEvictsOldest(t *testing.T) {
 func TestPoolAcquireRefreshesLRU(t *testing.T) {
 	p, be, _ := poolWithStubReset(t, 2, nil)
 
-	p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k1")
-	p.Release(PoolEntry{ID: "c2", IP: "10.0.0.2"}, "k2")
+	p.Release(testEntry("c1", "10.0.0.1"), "k1")
+	p.Release(testEntry("c2", "10.0.0.2"), "k2")
 
 	// Acquire and re-Release c1 — that pushes it to the back of the LRU.
 	got := p.Acquire("k1")
@@ -178,7 +190,7 @@ func TestPoolAcquireRefreshesLRU(t *testing.T) {
 	}
 
 	// Park c3: evict the *new* oldest, which is now c2 (not c1).
-	p.Release(PoolEntry{ID: "c3", IP: "10.0.0.3"}, "k3")
+	p.Release(testEntry("c3", "10.0.0.3"), "k3")
 	waitForEvictions(p)
 	if got := be.deletes; len(got) != 1 || got[0] != "c2" {
 		t.Fatalf("expected c2 to be evicted (older after c1 was refreshed), got %v", got)
@@ -187,7 +199,7 @@ func TestPoolAcquireRefreshesLRU(t *testing.T) {
 
 func TestPoolReleaseFailsOnResetError(t *testing.T) {
 	p, _, _ := poolWithStubReset(t, 4, errStubResetFailed)
-	if p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k") {
+	if p.Release(testEntry("c1", "10.0.0.1"), "k") {
 		t.Fatal("Release should fail when reset returns an error")
 	}
 	if got := p.Acquire("k"); got != nil {
@@ -195,12 +207,65 @@ func TestPoolReleaseFailsOnResetError(t *testing.T) {
 	}
 }
 
+// TestPoolReleaseRequiresResetPort guards the contract that callers must
+// populate ResetPort. A zero port would otherwise produce a malformed
+// reset URL and silently 0-port-fail at runtime.
+func TestPoolReleaseRequiresResetPort(t *testing.T) {
+	p, _, calls := poolWithStubReset(t, 4, nil)
+	if p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1" /* ResetPort omitted */}, "k") {
+		t.Fatal("Release with ResetPort=0 should be rejected")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("reset stub should not have been called, got %v", *calls)
+	}
+}
+
+// TestPoolReleasePassesResetPort verifies the cold-path-supplied port
+// reaches the reset RPC, so HIVE_CHECK_LIVE_PORT overrides take effect.
+func TestPoolReleasePassesResetPort(t *testing.T) {
+	p, _, calls := poolWithStubReset(t, 4, nil)
+	entry := PoolEntry{ID: "c1", IP: "10.0.0.1", ResetPort: 9999}
+	if !p.Release(entry, "k") {
+		t.Fatal("Release should succeed")
+	}
+	if len(*calls) != 1 || (*calls)[0].port != 9999 || (*calls)[0].ip != "10.0.0.1" {
+		t.Fatalf("reset called with wrong args: %+v", *calls)
+	}
+}
+
+// TestPoolPreservesLogFile verifies that the LogFile populated at Release
+// time round-trips through Acquire unchanged. api.startClient relies on
+// this to direct subsequent tests' offsets at the same file the docker
+// attach goroutine actually writes to.
+func TestPoolPreservesLogFile(t *testing.T) {
+	p, _, _ := poolWithStubReset(t, 4, nil)
+	entry := PoolEntry{
+		ID:        "c1",
+		IP:        "10.0.0.1",
+		LogFile:   "geth/client-deadbeef-full-id.log",
+		ResetPort: 8545,
+	}
+	if !p.Release(entry, "k") {
+		t.Fatal("Release should succeed")
+	}
+	got := p.Acquire("k")
+	if got == nil {
+		t.Fatal("Acquire should return the parked entry")
+	}
+	if got.LogFile != entry.LogFile {
+		t.Fatalf("LogFile not preserved across pool: got %q, want %q", got.LogFile, entry.LogFile)
+	}
+	if got.ResetPort != entry.ResetPort {
+		t.Fatalf("ResetPort not preserved: got %d, want %d", got.ResetPort, entry.ResetPort)
+	}
+}
+
 func TestPoolDrain(t *testing.T) {
 	p, be, _ := poolWithStubReset(t, 4, nil)
 
-	p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k1")
-	p.Release(PoolEntry{ID: "c2", IP: "10.0.0.2"}, "k2")
-	p.Release(PoolEntry{ID: "c3", IP: "10.0.0.3"}, "k1")
+	p.Release(testEntry("c1", "10.0.0.1"), "k1")
+	p.Release(testEntry("c2", "10.0.0.2"), "k2")
+	p.Release(testEntry("c3", "10.0.0.3"), "k1")
 
 	p.Drain(context.Background())
 
@@ -211,7 +276,7 @@ func TestPoolDrain(t *testing.T) {
 	if got := p.Acquire("k1"); got != nil {
 		t.Fatalf("Acquire after Drain should return nil, got %+v", got)
 	}
-	if p.Release(PoolEntry{ID: "c4", IP: "10.0.0.4"}, "k1") {
+	if p.Release(testEntry("c4", "10.0.0.4"), "k1") {
 		t.Fatal("Release after Drain should fail")
 	}
 }
@@ -229,11 +294,11 @@ func TestComputePoolKeyDeterministic(t *testing.T) {
 	files1 := buildMultipartFiles(t, map[string]string{"/genesis.json": `{"alloc":{}}`})
 	files2 := buildMultipartFiles(t, map[string]string{"/genesis.json": `{"alloc":{}}`})
 
-	k1, err := ComputePoolKey("img:tag", env1, files1)
+	k1, err := ComputePoolKey("img:tag", env1, files1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	k2, err := ComputePoolKey("img:tag", env2, files2)
+	k2, err := ComputePoolKey("img:tag", env2, files2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +310,7 @@ func TestComputePoolKeyDeterministic(t *testing.T) {
 	otherFiles := buildMultipartFiles(t, map[string]string{
 		"/genesis.json": `{"alloc":{"0x00":{"balance":"0x1"}}}`,
 	})
-	k3, err := ComputePoolKey("img:tag", env1, otherFiles)
+	k3, err := ComputePoolKey("img:tag", env1, otherFiles, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +319,7 @@ func TestComputePoolKeyDeterministic(t *testing.T) {
 	}
 
 	// Different image -> different key.
-	k4, err := ComputePoolKey("img:other", env1, buildMultipartFiles(t, map[string]string{"/genesis.json": `{"alloc":{}}`}))
+	k4, err := ComputePoolKey("img:other", env1, buildMultipartFiles(t, map[string]string{"/genesis.json": `{"alloc":{}}`}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,8 +328,51 @@ func TestComputePoolKeyDeterministic(t *testing.T) {
 	}
 }
 
+// TestComputePoolKeyNetworks verifies that the network set participates in
+// the key. Two tests with identical image/env/files but different requested
+// networks are NOT interchangeable: the warm path skips ConnectContainer,
+// so reusing across network sets would silently leave the container off
+// the network the new test asked for.
+func TestComputePoolKeyNetworks(t *testing.T) {
+	env := map[string]string{"HIVE_CHAIN_ID": "1"}
+	files := buildMultipartFiles(t, map[string]string{"/genesis.json": `{}`})
+
+	files2 := buildMultipartFiles(t, map[string]string{"/genesis.json": `{}`})
+	files3 := buildMultipartFiles(t, map[string]string{"/genesis.json": `{}`})
+	files4 := buildMultipartFiles(t, map[string]string{"/genesis.json": `{}`})
+
+	noNet, err := ComputePoolKey("img", env, files, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withNetA, err := ComputePoolKey("img", env, files2, []string{"netA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	withNetB, err := ComputePoolKey("img", env, files3, []string{"netB"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if noNet == withNetA || withNetA == withNetB {
+		t.Fatalf("network set must affect key: noNet=%s netA=%s netB=%s", noNet, withNetA, withNetB)
+	}
+
+	// Order-independence within the network set.
+	ab1, err := ComputePoolKey("img", env, files4, []string{"netA", "netB"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ab2, err := ComputePoolKey("img", env, buildMultipartFiles(t, map[string]string{"/genesis.json": `{}`}), []string{"netB", "netA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ab1 != ab2 {
+		t.Fatalf("network order should not affect key: %q vs %q", ab1, ab2)
+	}
+}
+
 func TestComputePoolKeyEmpty(t *testing.T) {
-	k, err := ComputePoolKey("img", nil, nil)
+	k, err := ComputePoolKey("img", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/libhive/pool_test.go
+++ b/internal/libhive/pool_test.go
@@ -1,0 +1,309 @@
+package libhive
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingBackend is the minimum ContainerBackend surface area used by the
+// pool. Methods that the pool doesn't touch are fine to leave as no-ops.
+type recordingBackend struct {
+	mu      sync.Mutex
+	deletes []string
+}
+
+func (b *recordingBackend) DeleteContainer(id string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.deletes = append(b.deletes, id)
+	return nil
+}
+
+func (b *recordingBackend) Build(context.Context, Builder) error { return nil }
+func (b *recordingBackend) SetHiveInstanceInfo(string, string)   {}
+func (b *recordingBackend) GetDockerClient() interface{}         { return nil }
+func (b *recordingBackend) ServeAPI(context.Context, http.Handler) (APIServer, error) {
+	return nil, nil
+}
+func (b *recordingBackend) CreateContainer(context.Context, string, ContainerOptions) (string, error) {
+	return "", nil
+}
+func (b *recordingBackend) StartContainer(context.Context, string, ContainerOptions) (*ContainerInfo, error) {
+	return nil, nil
+}
+func (b *recordingBackend) PauseContainer(string) error   { return nil }
+func (b *recordingBackend) UnpauseContainer(string) error { return nil }
+func (b *recordingBackend) RunProgram(context.Context, string, []string) (*ExecInfo, error) {
+	return nil, nil
+}
+func (b *recordingBackend) NetworkNameToID(string) (string, error)     { return "", nil }
+func (b *recordingBackend) CreateNetwork(string) (string, error)       { return "", nil }
+func (b *recordingBackend) RemoveNetwork(string) error                 { return nil }
+func (b *recordingBackend) ContainerIP(string, string) (net.IP, error) { return nil, nil }
+func (b *recordingBackend) ConnectContainer(string, string) error      { return nil }
+func (b *recordingBackend) DisconnectContainer(string, string) error   { return nil }
+
+// poolWithStubReset returns a pool whose reset function records calls
+// instead of doing HTTP, so unit tests don't need a live RPC endpoint.
+func poolWithStubReset(t *testing.T, maxPerKey int, resetErr error) (*ClientPool, *recordingBackend, *[]string) {
+	t.Helper()
+	be := &recordingBackend{}
+	p := NewClientPool(be, maxPerKey)
+	var resetIPs []string
+	p.reset = func(ip string) error {
+		resetIPs = append(resetIPs, ip)
+		return resetErr
+	}
+	return p, be, &resetIPs
+}
+
+// waitForEvictions blocks until all async DeleteContainer goroutines
+// spawned by Release have finished. Tests that observe be.deletes need
+// to call this first.
+func waitForEvictions(p *ClientPool) {
+	p.deleting.Wait()
+}
+
+func TestPoolDisabled(t *testing.T) {
+	be := &recordingBackend{}
+	p := NewClientPool(be, 0)
+	if p.Enabled() {
+		t.Fatal("pool with size 0 should be disabled")
+	}
+	if got := p.Acquire("k"); got != nil {
+		t.Fatalf("disabled pool should return nil on Acquire, got %+v", got)
+	}
+	if p.Release(PoolEntry{ID: "c", IP: "1.2.3.4"}, "k") {
+		t.Fatal("disabled pool should not retain on Release")
+	}
+}
+
+func TestPoolAcquireReleaseLIFO(t *testing.T) {
+	// Pool fits all 3 entries; verify Acquire returns LIFO within bucket.
+	p, _, resetIPs := poolWithStubReset(t, 4, nil)
+
+	if got := p.Acquire("k"); got != nil {
+		t.Fatalf("empty bucket should return nil, got %+v", got)
+	}
+
+	e1 := PoolEntry{ID: "c1", IP: "10.0.0.1"}
+	e2 := PoolEntry{ID: "c2", IP: "10.0.0.2"}
+	e3 := PoolEntry{ID: "c3", IP: "10.0.0.3"}
+	for _, e := range []PoolEntry{e1, e2, e3} {
+		if !p.Release(e, "k") {
+			t.Fatalf("Release of %s should succeed under cap", e.ID)
+		}
+	}
+
+	if got := p.Acquire("k"); got == nil || got.ID != "c3" {
+		t.Fatalf("Acquire should return most-recent (c3), got %+v", got)
+	}
+	if got := p.Acquire("k"); got == nil || got.ID != "c2" {
+		t.Fatalf("Acquire should return c2 next, got %+v", got)
+	}
+	if got := p.Acquire("k"); got == nil || got.ID != "c1" {
+		t.Fatalf("Acquire should return c1 last, got %+v", got)
+	}
+	if got := p.Acquire("k"); got != nil {
+		t.Fatalf("Acquire on drained bucket should return nil, got %+v", got)
+	}
+
+	if len(*resetIPs) != 3 {
+		t.Fatalf("expected 3 reset calls, got %v", *resetIPs)
+	}
+}
+
+// TestPoolGlobalCapEvictsOldest verifies that when the global cap is hit,
+// the oldest LRU entry (across all buckets) is evicted on the next Release,
+// not the new entry being parked. This is the property that prevents the
+// container-count blowup observed in CI run 24930111125.
+func TestPoolGlobalCapEvictsOldest(t *testing.T) {
+	p, be, _ := poolWithStubReset(t, 2, nil)
+
+	// Park 2 entries to fill the global cap.
+	if !p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k1") {
+		t.Fatal("first release must succeed")
+	}
+	if !p.Release(PoolEntry{ID: "c2", IP: "10.0.0.2"}, "k2") {
+		t.Fatal("second release must succeed under cap")
+	}
+	if got := len(be.deletes); got != 0 {
+		t.Fatalf("no evictions yet, got %d deletes", got)
+	}
+
+	// Park a 3rd: evicts c1 (oldest in LRU) to make room.
+	if !p.Release(PoolEntry{ID: "c3", IP: "10.0.0.3"}, "k3") {
+		t.Fatal("Release should succeed by evicting oldest")
+	}
+	waitForEvictions(p)
+	if got := be.deletes; len(got) != 1 || got[0] != "c1" {
+		t.Fatalf("expected c1 to be evicted, got %v", got)
+	}
+
+	// c1's bucket k1 should now be empty.
+	if got := p.Acquire("k1"); got != nil {
+		t.Fatalf("k1 bucket should be empty after eviction, got %+v", got)
+	}
+	// c2 and c3 are still parked.
+	if got := p.Acquire("k2"); got == nil || got.ID != "c2" {
+		t.Fatalf("k2 should still hold c2, got %+v", got)
+	}
+	if got := p.Acquire("k3"); got == nil || got.ID != "c3" {
+		t.Fatalf("k3 should still hold c3, got %+v", got)
+	}
+}
+
+// TestPoolAcquireRefreshesLRU verifies that Acquire-ing an entry and
+// re-Releasing it makes it the *newest* in the LRU, so future evictions
+// favour entries that haven't been touched recently.
+func TestPoolAcquireRefreshesLRU(t *testing.T) {
+	p, be, _ := poolWithStubReset(t, 2, nil)
+
+	p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k1")
+	p.Release(PoolEntry{ID: "c2", IP: "10.0.0.2"}, "k2")
+
+	// Acquire and re-Release c1 — that pushes it to the back of the LRU.
+	got := p.Acquire("k1")
+	if got == nil || got.ID != "c1" {
+		t.Fatalf("Acquire k1 should return c1, got %+v", got)
+	}
+	if !p.Release(*got, "k1") {
+		t.Fatal("Re-release of c1 should succeed")
+	}
+
+	// Park c3: evict the *new* oldest, which is now c2 (not c1).
+	p.Release(PoolEntry{ID: "c3", IP: "10.0.0.3"}, "k3")
+	waitForEvictions(p)
+	if got := be.deletes; len(got) != 1 || got[0] != "c2" {
+		t.Fatalf("expected c2 to be evicted (older after c1 was refreshed), got %v", got)
+	}
+}
+
+func TestPoolReleaseFailsOnResetError(t *testing.T) {
+	p, _, _ := poolWithStubReset(t, 4, errStubResetFailed)
+	if p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k") {
+		t.Fatal("Release should fail when reset returns an error")
+	}
+	if got := p.Acquire("k"); got != nil {
+		t.Fatalf("nothing should have been parked; got %+v", got)
+	}
+}
+
+func TestPoolDrain(t *testing.T) {
+	p, be, _ := poolWithStubReset(t, 4, nil)
+
+	p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1"}, "k1")
+	p.Release(PoolEntry{ID: "c2", IP: "10.0.0.2"}, "k2")
+	p.Release(PoolEntry{ID: "c3", IP: "10.0.0.3"}, "k1")
+
+	p.Drain(context.Background())
+
+	if len(be.deletes) != 3 {
+		t.Fatalf("Drain should delete all retained, got %d", len(be.deletes))
+	}
+	// After drain, Acquire is a no-op.
+	if got := p.Acquire("k1"); got != nil {
+		t.Fatalf("Acquire after Drain should return nil, got %+v", got)
+	}
+	if p.Release(PoolEntry{ID: "c4", IP: "10.0.0.4"}, "k1") {
+		t.Fatal("Release after Drain should fail")
+	}
+}
+
+var errStubResetFailed = errStubReset{}
+
+type errStubReset struct{}
+
+func (errStubReset) Error() string { return "stub reset failed" }
+
+func TestComputePoolKeyDeterministic(t *testing.T) {
+	env1 := map[string]string{"HIVE_CHAIN_ID": "1", "HIVE_FORK_HOMESTEAD": "0"}
+	env2 := map[string]string{"HIVE_FORK_HOMESTEAD": "0", "HIVE_CHAIN_ID": "1"} // same set, diff iteration
+
+	files1 := buildMultipartFiles(t, map[string]string{"/genesis.json": `{"alloc":{}}`})
+	files2 := buildMultipartFiles(t, map[string]string{"/genesis.json": `{"alloc":{}}`})
+
+	k1, err := ComputePoolKey("img:tag", env1, files1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	k2, err := ComputePoolKey("img:tag", env2, files2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k1 != k2 {
+		t.Fatalf("key should not depend on env iteration order: %q vs %q", k1, k2)
+	}
+
+	// Different genesis -> different key.
+	otherFiles := buildMultipartFiles(t, map[string]string{
+		"/genesis.json": `{"alloc":{"0x00":{"balance":"0x1"}}}`,
+	})
+	k3, err := ComputePoolKey("img:tag", env1, otherFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k1 == k3 {
+		t.Fatal("key should change with genesis bytes")
+	}
+
+	// Different image -> different key.
+	k4, err := ComputePoolKey("img:other", env1, buildMultipartFiles(t, map[string]string{"/genesis.json": `{"alloc":{}}`}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k1 == k4 {
+		t.Fatal("key should change with image")
+	}
+}
+
+func TestComputePoolKeyEmpty(t *testing.T) {
+	k, err := ComputePoolKey("img", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k == "" {
+		t.Fatal("key should be non-empty even with no env/files")
+	}
+}
+
+// buildMultipartFiles constructs real *multipart.FileHeader values by writing
+// to a multipart.Writer and parsing it back. This mirrors what
+// http.Request.ParseMultipartForm produces in api.startClient.
+func buildMultipartFiles(t *testing.T, contents map[string]string) map[string]*multipart.FileHeader {
+	t.Helper()
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	for name, content := range contents {
+		fw, err := mw.CreateFormFile(name, name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := fw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	mr := multipart.NewReader(strings.NewReader(body.String()), mw.Boundary())
+	form, err := mr.ReadForm(int64(body.Len()) + 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := make(map[string]*multipart.FileHeader, len(contents))
+	for k, v := range form.File {
+		if len(v) > 0 {
+			out[k] = v[0]
+		}
+	}
+	return out
+}

--- a/internal/libhive/pool_test.go
+++ b/internal/libhive/pool_test.go
@@ -57,6 +57,8 @@ type resetCall struct {
 
 // poolWithStubReset returns a pool whose reset function records calls
 // instead of doing HTTP, so unit tests don't need a live RPC endpoint.
+// The probe stub always returns nil (entry is alive); tests that want
+// staleness override p.probe directly.
 func poolWithStubReset(t *testing.T, maxIdle int, resetErr error) (*ClientPool, *recordingBackend, *[]resetCall) {
 	t.Helper()
 	be := &recordingBackend{}
@@ -66,13 +68,14 @@ func poolWithStubReset(t *testing.T, maxIdle int, resetErr error) (*ClientPool, 
 		calls = append(calls, resetCall{ip: ip, port: port})
 		return resetErr
 	}
+	p.probe = func(ip string, port uint16) error { return nil }
 	return p, be, &calls
 }
 
 // testEntry builds a PoolEntry with the boilerplate non-zero fields filled
-// in so tests don't have to repeat ResetPort: 8545 everywhere.
-func testEntry(id, ip string) PoolEntry {
-	return PoolEntry{ID: id, IP: ip, ResetPort: 8545}
+// in (ResetPort + Key) so tests don't repeat them everywhere.
+func testEntry(id, ip, key string) PoolEntry {
+	return PoolEntry{ID: id, IP: ip, ResetPort: 8545, Key: key}
 }
 
 // waitForEvictions blocks until all async DeleteContainer goroutines
@@ -91,7 +94,7 @@ func TestPoolDisabled(t *testing.T) {
 	if got := p.Acquire("k"); got != nil {
 		t.Fatalf("disabled pool should return nil on Acquire, got %+v", got)
 	}
-	if p.Release(testEntry("c", "1.2.3.4"), "k") {
+	if p.Release(testEntry("c", "1.2.3.4", "k")) {
 		t.Fatal("disabled pool should not retain on Release")
 	}
 }
@@ -104,11 +107,12 @@ func TestPoolAcquireReleaseLIFO(t *testing.T) {
 		t.Fatalf("empty bucket should return nil, got %+v", got)
 	}
 
-	e1 := testEntry("c1", "10.0.0.1")
-	e2 := testEntry("c2", "10.0.0.2")
-	e3 := testEntry("c3", "10.0.0.3")
-	for _, e := range []PoolEntry{e1, e2, e3} {
-		if !p.Release(e, "k") {
+	for _, e := range []PoolEntry{
+		testEntry("c1", "10.0.0.1", "k"),
+		testEntry("c2", "10.0.0.2", "k"),
+		testEntry("c3", "10.0.0.3", "k"),
+	} {
+		if !p.Release(e) {
 			t.Fatalf("Release of %s should succeed under cap", e.ID)
 		}
 	}
@@ -139,10 +143,10 @@ func TestPoolGlobalCapEvictsOldest(t *testing.T) {
 	p, be, _ := poolWithStubReset(t, 2, nil)
 
 	// Park 2 entries to fill the global cap.
-	if !p.Release(testEntry("c1", "10.0.0.1"), "k1") {
+	if !p.Release(testEntry("c1", "10.0.0.1", "k1")) {
 		t.Fatal("first release must succeed")
 	}
-	if !p.Release(testEntry("c2", "10.0.0.2"), "k2") {
+	if !p.Release(testEntry("c2", "10.0.0.2", "k2")) {
 		t.Fatal("second release must succeed under cap")
 	}
 	if got := len(be.deletes); got != 0 {
@@ -150,7 +154,7 @@ func TestPoolGlobalCapEvictsOldest(t *testing.T) {
 	}
 
 	// Park a 3rd: evicts c1 (oldest in LRU) to make room.
-	if !p.Release(testEntry("c3", "10.0.0.3"), "k3") {
+	if !p.Release(testEntry("c3", "10.0.0.3", "k3")) {
 		t.Fatal("Release should succeed by evicting oldest")
 	}
 	waitForEvictions(p)
@@ -177,20 +181,20 @@ func TestPoolGlobalCapEvictsOldest(t *testing.T) {
 func TestPoolAcquireRefreshesLRU(t *testing.T) {
 	p, be, _ := poolWithStubReset(t, 2, nil)
 
-	p.Release(testEntry("c1", "10.0.0.1"), "k1")
-	p.Release(testEntry("c2", "10.0.0.2"), "k2")
+	p.Release(testEntry("c1", "10.0.0.1", "k1"))
+	p.Release(testEntry("c2", "10.0.0.2", "k2"))
 
 	// Acquire and re-Release c1 — that pushes it to the back of the LRU.
 	got := p.Acquire("k1")
 	if got == nil || got.ID != "c1" {
 		t.Fatalf("Acquire k1 should return c1, got %+v", got)
 	}
-	if !p.Release(*got, "k1") {
+	if !p.Release(*got) {
 		t.Fatal("Re-release of c1 should succeed")
 	}
 
 	// Park c3: evict the *new* oldest, which is now c2 (not c1).
-	p.Release(testEntry("c3", "10.0.0.3"), "k3")
+	p.Release(testEntry("c3", "10.0.0.3", "k3"))
 	waitForEvictions(p)
 	if got := be.deletes; len(got) != 1 || got[0] != "c2" {
 		t.Fatalf("expected c2 to be evicted (older after c1 was refreshed), got %v", got)
@@ -199,7 +203,7 @@ func TestPoolAcquireRefreshesLRU(t *testing.T) {
 
 func TestPoolReleaseFailsOnResetError(t *testing.T) {
 	p, _, _ := poolWithStubReset(t, 4, errStubResetFailed)
-	if p.Release(testEntry("c1", "10.0.0.1"), "k") {
+	if p.Release(testEntry("c1", "10.0.0.1", "k")) {
 		t.Fatal("Release should fail when reset returns an error")
 	}
 	if got := p.Acquire("k"); got != nil {
@@ -212,7 +216,7 @@ func TestPoolReleaseFailsOnResetError(t *testing.T) {
 // reset URL and silently 0-port-fail at runtime.
 func TestPoolReleaseRequiresResetPort(t *testing.T) {
 	p, _, calls := poolWithStubReset(t, 4, nil)
-	if p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1" /* ResetPort omitted */}, "k") {
+	if p.Release(PoolEntry{ID: "c1", IP: "10.0.0.1", Key: "k" /* ResetPort omitted */}) {
 		t.Fatal("Release with ResetPort=0 should be rejected")
 	}
 	if len(*calls) != 0 {
@@ -224,8 +228,8 @@ func TestPoolReleaseRequiresResetPort(t *testing.T) {
 // reaches the reset RPC, so HIVE_CHECK_LIVE_PORT overrides take effect.
 func TestPoolReleasePassesResetPort(t *testing.T) {
 	p, _, calls := poolWithStubReset(t, 4, nil)
-	entry := PoolEntry{ID: "c1", IP: "10.0.0.1", ResetPort: 9999}
-	if !p.Release(entry, "k") {
+	entry := PoolEntry{ID: "c1", IP: "10.0.0.1", ResetPort: 9999, Key: "k"}
+	if !p.Release(entry) {
 		t.Fatal("Release should succeed")
 	}
 	if len(*calls) != 1 || (*calls)[0].port != 9999 || (*calls)[0].ip != "10.0.0.1" {
@@ -244,8 +248,9 @@ func TestPoolPreservesLogFile(t *testing.T) {
 		IP:        "10.0.0.1",
 		LogFile:   "geth/client-deadbeef-full-id.log",
 		ResetPort: 8545,
+		Key:       "k",
 	}
-	if !p.Release(entry, "k") {
+	if !p.Release(entry) {
 		t.Fatal("Release should succeed")
 	}
 	got := p.Acquire("k")
@@ -260,12 +265,70 @@ func TestPoolPreservesLogFile(t *testing.T) {
 	}
 }
 
+// TestPoolAcquireRejectsStaleEntry verifies that when the daemon's TCP
+// probe fails (daemon died after Release), Acquire drops that entry,
+// schedules its container for async DeleteContainer, and walks back to
+// find the next live candidate in the same bucket. The cold-path
+// CheckLive wait is skipped on pool reuse, so this is the only thing
+// stopping a dead container from reaching the test.
+func TestPoolAcquireRejectsStaleEntry(t *testing.T) {
+	p, be, _ := poolWithStubReset(t, 4, nil)
+
+	// c1-dead is at IP .1, c2-alive at IP .2. Both share key "k".
+	dead := map[string]bool{"10.0.0.1": true}
+	p.probe = func(ip string, port uint16) error {
+		if dead[ip] {
+			return errStubResetFailed
+		}
+		return nil
+	}
+
+	// Release c2 first (becomes oldest), then c1 (becomes newest). Acquire
+	// scans newest-first, so it must trip on dead c1 before reaching c2.
+	if !p.Release(testEntry("c2", "10.0.0.2", "k")) {
+		t.Fatal("Release c2 should succeed")
+	}
+	if !p.Release(testEntry("c1", "10.0.0.1", "k")) {
+		t.Fatal("Release c1 should succeed")
+	}
+
+	got := p.Acquire("k")
+	if got == nil || got.ID != "c2" {
+		t.Fatalf("Acquire should walk past dead c1 to live c2, got %+v", got)
+	}
+	waitForEvictions(p)
+	if len(be.deletes) != 1 || be.deletes[0] != "c1" {
+		t.Fatalf("dead c1 should have been scheduled for delete, got %v", be.deletes)
+	}
+	if p.staleRejected != 1 {
+		t.Fatalf("staleRejected should be 1, got %d", p.staleRejected)
+	}
+}
+
+// TestPoolAcquireAllStaleReturnsNil verifies the loop terminates and
+// returns a miss when every candidate fails the probe.
+func TestPoolAcquireAllStaleReturnsNil(t *testing.T) {
+	p, be, _ := poolWithStubReset(t, 4, nil)
+	p.probe = func(string, uint16) error { return errStubResetFailed }
+
+	p.Release(testEntry("c1", "10.0.0.1", "k"))
+	p.Release(testEntry("c2", "10.0.0.2", "k"))
+
+	if got := p.Acquire("k"); got != nil {
+		t.Fatalf("all entries stale: Acquire should return nil, got %+v", got)
+	}
+	waitForEvictions(p)
+	if len(be.deletes) != 2 {
+		t.Fatalf("both stale entries should be scheduled for delete, got %v", be.deletes)
+	}
+}
+
 func TestPoolDrain(t *testing.T) {
 	p, be, _ := poolWithStubReset(t, 4, nil)
 
-	p.Release(testEntry("c1", "10.0.0.1"), "k1")
-	p.Release(testEntry("c2", "10.0.0.2"), "k2")
-	p.Release(testEntry("c3", "10.0.0.3"), "k1")
+	p.Release(testEntry("c1", "10.0.0.1", "k1"))
+	p.Release(testEntry("c2", "10.0.0.2", "k2"))
+	p.Release(testEntry("c3", "10.0.0.3", "k1"))
 
 	p.Drain(context.Background())
 
@@ -276,7 +339,7 @@ func TestPoolDrain(t *testing.T) {
 	if got := p.Acquire("k1"); got != nil {
 		t.Fatalf("Acquire after Drain should return nil, got %+v", got)
 	}
-	if p.Release(testEntry("c4", "10.0.0.4"), "k1") {
+	if p.Release(testEntry("c4", "10.0.0.4", "k1")) {
 		t.Fatal("Release after Drain should fail")
 	}
 }

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -1,6 +1,7 @@
 package libhive
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"errors"
@@ -48,6 +49,11 @@ type SimEnv struct {
 	// This configures the amount of time the simulation waits
 	// for the client to open port 8545 after launching the container.
 	ClientStartTimeout time.Duration
+
+	// ClientPoolSize controls the maximum number of stopped client
+	// containers retained per (image, env, genesis) bucket. Zero or
+	// negative disables pooling. See pool.go.
+	ClientPoolSize int
 }
 
 // SimResult summarizes the results of a simulation run.
@@ -71,6 +77,7 @@ type HiveInfo struct {
 type TestManager struct {
 	config     SimEnv
 	backend    ContainerBackend
+	clientPool *ClientPool
 	clientDefs []*ClientDefinition
 	hiveInfo   HiveInfo
 
@@ -130,6 +137,7 @@ func NewTestManager(config SimEnv, b ContainerBackend, clients []*ClientDefiniti
 		clientDefs:        clients,
 		config:            config,
 		backend:           b,
+		clientPool:        NewClientPool(b, config.ClientPoolSize),
 		hiveInfo:          hiveInfo,
 		hiveInstanceID:    GenerateHiveInstanceID(),
 		hiveVersion:       hiveInfo.Commit,
@@ -163,6 +171,12 @@ func (manager *TestManager) Results() map[TestSuiteID]*TestSuite {
 // API returns the simulation API handler.
 func (manager *TestManager) API() http.Handler {
 	return newSimulationAPI(manager.backend, manager.config, manager, manager.hiveInfo)
+}
+
+// ClientPool exposes the manager's pool. It is always non-nil; callers
+// should check Enabled() to decide whether to use it.
+func (manager *TestManager) ClientPool() *ClientPool {
+	return manager.clientPool
 }
 
 // IsTestSuiteRunning checks if the test suite is still running and returns it if so
@@ -205,8 +219,6 @@ func (manager *TestManager) Terminate() error {
 		Details: "Test was terminated by host",
 	}
 	manager.testSuiteMutex.Lock()
-	defer manager.testSuiteMutex.Unlock()
-
 	for suiteID, suite := range manager.runningTestSuites {
 		for testID := range suite.TestCases {
 			if _, running := manager.IsTestRunning(testID); running {
@@ -214,6 +226,7 @@ func (manager *TestManager) Terminate() error {
 				// any resources (e.g. docker containers).
 				err := manager.EndTest(suiteID, testID, terminationSummary)
 				if err != nil {
+					manager.testSuiteMutex.Unlock()
 					return err
 				}
 			}
@@ -221,7 +234,11 @@ func (manager *TestManager) Terminate() error {
 		// ensure the db is updated with results
 		manager.doEndSuite(suiteID)
 	}
+	manager.testSuiteMutex.Unlock()
 
+	// Drain any pooled containers — they were intentionally retained
+	// across tests but should not outlive the test manager.
+	manager.clientPool.Drain(context.Background())
 	return nil
 }
 
@@ -578,18 +595,39 @@ func (manager *TestManager) EndTest(suiteID TestSuiteID, testID TestID, result *
 		}
 	}
 
-	// Stop running clients.
+	// Stop running clients. disposeClient routes to the pool when
+	// applicable; otherwise force-removes the container.
 	for _, v := range testCase.ClientInfo {
 		if v.wait != nil {
-			manager.backend.DeleteContainer(v.ID)
-			v.wait()
-			v.wait = nil
+			manager.disposeClient(v)
 		}
 	}
 
 	// Delete from running, if it's still there.
 	delete(manager.runningTestCases, testID)
 	return nil
+}
+
+// disposeClient releases or deletes a client container at the end of a test.
+// If the container has a poolKey set and the pool's reset RPC succeeds, the
+// daemon stays up and the container is parked for the next matching test.
+// Otherwise we delete it and call its wait() to clean up the attach goroutine.
+//
+// The wait callback is always cleared so Terminate doesn't try again.
+func (manager *TestManager) disposeClient(c *ClientInfo) {
+	if c.poolKey != "" {
+		entry := PoolEntry{ID: c.ID, IP: c.IP}
+		if manager.clientPool.Release(entry, c.poolKey) {
+			// Warm-daemon path: container keeps running. Don't call wait()
+			// — that would block indefinitely. The original attach goroutine
+			// stays parked until pool Drain calls DeleteContainer at shutdown.
+			c.wait = nil
+			return
+		}
+	}
+	manager.backend.DeleteContainer(c.ID)
+	c.wait()
+	c.wait = nil
 }
 
 func (manager *TestManager) writeTestDetails(suite *TestSuite, testCase *TestCase, text string) *TestLogOffsets {
@@ -646,8 +684,16 @@ func (manager *TestManager) StopNode(testID TestID, nodeID string) error {
 	if !ok {
 		return ErrNoSuchNode
 	}
-	// Stop the container.
+	// Stop the container — let the pool's reset RPC handle the warm-daemon
+	// path when applicable; otherwise force-remove.
 	if nodeInfo.wait != nil {
+		if nodeInfo.poolKey != "" {
+			entry := PoolEntry{ID: nodeInfo.ID, IP: nodeInfo.IP}
+			if manager.clientPool.Release(entry, nodeInfo.poolKey) {
+				nodeInfo.wait = nil
+				return nil
+			}
+		}
 		if err := manager.backend.DeleteContainer(nodeInfo.ID); err != nil {
 			return fmt.Errorf("unable to stop client: %v", err)
 		}

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -621,8 +621,9 @@ func (manager *TestManager) disposeClient(c *ClientInfo) {
 			IP:        c.IP,
 			LogFile:   c.LogFile,
 			ResetPort: c.resetPort,
+			Key:       c.poolKey,
 		}
-		if manager.clientPool.Release(entry, c.poolKey) {
+		if manager.clientPool.Release(entry) {
 			// Warm-daemon path: container keeps running. Don't call wait()
 			// — that would block indefinitely. The original attach goroutine
 			// stays parked until pool Drain calls DeleteContainer at shutdown.
@@ -698,8 +699,9 @@ func (manager *TestManager) StopNode(testID TestID, nodeID string) error {
 				IP:        nodeInfo.IP,
 				LogFile:   nodeInfo.LogFile,
 				ResetPort: nodeInfo.resetPort,
+				Key:       nodeInfo.poolKey,
 			}
-			if manager.clientPool.Release(entry, nodeInfo.poolKey) {
+			if manager.clientPool.Release(entry) {
 				nodeInfo.wait = nil
 				return nil
 			}

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -616,7 +616,12 @@ func (manager *TestManager) EndTest(suiteID TestSuiteID, testID TestID, result *
 // The wait callback is always cleared so Terminate doesn't try again.
 func (manager *TestManager) disposeClient(c *ClientInfo) {
 	if c.poolKey != "" {
-		entry := PoolEntry{ID: c.ID, IP: c.IP}
+		entry := PoolEntry{
+			ID:        c.ID,
+			IP:        c.IP,
+			LogFile:   c.LogFile,
+			ResetPort: c.resetPort,
+		}
 		if manager.clientPool.Release(entry, c.poolKey) {
 			// Warm-daemon path: container keeps running. Don't call wait()
 			// — that would block indefinitely. The original attach goroutine
@@ -688,7 +693,12 @@ func (manager *TestManager) StopNode(testID TestID, nodeID string) error {
 	// path when applicable; otherwise force-remove.
 	if nodeInfo.wait != nil {
 		if nodeInfo.poolKey != "" {
-			entry := PoolEntry{ID: nodeInfo.ID, IP: nodeInfo.IP}
+			entry := PoolEntry{
+				ID:        nodeInfo.ID,
+				IP:        nodeInfo.IP,
+				LogFile:   nodeInfo.LogFile,
+				ResetPort: nodeInfo.resetPort,
+			}
 			if manager.clientPool.Release(entry, nodeInfo.poolKey) {
 				nodeInfo.wait = nil
 				return nil

--- a/simulators/ethereum/eels/consume-engine/Dockerfile
+++ b/simulators/ethereum/eels/consume-engine/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,12 +18,26 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv sync
 RUN uv run consume cache --input "$FIXTURES"
 
 

--- a/simulators/ethereum/eels/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eels/consume-rlp/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume rlp simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,13 +18,27 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
 RUN uv run consume cache --input "$FIXTURES"
-RUN uv sync
 
 ## Define `consume rlp` entry point using the local fixtures
 ENTRYPOINT uv run consume rlp -v --input "$FIXTURES"


### PR DESCRIPTION
**Opt-in via flag, default off.**

## What

Adds a `ClientPool` in `internal/libhive` that retains running client containers across tests, keyed by `(image, sanitized HIVE_* env, file contents, networks)`. Between tests, instead of stopping/removing the container, hive sends the client a JSON-RPC `debug_setHead(0)` to revert chain state to genesis. The next test that hashes to the same key reuses the already-running daemon — skipping `docker create + tar upload + client init + daemon boot`.

The pool is opt-in via `--client.pool.size N` (default `0` = off). With `0`, the new code paths are short-circuited and behaviour is byte-identical to the current fresh-container flow.

## Why

EEST `consume-engine` tests average ~2 s wall per test on bare-metal CI runners. ~1.9 s of that is overhead — the actual engine-API work (one `newPayload` for height-1) takes ~100 ms. On corpora with high pre-state reuse (cancun/osaka/prague where static state tests share allocations), the pool can hit 40–50% of the time and skip almost all that overhead.

Measured Erigon improvement on the EEST consume-engine shards (parallelism=12, full hive-eest workflow run on bare-metal Linux). `pool.size` was tuned per shard from a trace-instrumented run + offline LRU simulation; the access pattern is depth-2 consecutive, so `4` captures all available reuse and bigger caches buy nothing:

| Shard | `pool.size` | Baseline | With pool | Δ | Hit rate |
|---|---|---|---|---|---|
| cancun | 4 | 52.2 min | **18.0 min** | **−65.5%** | 49.6% |
| prague | 4 | 61.0 min | **22.4 min** | **−63.4%** | 42.3% |
| osaka | 4 | 63.0 min | **23.6 min** | **−62.6%** | 40.8% |
| glamsterdam-devnet | 24 | 8.5 min | **6.5 min** | −22.9% | 13.8% |
| paris+shanghai | 0 | 13.5 min | 12.3 min | −8.8% (variance) | n/a |
| consume-rlp | 0 | 32.3 min | 31.1 min | −3.9% (variance) | n/a |

paris+shanghai and consume-rlp have ~unique pre-state per test (~0% hit at any pool size). They run with `--client.pool.size=0`, fully short-circuiting the new code paths.

**Net effect**: hive-eest pacemaker dropped from 63 min → 24 min, a **2.7× speedup** on the merge-queue gate.

## Design

### Pool key

`sha256(image || sorted-HIVE_*-env || sorted-files-with-content || sorted-networks)`. Two tests are interchangeable iff their client startup would be byte-identical: same image, same flags, same uploaded files (genesis.json/chain.rlp/etc), same docker network membership. Networks are part of the key because the warm path skips `ConnectContainer`.

### Global cap with LRU eviction

Every parked container holds a live daemon (~150 MB RAM each). On a low-reuse workload with thousands of unique keys, a per-bucket cap would let the pool accumulate thousands of running daemons and exhaust the docker daemon. So the cap is *global*: when a `Release` would exceed `--client.pool.size`, the LRU front (oldest entry across all buckets) is evicted (`DeleteContainer`).

Entries are stored in a single global LRU list. Acquire scans the list back-to-front for a key match (LIFO so hottest first); with `pool.size` bounded (~24 in practice) the scan is trivially fast vs the docker calls it replaces. Eviction pops the front (oldest); insertion appends to the back.

`DeleteContainer` runs in a background goroutine tracked by a `sync.WaitGroup` so it doesn't serialize the test-end hot path; `Drain` at hive shutdown waits on the group so all evictions complete before reporting clean.

### Reset RPC

Default reset POSTs to `http://<container-ip>:<port>/` with
```json
{"jsonrpc":"2.0","method":"debug_setHead","params":["0x0"],"id":1}
```

`<port>` comes from the cold-path `options.CheckLive` (i.e. `HIVE_CHECK_LIVE_PORT`, default 8545) — the same port the cold path's liveness check uses. It's stashed on `PoolEntry.ResetPort` at startup so disposeClient can build a complete entry without re-parsing env.

Erigon, Geth, Reth, Nethermind, Besu all support `debug_setHead` or an equivalent. Clients that don't can keep `--client.pool.size=0`.

The reset function is injectable for testing — `pool_test.go` swaps in a stub that records IPs without opening a socket.

### Suitability

`debug_setHead(0)` only rewinds the canonical chain head. It does **not** clear:
- txpool entries
- RPC subscriptions / log filters
- miner state
- peer lists
- in-memory caches

Pooling is therefore safe for **near-stateless workloads** (e.g. EEST consume-engine: each test is one `newPayload` from genesis with no txpool / subscription / mining activity) and unsafe for tests that mutate any of the above. Workloads that don't fit should keep `--client.pool.size=0`. The flag help text spells this out so adopters don't enable pooling on something it can't handle.

### Liveness

The cold path waits on a port-readiness check (`CheckLive`) before declaring the container started. The warm path skips that — synthesises `ContainerInfo` directly from the pool entry. Without further care, a daemon that died between Release and Acquire (OOM, panic, host pressure) would be silently handed back; the next test would issue an RPC that hangs or refuses.

To close that gap, `Acquire` runs a 500ms TCP probe (`net.DialTimeout` against `<ip>:<resetPort>`) on each candidate before returning it. On probe failure the entry is dropped, the container scheduled for async `DeleteContainer` (reusing the eviction WaitGroup), and Acquire walks back to the next live candidate in the same bucket. Loop is bounded by list length. This isn't an RPC roundtrip — the dial succeeding is sufficient evidence the listen socket is up; the inevitable `debug_setHead` at end-of-test exercises the JSON-RPC layer and rejects entries that pass the dial but can't answer.

### Drain ↔ Release ordering

`Release` and `Acquire` (on stale-rejection) both spawn background `DeleteContainer` goroutines tracked by a `sync.WaitGroup`. `Drain` flips a `closed` flag under the pool mutex, then `Wait()`s. Each goroutine spawn does its `wg.Add(1)` *while holding the same mutex, after a `closed` check*, so any goroutine visible to a future caller was either added before Drain saw the WaitGroup or short-circuited by the closed check. No "spawned-but-not-counted" window.

## Files

| File | Change |
|---|---|
| `internal/libhive/pool.go` | new — `ClientPool`, `PoolEntry` (ID/IP/LogFile/ResetPort/Key), `ComputePoolKey`, `defaultReset`, `defaultProbe` |
| `internal/libhive/pool_test.go` | new — 10 unit tests covering LIFO, global-cap eviction, LRU refresh on Acquire, reset failure, ResetPort propagation/rejection, log-file round-trip, network keying, two stale-probe paths, drain |
| `internal/libhive/api.go` | `startClient` consults pool; on hit, skips `CreateContainer`, `StartContainer`, `ConnectContainer` and synthesises `ContainerInfo` from the entry; reuses original LogFile path |
| `internal/libhive/data.go` | `poolKey` + `resetPort` fields on `ClientInfo` (so EndTest/StopNode can build a complete `PoolEntry`) |
| `internal/libhive/testmanager.go` | pool plumbed through `TestManager`; `EndTest` / `StopNode` route to `Pool.Release` (warm) or `DeleteContainer` (cold); `Drain` on `Terminate` (after the testSuiteMutex is released) |
| `hive.go` | `--client.pool.size` flag, default 0; help text covers suitability |

No changes to `internal/libdocker/`, `internal/fakes/`, `dockerface.go`, or any client `Dockerfile`/script.

## Test plan

- [x] `go test ./...` — all existing tests pass; 10 pool unit tests pass under `-race -count=3`.
- [x] End-to-end on bare-metal CI: 7 dispatches across 6 shards (Erigon's `test-hive-eest.yml` workflow, full EEST corpus). Latest run green, results above.
- [x] Trace-instrumented dispatch + offline LRU simulation to size the pool from data, not guesses.
- [ ] Tested with go-ethereum / nethermind / etc. — not yet; the pool is opt-in and default-off, so this PR doesn't gate on them.

## Out of scope

- An alternative reset hook for clients that don't expose `debug_setHead`. The major execution clients (geth, reth, nethermind, besu, erigon) all support it, so the inline RPC is the right default. If a future client doesn't, a pluggable per-client reset (e.g. a `/hive-reset.sh` script in the client image) could replace the inline call. Not needed for any client we currently care about.

- A more radical "load arbitrary genesis on a running daemon" RPC. That would let the pool drop the genesis-bytes component of the key and converge to ~100% hit rate even on procedurally-generated tests with unique pre-states. Real win, but needs a co-operating client-side change outside this PR's scope.
