### PR TITLE
clients/nethermind: add EIP-7976 and EIP-7981 transition timestamps

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -180,6 +180,8 @@ def clique_engine:
     "eip7843TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip7928TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip7954TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
+    "eip7976TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
+    "eip7981TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip8024TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip8037TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
 


### PR DESCRIPTION
## Summary

Adds two missing Nethermind chainspec transition timestamps activated at the Amsterdam fork:

- `eip7976TransitionTimestamp` — EIP-7976: Increase Calldata Floor Cost
- `eip7981TransitionTimestamp` — EIP-7981: Increase Access List Cost

## Why

Nethermind already reads both keys in [`ChainSpecParamsJson.cs`](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs#L164-L165) and toggles `IsEip7976Enabled` / `IsEip7981Enabled` from them in [`ChainSpecBasedSpecProvider`](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs#L281-L282).

Without these fields in the generated chainspec, hive-driven Nethermind runs the Amsterdam fork without the new calldata-floor and access-list gas rules and diverges from clients (e.g. geth) that activate both EIPs at the Amsterdam timestamp.

Same pattern as #1410 (EIP-7954 / EIP-8037).

## Test plan

- [ ] Run an EELS / engine simulator against `nethermind:bal-devnet-4` to confirm Amsterdam-block gas accounting matches geth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)