### PR TITLE
clients/go-ethereum: restore amsterdam entry in blobSchedule

### DIFF
--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -76,6 +76,11 @@ def to_bool:
         "max": (if env.HIVE_OSAKA_BLOB_MAX then env.HIVE_OSAKA_BLOB_MAX|to_int else 9 end),
         "baseFeeUpdateFraction": (if env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 5007716 end)
       },
+      "amsterdam": {
+        "target": (if env.HIVE_AMSTERDAM_BLOB_TARGET then env.HIVE_AMSTERDAM_BLOB_TARGET|to_int else 14 end),
+        "max": (if env.HIVE_AMSTERDAM_BLOB_MAX then env.HIVE_AMSTERDAM_BLOB_MAX|to_int else 21 end),
+        "baseFeeUpdateFraction": (if env.HIVE_AMSTERDAM_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_AMSTERDAM_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 11684671 end)
+      },
       "bpo1": {
         "target": (if env.HIVE_BPO1_BLOB_TARGET then env.HIVE_BPO1_BLOB_TARGET|to_int else 10 end),
         "max": (if env.HIVE_BPO1_BLOB_MAX then env.HIVE_BPO1_BLOB_MAX|to_int else 15 end),


### PR DESCRIPTION
## Summary

Re-adds the `amsterdam` entry to geth's genesis `blobSchedule`. The entry was removed in #1387, but geth's chain-config validator still rejects genesis files where `amsterdamTime` is set without `blobSchedule.amsterdam`, so any hive simulator targeting an Amsterdam-active devnet (bal-devnet-4, glamsterdam-devnet-N, …) fails immediately at:

```
Fatal: Failed to write genesis block: invalid chain configuration:
missing entry for fork "amsterdam" in blobSchedule
```

The validation lives in [`params/config.go::checkBlobSchedule`](https://github.com/ethereum/go-ethereum/blob/bal-devnet-4/params/config.go#L1011-L1023): if a fork timestamp is set, the corresponding blob-schedule entry must be non-nil.

## Why

Even though #1387 dropped the named-fork blob defaults from the mapper, geth on `bal-devnet-4` (and `glamsterdam-devnet-0`) hasn't yet relaxed the validator to make Amsterdam optional, so hive currently can't bring up geth on those devnets at all. Restoring the entry here is the minimum-impact fix while a future geth PR (or a follow-up hive change) decides on the long-term shape of the blob schedule for named forks.

Defaults follow the bpo2 cadence (`target=14`, `max=21`, `baseFeeUpdateFraction=11684671`), and are overridable per-test via:
- `HIVE_AMSTERDAM_BLOB_TARGET`
- `HIVE_AMSTERDAM_BLOB_MAX`
- `HIVE_AMSTERDAM_BLOB_BASE_FEE_UPDATE_FRACTION`

## Test plan

- [ ] `hive --client go-ethereum` against any Amsterdam-active simulator (e.g. `eels/consume-engine` with bal-devnet-4 fixtures) reaches the running state instead of dying at `geth init`.
- [ ] Set `HIVE_AMSTERDAM_BLOB_TARGET`/`_MAX`/`_BASE_FEE_UPDATE_FRACTION` and confirm overrides land in the generated genesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)