### PR TITLE
clients/qlean: static exe and simple cli flags

### DIFF
--- a/clients/qlean/Dockerfile
+++ b/clients/qlean/Dockerfile
@@ -7,18 +7,16 @@ FROM $devnet4_baseimage:$devnet4_tag AS devnet4
 
 FROM $devnet3_baseimage:$devnet3_tag
 
-RUN mkdir -p /opt/qlean-d3/bin && \
-    cp -a /opt/qlean/. /opt/qlean-d3/ || true && \
-    (cp /usr/local/bin/qlean /opt/qlean-d3/bin/qlean-devnet3 || \
-     cp $(find /opt/qlean-d3 -name qlean -type f -executable | head -n 1) /opt/qlean-d3/bin/qlean-devnet3)
-
-RUN mkdir -p /opt/qlean-d4/bin
-COPY --from=devnet4 /opt/qlean /opt/qlean-d4
-RUN (cp $(find /opt/qlean-d4 -name qlean -type f -executable | head -n 1) /opt/qlean-d4/bin/qlean-devnet4)
+RUN cp /opt/qlean/bin/qlean /usr/local/bin/qlean-devnet3
+COPY --from=devnet4 /opt/qlean/bin/qlean /usr/local/bin/qlean-devnet4
 
 COPY qlean.sh /qlean.sh
 RUN chmod +x /qlean.sh \
-    && qlean --version | head -1 > /version.txt
+    && /usr/local/bin/qlean-devnet3 --version | head -1 > /version-devnet3.txt \
+    && /usr/local/bin/qlean-devnet4 --version | head -1 > /version-devnet4.txt \
+    && printf "qlean devnet3: %s\nqlean devnet4: %s\n" \
+        "$(cat /version-devnet3.txt)" \
+        "$(cat /version-devnet4.txt)" > /version.txt
 
 EXPOSE 5052 9000/udp 8080
 

--- a/clients/qlean/qlean.sh
+++ b/clients/qlean/qlean.sh
@@ -3,36 +3,21 @@ set -euo pipefail
 
 DEVNET_LABEL="${HIVE_LEAN_DEVNET_LABEL:-devnet3}" 
 ASSET_ROOT="/tmp/qlean-runtime" 
-WORKSPACE="/opt/qlean" 
-REAL_MODS="/opt/qlean_internal_storage" 
 
-if [[ "$DEVNET_LABEL" == "devnet4" ]]; then 
-    SOURCE_DIR="/opt/qlean-d4" 
-    QLEAN_BIN_NAME="qlean-devnet4" 
-    MANIFEST_NAME="validator-keys-manifest-devnet4.yaml" 
-    QLEAN_USES_GENESIS_DIR=1
-else 
-    SOURCE_DIR="/opt/qlean-d3" 
-    QLEAN_BIN_NAME="qlean-devnet3" 
-    MANIFEST_NAME="validator-keys-manifest.yaml" 
-    QLEAN_USES_GENESIS_DIR=0
-fi 
+case "$DEVNET_LABEL" in
+    devnet3)
+        DEFAULT_QLEAN_BIN="/usr/local/bin/qlean-devnet3"
+        ;;
+    devnet4)
+        DEFAULT_QLEAN_BIN="/usr/local/bin/qlean-devnet4"
+        ;;
+    *)
+        echo "Unsupported Lean devnet label: $DEVNET_LABEL" >&2
+        exit 1
+        ;;
+esac
 
-rm -rf "$WORKSPACE" "$REAL_MODS" 
-mkdir -p "$WORKSPACE/bin" "$WORKSPACE/lib" "$WORKSPACE/modules" "$REAL_MODS" 
-
-cp "$SOURCE_DIR/bin/$QLEAN_BIN_NAME" "$WORKSPACE/bin/" 
-cp "$SOURCE_DIR"/lib/*.so* "$WORKSPACE/lib/" 2>/dev/null || true 
-
-mkdir -p "$WORKSPACE/internal_modules" 
-
-find "$SOURCE_DIR/modules" -maxdepth 1 -type f -name "*_module.so" -exec cp {} "$REAL_MODS/" \; 
-
-for mod in "$REAL_MODS"/*_module.so; do 
-    ln -s "$mod" "$WORKSPACE/internal_modules/$(basename "$mod")" 
-done 
-
-QLEAN_BIN="$WORKSPACE/bin/$QLEAN_BIN_NAME" 
+QLEAN_BIN="${QLEAN_BIN:-$DEFAULT_QLEAN_BIN}"
 
 V_IDX="${HIVE_VALIDATOR_INDEX:-0}" 
 RAW_ID="${HIVE_NODE_ID:-${HIVE_CLIENT_ID:-qlean_$V_IDX}}" 
@@ -49,7 +34,7 @@ find "$ASSET_ROOT" -type f \( -name "*.yaml" -o -name "*.json" \) -exec sed -i '
 NODE_KEY="$(cat "$ASSET_ROOT/node.key")"
 
 FLAGS=( 
-    --modules-dir "$WORKSPACE/internal_modules" 
+    --genesis-dir "$ASSET_ROOT"
     --data-dir "/data" 
     --node-id "$CLEAN_NODE_ID" 
     --node-key "$NODE_KEY"
@@ -57,21 +42,6 @@ FLAGS=(
     --api-host "0.0.0.0" 
     --api-port 5052 
 ) 
-
-if [[ "$QLEAN_USES_GENESIS_DIR" == "1" ]]; then
-    FLAGS+=(
-        --genesis-dir "$ASSET_ROOT"
-        --bootnodes "$ASSET_ROOT/nodes.yaml"
-    )
-else
-    FLAGS+=(
-        --genesis "$ASSET_ROOT/config.yaml"
-        --validator-registry-path "$ASSET_ROOT/validators.yaml"
-        --validator-keys-manifest "$ASSET_ROOT/hash-sig-keys/$MANIFEST_NAME"
-        --xmss-pk "$ASSET_ROOT/hash-sig-keys/v${V_IDX}_att.pk"
-        --xmss-sk "$ASSET_ROOT/hash-sig-keys/v${V_IDX}_att.sk"
-    )
-fi
 
 if [ "${HIVE_IS_AGGREGATOR:-0}" = "1" ]; then
     FLAGS+=(--is-aggregator)


### PR DESCRIPTION
- Qlean was distributed as executable file and dynamic libraries (lib, modules).
  Changed to single static executable file to simplify deployment.
  Backported to [`devnet3` branch](https://github.com/qdrvm/qlean-mini/tree/devnet3) and [`devnet-3` docker tag](https://hub.docker.com/layers/qdrvm/qlean-mini/devnet-3).
- Qlean devnet3 was using separate cli flags for each file in genesis directory.
  Qlean devnet4 simplified this to single `--genesis-dir` cli flag.
  Backported to [`devnet3` branch](https://github.com/qdrvm/qlean-mini/tree/devnet3) and [`devnet-3` docker tag](https://hub.docker.com/layers/qdrvm/qlean-mini/devnet-3).
- Updated clients/qlean docker and script