### PR TITLE
cmd/hiveview: Lean latest test grid page

### DIFF
--- a/cmd/hiveview/assets/lean-latest.html
+++ b/cmd/hiveview/assets/lean-latest.html
@@ -38,7 +38,10 @@
             <h1>Lean latest</h1>
             <p id="lean-latest-subtitle" class="text-secondary"></p>
           </div>
-          <div id="lean-latest-summary" class="lean-latest-summary"></div>
+          <div class="lean-latest-summary-panel">
+            <div id="lean-latest-summary" class="lean-latest-summary"></div>
+            <div id="lean-latest-devnets" class="lean-devnet-controls"></div>
+          </div>
         </div>
         <div id="lean-latest-error" class="alert alert-danger" style="display: none"></div>
         <div id="lean-latest-content"></div>

--- a/cmd/hiveview/assets/lean-latest.html
+++ b/cmd/hiveview/assets/lean-latest.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="dark">
   <head>
-    <title>hive</title>
+    <title>Lean latest - hive</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="icon" href="images/favicon.svg">
@@ -9,13 +9,13 @@
   </head>
 
   <body>
-    <script src="lib/app-index.js" type="module"></script>
+    <script src="lib/app-lean-latest.js" type="module"></script>
     <main role="main">
       <div id="hive-header">
         <a href="index.html"><img id="hive-logo" height="35" src="images/hive3.svg"></a>
         <nav id="hive-static-nav">
-          <a class="nav-item btn btn-sm btn-secondary lean-latest-nav" id="lean-latest-nav-link" href="lean-latest" style="display: none">Lean latest</a>
           <span class="nav-item" id="hive-instance-info"></span>
+          <a class="nav-item" href="index.html">Runs</a>
           <a class="nav-item" href="https://github.com/ethereum/hive/blob/master/docs/overview.md#what-is-hive">What is Hive?</a>
           <span class="nav-item theme-toggle">🌙</span>
         </nav>
@@ -32,12 +32,16 @@
         </div>
       </div>
 
-      <div class="script-content">
-        <div id="summary-section" class="mb-3">
-          <div id="suite-summary" class="d-flex flex-wrap"></div>
+      <div class="script-content lean-latest-page">
+        <div class="lean-latest-title-row">
+          <div>
+            <h1>Lean latest</h1>
+            <p id="lean-latest-subtitle" class="text-secondary"></p>
+          </div>
+          <div id="lean-latest-summary" class="lean-latest-summary"></div>
         </div>
-        <p id="filters-notice" style="display: none">Note: column filters are active: <a id="filters-clear" href="">[Clear Filters]</a></p>
-        <table id="filetable" class="table table-bordered"></table>
+        <div id="lean-latest-error" class="alert alert-danger" style="display: none"></div>
+        <div id="lean-latest-content"></div>
       </div>
     </main>
   </body>

--- a/cmd/hiveview/assets/lib/app-common.js
+++ b/cmd/hiveview/assets/lib/app-common.js
@@ -24,6 +24,8 @@ $(document).ready(function() {
 
 // updateHeader populates the page header with version information from hive.json.
 export function updateHeader() {
+    updateFeatureNav();
+
     $.ajax({
         type: 'GET',
         url: routes.resultsRoot + 'hive.json',
@@ -35,6 +37,26 @@ export function updateHeader() {
         },
         error: function(xhr, status, error) {
             console.log('error fetching hive.json:', error);
+        },
+    });
+}
+
+function updateFeatureNav() {
+    const link = $('#lean-latest-nav-link');
+    if (!link.length) {
+        return;
+    }
+
+    $.ajax({
+        type: 'GET',
+        url: 'features.json',
+        dataType: 'json',
+        cache: false,
+        success: function(features) {
+            link.toggle(!!features.leanLatest);
+        },
+        error: function(xhr, status, error) {
+            console.log('error fetching features.json:', error);
         },
     });
 }

--- a/cmd/hiveview/assets/lib/app-lean-latest.js
+++ b/cmd/hiveview/assets/lib/app-lean-latest.js
@@ -6,6 +6,11 @@ import { formatDuration } from './utils.js';
 
 const listingURL = 'listing.jsonl?limit=1000';
 const preferredSuiteOrder = ['client-interop', 'rpc-compat', 'sync', 'validation', 'gossip', 'reqresp'];
+const leanLatestState = {
+    entries: [],
+    devnets: [],
+    selectedDevnet: '',
+};
 
 $(document).ready(function () {
     common.updateHeader();
@@ -18,19 +23,40 @@ async function loadLeanLatest() {
 
     try {
         const listingText = await loadText(listingURL);
-        const entries = latestSuiteEntries(parseListing(listingText));
+        const entries = prepareEntries(parseListing(listingText));
         if (entries.length === 0) {
             renderEmptyState('No lean suite runs found.');
             return;
         }
 
-        const matrices = await Promise.all(entries.map(loadSuiteMatrices));
-        renderLeanLatest(matrices.flat().filter(Boolean));
+        leanLatestState.entries = entries;
+        leanLatestState.devnets = collectDevnets(entries);
+        const selectedDevnet = selectedDevnetFromURL(leanLatestState.devnets) || defaultDevnet(leanLatestState.devnets);
+        await renderSelectedDevnet(selectedDevnet, false);
     } catch (err) {
         showError(`Unable to load lean latest results: ${err.message || err}`);
     } finally {
         $('#loading-container').removeClass('show');
     }
+}
+
+async function renderSelectedDevnet(devnet, updateURL) {
+    leanLatestState.selectedDevnet = devnet || '';
+    if (updateURL) {
+        updateDevnetURL(leanLatestState.selectedDevnet);
+    }
+    renderDevnetControls(leanLatestState.devnets, leanLatestState.selectedDevnet);
+
+    const entries = entriesForDevnet(leanLatestState.entries, leanLatestState.selectedDevnet);
+    const latestEntries = latestSuiteEntries(entries);
+    if (latestEntries.length === 0) {
+        const suffix = leanLatestState.selectedDevnet ? ` for ${leanLatestState.selectedDevnet}` : '';
+        renderEmptyState(`No lean suite runs found${suffix}.`);
+        return;
+    }
+
+    const matrices = await Promise.all(latestEntries.map(loadSuiteMatrices));
+    renderLeanLatest(matrices.flat().filter(Boolean), leanLatestState.selectedDevnet);
 }
 
 async function loadSuiteMatrices(entry) {
@@ -70,6 +96,94 @@ function parseListing(data) {
         }
         return entries;
     }, []);
+}
+
+function prepareEntries(entries) {
+    return entries.map(entry => ({
+        ...entry,
+        devnet: normalizeDevnet(entry.devnet) || devnetFromEntry(entry),
+    }));
+}
+
+function collectDevnets(entries) {
+    const devnets = new Set();
+    entries.forEach(entry => {
+        if (entry.devnet) {
+            devnets.add(entry.devnet);
+        }
+    });
+    return Array.from(devnets).sort(compareDevnets);
+}
+
+function entriesForDevnet(entries, devnet) {
+    if (!devnet) {
+        return entries;
+    }
+    return entries.filter(entry => entry.devnet === devnet);
+}
+
+function selectedDevnetFromURL(devnets) {
+    const params = new URLSearchParams(window.location.search);
+    const devnet = normalizeDevnet(params.get('devnet'));
+    return devnets.includes(devnet) ? devnet : '';
+}
+
+function defaultDevnet(devnets) {
+    return devnets[devnets.length - 1] || '';
+}
+
+function updateDevnetURL(devnet) {
+    const url = new URL(window.location.href);
+    if (devnet) {
+        url.searchParams.set('devnet', devnet);
+    } else {
+        url.searchParams.delete('devnet');
+    }
+    window.history.replaceState(null, '', url);
+}
+
+function devnetFromEntry(entry) {
+    for (const client of entry.clients || []) {
+        const devnet = normalizeDevnet(client);
+        if (devnet) {
+            return devnet;
+        }
+    }
+    for (const client of Object.keys(entry.versions || {})) {
+        const devnet = normalizeDevnet(client);
+        if (devnet) {
+            return devnet;
+        }
+    }
+    return '';
+}
+
+function normalizeDevnet(value) {
+    if (!value || typeof value !== 'string') {
+        return '';
+    }
+    const match = value.match(/(?:^|[^a-z0-9])(devnet[0-9][a-z0-9_-]*)/i);
+    return match ? match[1].toLowerCase() : '';
+}
+
+function compareDevnets(a, b) {
+    const left = devnetSortParts(a);
+    const right = devnetSortParts(b);
+    if (left.number !== right.number) {
+        return left.number - right.number;
+    }
+    return left.suffix.localeCompare(right.suffix) || a.localeCompare(b);
+}
+
+function devnetSortParts(devnet) {
+    const match = devnet.match(/^devnet([0-9]+)(.*)$/i);
+    if (!match) {
+        return { number: Number.MAX_SAFE_INTEGER, suffix: devnet };
+    }
+    return {
+        number: Number.parseInt(match[1], 10),
+        suffix: match[2] || '',
+    };
 }
 
 function latestSuiteEntries(entries) {
@@ -407,7 +521,7 @@ function isSuiteSetupTest(test, suiteName) {
     return /:\s*client launch$/i.test(name);
 }
 
-function renderLeanLatest(matrices) {
+function renderLeanLatest(matrices, devnet) {
     if (matrices.length === 0) {
         renderEmptyState('No lean suite runs found.');
         return;
@@ -419,7 +533,8 @@ function renderLeanLatest(matrices) {
             .filter(matrix => matrix.stats.failed > 0)
             .map(matrix => matrix.linkSuiteName || matrix.suiteName)
     ).size;
-    $('#lean-latest-subtitle').text(`Latest runs for ${suiteNames.size} suites.`);
+    const devnetLabel = devnet ? `${devnet} ` : '';
+    $('#lean-latest-subtitle').text(`Latest ${devnetLabel}runs for ${suiteNames.size} suites.`);
     $('#lean-latest-summary').empty()
         .append(summaryPill('Suites', suiteNames.size))
         .append(summaryPill('Failing', failingSuites, failingSuites > 0 ? 'danger' : 'success'));
@@ -427,6 +542,39 @@ function renderLeanLatest(matrices) {
     const content = $('#lean-latest-content').empty();
     matrices.forEach(matrix => {
         content.append(renderSuiteSection(matrix));
+    });
+}
+
+function renderDevnetControls(devnets, selectedDevnet) {
+    const controls = $('#lean-latest-devnets').empty();
+    if (!controls.length || devnets.length === 0) {
+        return;
+    }
+
+    devnets.forEach(devnet => {
+        const active = devnet === selectedDevnet;
+        const button = $('<button />')
+            .attr('type', 'button')
+            .addClass('btn btn-sm btn-secondary lean-devnet-button')
+            .toggleClass('active', active)
+            .attr('aria-pressed', active ? 'true' : 'false')
+            .text(devnet)
+            .on('click', async function() {
+                if (leanLatestState.selectedDevnet === devnet) {
+                    return;
+                }
+
+                $('#loading-container').addClass('show');
+                $('#lean-latest-error').hide();
+                try {
+                    await renderSelectedDevnet(devnet, true);
+                } catch (err) {
+                    showError(`Unable to load ${devnet} results: ${err.message || err}`);
+                } finally {
+                    $('#loading-container').removeClass('show');
+                }
+            });
+        controls.append(button);
     });
 }
 

--- a/cmd/hiveview/assets/lib/app-lean-latest.js
+++ b/cmd/hiveview/assets/lib/app-lean-latest.js
@@ -1,0 +1,616 @@
+import $ from 'jquery';
+
+import * as common from './app-common.js';
+import * as routes from './routes.js';
+import { formatDuration } from './utils.js';
+
+const listingURL = 'listing.jsonl?limit=1000';
+const preferredSuiteOrder = ['client-interop', 'rpc-compat', 'sync', 'validation', 'gossip', 'reqresp'];
+
+$(document).ready(function () {
+    common.updateHeader();
+    loadLeanLatest();
+});
+
+async function loadLeanLatest() {
+    $('#loading-container').addClass('show');
+    $('#lean-latest-error').hide();
+
+    try {
+        const listingText = await loadText(listingURL);
+        const entries = latestSuiteEntries(parseListing(listingText));
+        if (entries.length === 0) {
+            renderEmptyState('No lean suite runs found.');
+            return;
+        }
+
+        const matrices = await Promise.all(entries.map(loadSuiteMatrices));
+        renderLeanLatest(matrices.flat().filter(Boolean));
+    } catch (err) {
+        showError(`Unable to load lean latest results: ${err.message || err}`);
+    } finally {
+        $('#loading-container').removeClass('show');
+    }
+}
+
+async function loadSuiteMatrices(entry) {
+    const suiteData = await loadJSON(routes.resultsRoot + entry.fileName);
+    return buildSuiteMatrices(entry, suiteData);
+}
+
+async function loadText(url) {
+    const response = await fetch(url, { cache: 'no-store' });
+    if (!response.ok) {
+        throw new Error(`${url} returned ${response.status}`);
+    }
+    return response.text();
+}
+
+async function loadJSON(url) {
+    const response = await fetch(url, { cache: 'no-store' });
+    if (!response.ok) {
+        throw new Error(`${url} returned ${response.status}`);
+    }
+    return response.json();
+}
+
+function parseListing(data) {
+    return data.split('\n').reduce((entries, line) => {
+        line = line.trim();
+        if (!line) {
+            return entries;
+        }
+
+        try {
+            const entry = JSON.parse(line);
+            entry.startDate = parseDate(entry.start);
+            entries.push(entry);
+        } catch (err) {
+            console.warn('Skipping invalid listing entry:', err);
+        }
+        return entries;
+    }, []);
+}
+
+function latestSuiteEntries(entries) {
+    const latest = new Map();
+    entries.forEach(entry => {
+        if (!entry.name) {
+            return;
+        }
+
+        const previous = latest.get(entry.name);
+        if (!previous || compareDates(entry.startDate, previous.startDate) > 0) {
+            latest.set(entry.name, entry);
+        }
+    });
+    return Array.from(latest.values()).sort(compareSuites);
+}
+
+function compareSuites(a, b) {
+    const ar = suiteRank(a.name);
+    const br = suiteRank(b.name);
+    if (ar !== br) {
+        return ar - br;
+    }
+    return a.name.localeCompare(b.name);
+}
+
+function suiteRank(name) {
+    const index = preferredSuiteOrder.indexOf(name);
+    return index === -1 ? preferredSuiteOrder.length : index;
+}
+
+function buildSuiteMatrices(entry, suiteData) {
+    if ((suiteData.name || entry.name) === 'client-interop') {
+        return buildClientInteropMatrices(entry, suiteData);
+    }
+    return [buildSuiteMatrix(entry, suiteData)];
+}
+
+function buildSuiteMatrix(entry, suiteData) {
+    const suiteName = suiteData.name || entry.name;
+    const cases = Object.entries(suiteData.testCases || {})
+        .map(([testIndex, test]) => ({
+            ...test,
+            testIndex,
+            numericIndex: numericTestIndex(testIndex),
+        }))
+        .sort((a, b) => a.numericIndex - b.numericIndex || testName(a).localeCompare(testName(b)));
+
+    const rowMap = new Map();
+
+    cases.forEach(test => {
+        const clients = clientNamesForTest(test);
+        if (clients.length === 0) {
+            return;
+        }
+
+        const name = testName(test);
+        if (!rowMap.has(name)) {
+            rowMap.set(name, {
+                name,
+                order: test.numericIndex,
+                cells: new Map(),
+            });
+        }
+
+        const row = rowMap.get(name);
+        row.order = Math.min(row.order, test.numericIndex);
+
+        clients.forEach(clientName => {
+            if (!row.cells.has(clientName)) {
+                row.cells.set(clientName, []);
+            }
+            row.cells.get(clientName).push(test);
+        });
+    });
+
+    const clients = collectClients(entry, suiteData, cases);
+
+    return {
+        entry,
+        suiteData,
+        suiteName,
+        clients,
+        cases,
+        rowHeaderLabel: 'Test',
+        rows: Array.from(rowMap.values()).sort((a, b) => a.order - b.order || a.name.localeCompare(b.name)),
+        stats: suiteStats(cases, suiteName),
+    };
+}
+
+function buildClientInteropMatrices(entry, suiteData) {
+    const suiteName = suiteData.name || entry.name;
+    const cases = Object.entries(suiteData.testCases || {})
+        .map(([testIndex, test]) => ({
+            ...test,
+            testIndex,
+            numericIndex: numericTestIndex(testIndex),
+            topology: clientInteropTopology(test),
+        }))
+        .sort((a, b) => a.numericIndex - b.numericIndex || testName(a).localeCompare(testName(b)));
+
+    const topologyCases = cases
+        .map(test => ({
+            ...test,
+            roles: clientInteropRoles(test.topology),
+        }))
+        .filter(test => test.roles);
+
+    const clients = collectClients(entry, suiteData, topologyCases);
+    const clientOrder = clientOrderMap(clients);
+    const rows = buildClientInteropRows(topologyCases, 'majority', 'minority', clientOrder, 'maj');
+
+    return [{
+        entry,
+        suiteData,
+        suiteName,
+        linkSuiteName: suiteName,
+        clients: roleLabelClients(clients, 'min'),
+        cases,
+        rowHeaderLabel: '',
+        rowRoleLabel: 'majority',
+        columnRoleLabel: 'minority',
+        rows,
+        stats: suiteStats(cases, suiteName),
+        emptyMessage: 'No client-interop topology tests with client results.',
+    }];
+}
+
+function buildClientInteropRows(cases, rowRole, columnRole, clientOrder, rowRoleLabel) {
+    const rowMap = new Map();
+
+    cases.forEach(test => {
+        const rowName = test.roles[rowRole];
+        const columnName = test.roles[columnRole];
+        if (!rowMap.has(rowName)) {
+            rowMap.set(rowName, {
+                name: rowName,
+                label: roleLabel(rowName, rowRoleLabel),
+                order: test.numericIndex,
+                cells: new Map(),
+            });
+        }
+
+        const row = rowMap.get(rowName);
+        row.order = Math.min(row.order, test.numericIndex);
+        if (!row.cells.has(columnName)) {
+            row.cells.set(columnName, []);
+        }
+        row.cells.get(columnName).push(test);
+    });
+
+    return Array.from(rowMap.values()).sort((a, b) => {
+        const orderDiff = clientOrderRank(clientOrder, a.name) - clientOrderRank(clientOrder, b.name);
+        if (orderDiff !== 0) {
+            return orderDiff;
+        }
+        return a.order - b.order || a.name.localeCompare(b.name);
+    });
+}
+
+function roleLabelClients(clients, role) {
+    return clients.map(client => ({
+        ...client,
+        label: roleLabel(client.label, role),
+    }));
+}
+
+function roleLabel(label, role) {
+    return `${label} (${role})`;
+}
+
+function clientOrderMap(clients) {
+    const order = new Map();
+    clients.forEach((client, index) => {
+        order.set(client.name, index);
+    });
+    return order;
+}
+
+function clientOrderRank(order, name) {
+    return order.has(name) ? order.get(name) : Number.MAX_SAFE_INTEGER;
+}
+
+function clientInteropTopology(test) {
+    const marker = ' / ';
+    const name = testName(test);
+    const index = name.lastIndexOf(marker);
+    if (index !== -1) {
+        const topology = name.slice(index + marker.length).split(',').map(client => client.trim()).filter(Boolean);
+        if (topology.length > 0) {
+            return topology;
+        }
+    }
+
+    const match = (test.description || '').match(/^Starts\s+(.+?)\s+with a shared genesis/);
+    if (!match) {
+        return [];
+    }
+    return match[1].split(',').map(client => client.trim()).filter(Boolean);
+}
+
+function clientInteropRoles(topology) {
+    if (topology.length === 0) {
+        return null;
+    }
+
+    const counts = new Map();
+    topology.forEach(client => counts.set(client, (counts.get(client) || 0) + 1));
+    if (counts.size < 2) {
+        return null;
+    }
+
+    const entries = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+    const [majority, majorityCount] = entries[0];
+    const [minority, minorityCount] = entries[entries.length - 1];
+    if (majorityCount === minorityCount) {
+        return null;
+    }
+    return { majority, minority };
+}
+
+function collectClients(entry, suiteData, cases) {
+    const versions = suiteData.clientVersions || entry.versions || {};
+    const names = [];
+    const seen = new Set();
+
+    const addClient = name => {
+        if (!name || seen.has(name)) {
+            return;
+        }
+        seen.add(name);
+        names.push(name);
+    };
+
+    cases.forEach(test => {
+        if (test.topology && test.topology.length > 0) {
+            test.topology.forEach(addClient);
+            return;
+        }
+        clientNamesForTest(test).forEach(addClient);
+    });
+
+    Object.keys(versions).sort().forEach(addClient);
+    if (names.length === 0) {
+        (entry.clients || []).slice().sort().forEach(addClient);
+    }
+
+    return names.map(name => ({
+        name,
+        label: name,
+        version: versions[name] || '',
+    }));
+}
+
+function clientNamesForTest(test) {
+    const names = [];
+    const seen = new Set();
+    clientInfoEntries(test).forEach(info => {
+        if (info && info.name && !seen.has(info.name)) {
+            seen.add(info.name);
+            names.push(info.name);
+        }
+    });
+    return names;
+}
+
+function clientInfoEntries(test) {
+    return Object.values(test.clientInfo || {}).sort((a, b) => {
+        const aTime = parseDate(a.instantiatedAt);
+        const bTime = parseDate(b.instantiatedAt);
+        const timeDiff = compareDates(aTime, bTime);
+        if (timeDiff !== 0) {
+            return timeDiff;
+        }
+
+        const nameDiff = (a.name || '').localeCompare(b.name || '');
+        if (nameDiff !== 0) {
+            return nameDiff;
+        }
+        return (a.id || '').localeCompare(b.id || '');
+    });
+}
+
+function suiteStats(cases, suiteName) {
+    let passed = 0;
+    let failed = 0;
+    let timeouts = 0;
+    let total = 0;
+    let start = null;
+    let end = null;
+
+    cases.forEach(test => {
+        if (!isSuiteSetupTest(test, suiteName)) {
+            total++;
+            if (test.summaryResult && test.summaryResult.pass) {
+                passed++;
+            } else {
+                failed++;
+                if (test.summaryResult && test.summaryResult.timeout) {
+                    timeouts++;
+                }
+            }
+        }
+
+        const testStart = parseDate(test.start);
+        const testEnd = parseDate(test.end);
+        if (testStart && (!start || testStart < start)) {
+            start = testStart;
+        }
+        if (testEnd && (!end || testEnd > end)) {
+            end = testEnd;
+        }
+    });
+
+    return {
+        total,
+        passed,
+        failed,
+        timeouts,
+        start,
+        end,
+        duration: start && end ? end - start : null,
+    };
+}
+
+function isSuiteSetupTest(test, suiteName) {
+    const name = testName(test).trim().toLowerCase();
+    const normalizedSuite = (suiteName || '').trim().toLowerCase();
+    if (normalizedSuite && (
+        name === `${normalizedSuite}: client launch` ||
+        name === `${normalizedSuite}: matrix`
+    )) {
+        return true;
+    }
+    return /:\s*client launch$/i.test(name);
+}
+
+function renderLeanLatest(matrices) {
+    if (matrices.length === 0) {
+        renderEmptyState('No lean suite runs found.');
+        return;
+    }
+
+    const suiteNames = new Set(matrices.map(matrix => matrix.linkSuiteName || matrix.suiteName));
+    const failingSuites = new Set(
+        matrices
+            .filter(matrix => matrix.stats.failed > 0)
+            .map(matrix => matrix.linkSuiteName || matrix.suiteName)
+    ).size;
+    $('#lean-latest-subtitle').text(`Latest runs for ${suiteNames.size} suites.`);
+    $('#lean-latest-summary').empty()
+        .append(summaryPill('Suites', suiteNames.size))
+        .append(summaryPill('Failing', failingSuites, failingSuites > 0 ? 'danger' : 'success'));
+
+    const content = $('#lean-latest-content').empty();
+    matrices.forEach(matrix => {
+        content.append(renderSuiteSection(matrix));
+    });
+}
+
+function renderSuiteSection(matrix) {
+    const section = $('<section />').addClass('lean-suite-section');
+    const header = $('<div />').addClass('lean-suite-header');
+    const title = $('<div />').addClass('lean-suite-title');
+    const actions = $('<div />').addClass('lean-suite-actions');
+
+    title.append($('<h2 />').text(matrix.suiteName));
+    title.append(renderSuiteMeta(matrix));
+
+    const statusClass = matrix.stats.failed > 0 ? 'bg-danger' : 'bg-success';
+    const statusText = matrix.stats.failed > 0 ? 'Fail' : 'Pass';
+    actions.append($('<span />').addClass(`badge ${statusClass}`).text(statusText));
+    actions.append($('<a />')
+        .addClass('btn btn-sm btn-secondary')
+        .attr('href', routes.suite(matrix.entry.fileName, matrix.linkSuiteName || matrix.suiteName))
+        .text('Open suite'));
+
+    header.append(title, actions);
+    section.append(header);
+
+    if (matrix.rows.length === 0 || matrix.clients.length === 0) {
+        section.append($('<p />').addClass('text-secondary').text(matrix.emptyMessage || 'No test cases with client results.'));
+        return section;
+    }
+
+    const scroll = $('<div />').addClass('lean-grid-scroll');
+    const table = $('<table />').addClass('lean-latest-grid');
+    const thead = $('<thead />');
+    const headerRow = $('<tr />');
+
+    headerRow.append($('<th />').addClass('lean-test-column').text(matrix.rowHeaderLabel ?? 'Test'));
+    matrix.clients.forEach(client => {
+        const heading = $('<span />').addClass('lean-client-heading').text(client.label);
+        const th = $('<th />')
+            .addClass('lean-result-column')
+            .attr('title', client.version || client.label)
+            .append(heading);
+        headerRow.append(th);
+    });
+
+    thead.append(headerRow);
+    table.append(thead);
+
+    const tbody = $('<tbody />');
+    matrix.rows.forEach(row => {
+        const tr = $('<tr />');
+        tr.append($('<th />').addClass('lean-test-column').attr('scope', 'row').text(rowLabel(row)));
+        matrix.clients.forEach(client => {
+            tr.append(renderResultCell(matrix, row, client));
+        });
+        tbody.append(tr);
+    });
+    table.append(tbody);
+    scroll.append(table);
+    section.append(scroll);
+
+    return section;
+}
+
+function renderSuiteMeta(matrix) {
+    const meta = $('<div />').addClass('lean-suite-meta');
+    const start = matrix.entry.startDate || matrix.stats.start;
+    if (start) {
+        meta.append($('<span />').text(start.toLocaleString()));
+    }
+    meta.append($('<span />').text(`${matrix.stats.total} tests`));
+    meta.append($('<span />').text(`${matrix.clients.length} clients`));
+    meta.append($('<span />').addClass('pass-count').text(`${matrix.stats.passed} passed`));
+    if (matrix.stats.failed > 0) {
+        meta.append($('<span />').addClass('fail-count').text(`${matrix.stats.failed} failed`));
+    }
+    if (matrix.stats.timeouts > 0) {
+        meta.append($('<span />').addClass('text-warning').text(`${matrix.stats.timeouts} timeouts`));
+    }
+    if (matrix.stats.duration !== null) {
+        meta.append($('<span />').text(formatDuration(matrix.stats.duration)));
+    }
+    return meta;
+}
+
+function renderResultCell(matrix, row, client) {
+    const tests = row.cells.get(client.name) || [];
+    const td = $('<td />').addClass('lean-result-column');
+
+    if (tests.length === 0) {
+        td.append($('<span />')
+            .addClass('lean-result-box empty')
+            .attr('aria-label', `${client.label} did not run ${rowLabel(row)}`));
+        return td;
+    }
+
+    const status = resultStatus(tests);
+    const linkedTest = preferredLinkedTest(tests);
+    const url = routes.testInSuite(matrix.entry.fileName, matrix.linkSuiteName || matrix.suiteName, linkedTest.testIndex);
+    const label = statusLabel(status);
+    const link = $('<a />')
+        .addClass(`lean-result-box ${status}`)
+        .attr('href', url)
+        .attr('title', resultTitle(matrix, row, client, tests, label))
+        .attr('aria-label', `${client.label} ${label} ${rowLabel(row)}`)
+        .append($('<i />').addClass(status === 'pass' ? 'bi bi-check-lg' : 'bi bi-x-lg'));
+
+    if (tests.length > 1) {
+        link.append($('<span />').addClass('lean-result-count').text(tests.length));
+    }
+
+    td.append(link);
+    return td;
+}
+
+function resultStatus(tests) {
+    const failed = tests.some(test => !test.summaryResult || !test.summaryResult.pass);
+    if (!failed) {
+        return 'pass';
+    }
+    return tests.some(test => test.summaryResult && test.summaryResult.timeout) ? 'timeout' : 'fail';
+}
+
+function preferredLinkedTest(tests) {
+    return tests.find(test => !test.summaryResult || !test.summaryResult.pass) || tests[0];
+}
+
+function rowLabel(row) {
+    return row.label || row.name;
+}
+
+function resultTitle(matrix, row, client, tests, label) {
+    if (matrix.columnRoleLabel) {
+        const rowRole = matrix.rowRoleLabel || matrix.rowHeaderLabel;
+        return `${rowRole} ${rowLabel(row)}, ${matrix.columnRoleLabel} ${client.label}: ${label}`;
+    }
+    return `${client.label}: ${label} - ${rowLabel(row)}`;
+}
+
+function statusLabel(status) {
+    switch (status) {
+        case 'pass':
+            return 'Pass';
+        case 'timeout':
+            return 'Timeout';
+        default:
+            return 'Fail';
+    }
+}
+
+function summaryPill(label, value, tone) {
+    const pill = $('<span />').addClass('lean-summary-pill');
+    if (tone) {
+        pill.addClass(`lean-summary-pill-${tone}`);
+    }
+    pill.append($('<span />').addClass('lean-summary-label').text(label));
+    pill.append($('<span />').addClass('lean-summary-value').text(value));
+    return pill;
+}
+
+function renderEmptyState(message) {
+    $('#lean-latest-subtitle').text('');
+    $('#lean-latest-summary').empty();
+    $('#lean-latest-content').empty().append($('<p />').addClass('text-secondary').text(message));
+}
+
+function showError(message) {
+    $('#lean-latest-error').text(message).show();
+}
+
+function testName(test) {
+    return test.name || `test ${test.testIndex}`;
+}
+
+function numericTestIndex(value) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed;
+}
+
+function parseDate(value) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function compareDates(a, b) {
+    const left = a ? a.getTime() : 0;
+    const right = b ? b.getTime() : 0;
+    return left - right;
+}

--- a/cmd/hiveview/assets/lib/app.css
+++ b/cmd/hiveview/assets/lib/app.css
@@ -673,6 +673,24 @@ kbd {
     gap: 0.5rem;
 }
 
+.lean-latest-summary-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.lean-devnet-controls {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.lean-devnet-button {
+    min-width: 5.75rem;
+}
+
 .lean-summary-pill {
     display: inline-flex;
     align-items: baseline;
@@ -869,7 +887,10 @@ kbd {
     }
 
     .lean-latest-summary,
+    .lean-latest-summary-panel,
+    .lean-devnet-controls,
     .lean-suite-actions {
+        align-items: flex-start;
         justify-content: flex-start;
     }
 

--- a/cmd/hiveview/assets/lib/app.css
+++ b/cmd/hiveview/assets/lib/app.css
@@ -21,6 +21,7 @@ main {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
     background: color-mix(in srgb, var(--bs-body-bg) 97%, var(--bs-primary));
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
@@ -43,8 +44,11 @@ main {
     margin: 0;
     font-size: 0.9rem;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: flex-end;
     gap: 1.2rem;
+    min-width: 0;
 }
 
 #hive-static-nav a {
@@ -56,6 +60,18 @@ main {
 
 #hive-static-nav a:hover {
     color: var(--bs-primary);
+}
+
+#hive-static-nav a.lean-latest-nav {
+    color: var(--bs-btn-color);
+    padding: 0.25rem 0.65rem;
+    border-radius: 4px;
+}
+
+#hive-static-nav a.lean-latest-nav:hover {
+    color: var(--bs-btn-hover-color);
+    background-color: var(--bs-btn-hover-bg);
+    border-color: var(--bs-btn-hover-border-color);
 }
 
 .theme-toggle {
@@ -626,4 +642,248 @@ kbd {
     border-radius: 4px;
     box-shadow: 0 2px 0 var(--bs-border-color);
     margin: 0 0.2rem;
+}
+
+.lean-latest-page {
+    overflow: hidden;
+}
+
+.lean-latest-title-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.lean-latest-title-row h1 {
+    margin: 0;
+    font-size: 1.8rem;
+    line-height: 1.2;
+}
+
+.lean-latest-title-row p {
+    margin: 0.25rem 0 0;
+}
+
+.lean-latest-summary {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.lean-summary-pill {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 6px;
+    padding: 0.35rem 0.65rem;
+    background: color-mix(in srgb, var(--bs-body-bg) 90%, var(--bs-border-color));
+}
+
+.lean-summary-pill-success {
+    border-color: color-mix(in srgb, var(--bs-success) 55%, var(--bs-border-color));
+}
+
+.lean-summary-pill-danger {
+    border-color: color-mix(in srgb, var(--bs-danger) 55%, var(--bs-border-color));
+}
+
+.lean-summary-label {
+    color: var(--bs-secondary);
+    font-size: 0.85rem;
+}
+
+.lean-summary-value {
+    font-weight: 600;
+}
+
+.lean-suite-section {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--bs-border-color);
+}
+
+.lean-suite-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.lean-suite-title h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    line-height: 1.25;
+}
+
+.lean-suite-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.75rem;
+    margin-top: 0.35rem;
+    color: var(--bs-secondary);
+    font-size: 0.9rem;
+}
+
+.lean-suite-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.lean-grid-scroll {
+    width: 100%;
+    overflow: auto;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 6px;
+    background: var(--bs-body-bg);
+}
+
+.lean-latest-grid {
+    width: 100%;
+    min-width: max-content;
+    margin: 0;
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+.lean-latest-grid th,
+.lean-latest-grid td {
+    border-bottom: 1px solid var(--bs-border-color);
+    border-right: 1px solid var(--bs-border-color);
+    padding: 0.45rem 0.55rem;
+}
+
+.lean-latest-grid tr:last-child th,
+.lean-latest-grid tr:last-child td {
+    border-bottom: 0;
+}
+
+.lean-latest-grid th:last-child,
+.lean-latest-grid td:last-child {
+    border-right: 0;
+}
+
+.lean-latest-grid thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: color-mix(in srgb, var(--bs-body-bg) 86%, var(--bs-border-color));
+    font-weight: 600;
+}
+
+.lean-test-column {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    width: 28rem;
+    min-width: 18rem;
+    max-width: 32rem;
+    background: var(--bs-body-bg);
+    text-align: left;
+    overflow-wrap: anywhere;
+    vertical-align: middle;
+}
+
+.lean-latest-grid thead .lean-test-column {
+    z-index: 3;
+    background: color-mix(in srgb, var(--bs-body-bg) 86%, var(--bs-border-color));
+}
+
+.lean-result-column {
+    width: 6.5rem;
+    min-width: 6.5rem;
+    max-width: 8rem;
+    text-align: center;
+    vertical-align: middle;
+}
+
+.lean-client-heading {
+    display: inline-block;
+    max-width: 7rem;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
+.lean-result-box {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 4px;
+    color: #fff;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: transform 0.12s ease, filter 0.12s ease;
+}
+
+.lean-result-box:hover {
+    color: #fff;
+    filter: brightness(1.08);
+    transform: translateY(-1px);
+}
+
+.lean-result-box.pass {
+    background: var(--bs-success);
+    border-color: color-mix(in srgb, var(--bs-success) 75%, #000);
+}
+
+.lean-result-box.fail,
+.lean-result-box.timeout {
+    background: var(--bs-danger);
+    border-color: color-mix(in srgb, var(--bs-danger) 75%, #000);
+}
+
+.lean-result-box.empty {
+    background: color-mix(in srgb, var(--bs-body-bg) 82%, var(--bs-border-color));
+    border-color: var(--bs-border-color);
+}
+
+.lean-result-count {
+    position: absolute;
+    right: -0.35rem;
+    bottom: -0.35rem;
+    min-width: 1rem;
+    height: 1rem;
+    border-radius: 999px;
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    border: 1px solid var(--bs-border-color);
+    font-size: 0.65rem;
+    line-height: 0.9rem;
+    font-weight: 600;
+}
+
+@media screen and (max-width: 700px) {
+    .lean-latest-title-row,
+    .lean-suite-header {
+        flex-direction: column;
+    }
+
+    .lean-latest-summary,
+    .lean-suite-actions {
+        justify-content: flex-start;
+    }
+
+    .lean-test-column {
+        width: 16rem;
+        min-width: 14rem;
+    }
+
+    .lean-result-column {
+        width: 5.25rem;
+        min-width: 5.25rem;
+    }
+
+    .lean-client-heading {
+        max-width: 5.5rem;
+    }
 }

--- a/cmd/hiveview/assets/suite.html
+++ b/cmd/hiveview/assets/suite.html
@@ -13,6 +13,7 @@
       <div id="hive-header">
         <a href="index.html"><img id="hive-logo" height="35" src="images/hive3.svg"></a>
         <nav id="hive-static-nav">
+          <a class="nav-item btn btn-sm btn-secondary lean-latest-nav" id="lean-latest-nav-link" href="lean-latest" style="display: none">Lean latest</a>
           <span class="nav-item" id="hive-instance-info"></span>
           <a class="nav-item" href="https://github.com/ethereum/hive/blob/master/docs/overview.md#what-is-hive">What is Hive?</a>
           <span class="nav-item theme-toggle">🌙</span>

--- a/cmd/hiveview/assets/viewer.html
+++ b/cmd/hiveview/assets/viewer.html
@@ -24,6 +24,7 @@
       <div id="hive-header">
         <a href="index.html"><img id="hive-logo" height="35" src="images/hive3.svg"></a>
         <nav id="hive-static-nav">
+          <a class="nav-item btn btn-sm btn-secondary lean-latest-nav" id="lean-latest-nav-link" href="lean-latest" style="display: none">Lean latest</a>
           <span class="nav-item" id="hive-instance-info"></span>
           <a class="nav-item" href="https://github.com/ethereum/hive/blob/master/docs/overview.md#what-is-hive">What is Hive?</a>
           <span class="nav-item theme-toggle">🌙</span>

--- a/cmd/hiveview/deploy.go
+++ b/cmd/hiveview/deploy.go
@@ -17,6 +17,7 @@ import (
 func hiveviewBundler(fsys fs.FS) *bundler {
 	entrypoints := []string{
 		"lib/app-index.js",
+		"lib/app-lean-latest.js",
 		"lib/app-suite.js",
 		"lib/app-viewer.js",
 		"lib/app.css",

--- a/cmd/hiveview/listing.go
+++ b/cmd/hiveview/listing.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log"
 	"path"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -61,6 +62,7 @@ type listingEntry struct {
 	Timeout  bool              `json:"timeout"`
 	Clients  []string          `json:"clients"`  // client names involved in this run
 	Versions map[string]string `json:"versions"` // client versions
+	Devnet   string            `json:"devnet,omitempty"`
 	Start    time.Time         `json:"start"`    // timestamp of test start (ISO 8601 format)
 	FileName string            `json:"fileName"` // hive output file
 	Size     int64             `json:"size"`     // size of hive output file
@@ -95,7 +97,62 @@ func suiteToEntry(s *libhive.TestSuite, file fs.FileInfo) listingEntry {
 			}
 		}
 	}
+	e.Devnet = suiteDevnet(s, e.Clients)
 	return e
+}
+
+var devnetLabelPattern = regexp.MustCompile(`(?i)(?:^|[^a-z0-9])((?:devnet)[0-9][a-z0-9_-]*)`)
+
+func suiteDevnet(s *libhive.TestSuite, clients []string) string {
+	if s.RunMetadata != nil {
+		if devnet := devnetFromClientConfig(s.RunMetadata.ClientConfig); devnet != "" {
+			return devnet
+		}
+		for _, arg := range s.RunMetadata.HiveCommand {
+			if devnet := devnetFromString(arg); devnet != "" {
+				return devnet
+			}
+		}
+	}
+	for _, client := range clients {
+		if devnet := devnetFromString(client); devnet != "" {
+			return devnet
+		}
+	}
+	for client := range s.ClientVersions {
+		if devnet := devnetFromString(client); devnet != "" {
+			return devnet
+		}
+	}
+	return devnetFromString(s.Description)
+}
+
+func devnetFromClientConfig(config *libhive.ClientConfigInfo) string {
+	if config == nil {
+		return ""
+	}
+	if clients, ok := config.Content["clients"].([]any); ok {
+		for _, rawClient := range clients {
+			client, ok := rawClient.(map[string]any)
+			if !ok {
+				continue
+			}
+			if nametag, ok := client["nametag"].(string); ok {
+				if devnet := devnetFromString(nametag); devnet != "" {
+					return devnet
+				}
+			}
+		}
+	}
+	return devnetFromString(config.FilePath)
+}
+
+func devnetFromString(value string) string {
+	match := devnetLabelPattern.FindStringSubmatch(value)
+	if len(match) < 2 {
+		return ""
+	}
+	return strings.ToLower(match[1])
 }
 
 type suiteCB func(*libhive.TestSuite, fs.FileInfo) error

--- a/cmd/hiveview/listing_test.go
+++ b/cmd/hiveview/listing_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ethereum/hive/internal/libhive"
+)
+
+func TestSuiteDevnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		suite   *libhive.TestSuite
+		clients []string
+		want    string
+	}{
+		{
+			name: "client config nametag",
+			suite: &libhive.TestSuite{
+				RunMetadata: &libhive.RunMetadata{
+					ClientConfig: &libhive.ClientConfigInfo{
+						Content: map[string]any{
+							"clients": []any{
+								map[string]any{"client": "ream", "nametag": "devnet4"},
+							},
+						},
+					},
+				},
+			},
+			want: "devnet4",
+		},
+		{
+			name: "client config file path",
+			suite: &libhive.TestSuite{
+				RunMetadata: &libhive.RunMetadata{
+					ClientConfig: &libhive.ClientConfigInfo{
+						FilePath: "simulators/lean/clients/devnet5.yaml",
+					},
+				},
+			},
+			want: "devnet5",
+		},
+		{
+			name:    "client name",
+			suite:   &libhive.TestSuite{},
+			clients: []string{"ream_devnet3"},
+			want:    "devnet3",
+		},
+		{
+			name: "suite description",
+			suite: &libhive.TestSuite{
+				Description: "Runs Lean tests using the devnet6 profile.",
+			},
+			want: "devnet6",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := suiteDevnet(test.suite, test.clients); got != test.want {
+				t.Fatalf("devnet mismatch: got %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/hiveview/main.go
+++ b/cmd/hiveview/main.go
@@ -33,6 +33,7 @@ func main() {
 	flag.StringVar(&config.logDir, "logdir", "workspace/logs", "Path to hive simulator log directory")
 	flag.StringVar(&config.assetsDir, "assets", "", "Path to static files directory. Serves baked-in assets when not set.")
 	flag.BoolVar(&config.disableBundle, "assets.nobundle", false, "Disables JS/CSS bundling (for development).")
+	flag.BoolVar(&config.enableLeanLatest, "lean-latest", false, "Enables the Lean latest status page at /lean-latest.")
 	flag.Parse()
 
 	log.SetFlags(log.LstdFlags)

--- a/cmd/hiveview/serve.go
+++ b/cmd/hiveview/serve.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -17,10 +19,11 @@ import (
 var embeddedAssets embed.FS
 
 type serverConfig struct {
-	listenAddr    string
-	logDir        string
-	assetsDir     string
-	disableBundle bool
+	listenAddr       string
+	logDir           string
+	assetsDir        string
+	disableBundle    bool
+	enableLeanLatest bool
 }
 
 func (cfg *serverConfig) assetFS() (fs.FS, error) {
@@ -54,9 +57,13 @@ func runServer(config serverConfig) {
 	listingHandler := serveListing{fsys: logDirFS}
 
 	mux := mux.NewRouter()
+	mux.Handle("/features.json", serveFeatures{enableLeanLatest: config.enableLeanLatest}).Methods("GET")
 	mux.Handle("/listing.jsonl", listingHandler).Methods("GET")
 	mux.PathPrefix("/results").Handler(http.StripPrefix("/results/", logHandler))
-	mux.PathPrefix("/").Handler(serveFiles{deployFS})
+	mux.PathPrefix("/").Handler(serveFiles{
+		fsys:             deployFS,
+		enableLeanLatest: config.enableLeanLatest,
+	})
 
 	// Start the server.
 	l, err := net.Listen("tcp", config.listenAddr)
@@ -71,18 +78,59 @@ type serveListing struct{ fsys fs.FS }
 
 func (h serveListing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Generating listing...")
-	err := generateListing(h.fsys, ".", w, 200)
+	limit := 200
+	if rawLimit := r.URL.Query().Get("limit"); rawLimit != "" {
+		parsedLimit, err := strconv.Atoi(rawLimit)
+		if err != nil || parsedLimit <= 0 {
+			http.Error(w, "invalid limit", http.StatusBadRequest)
+			return
+		}
+		limit = min(parsedLimit, 5000)
+	}
+
+	err := generateListing(h.fsys, ".", w, limit)
 	if err != nil {
 		fmt.Println("error:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 
-type serveFiles struct{ fsys fs.FS }
+type serveFeatures struct {
+	enableLeanLatest bool
+}
+
+func (h serveFeatures) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("cache-control", "no-cache")
+	w.Header().Set("content-type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{
+		"leanLatest": h.enableLeanLatest,
+	})
+}
+
+type serveFiles struct {
+	fsys             fs.FS
+	enableLeanLatest bool
+}
 
 func (h serveFiles) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Add caching-related headers.
 	path := r.URL.Path
+	if isLeanLatestPath(path) && !h.enableLeanLatest {
+		http.NotFound(w, r)
+		return
+	}
+	if path == "/lean-latest/" {
+		target := "/lean-latest"
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusMovedPermanently)
+		return
+	}
+	if path == "/lean-latest" {
+		r.URL.Path = "/lean-latest.html"
+		path = r.URL.Path
+	}
 	if path == "/" || strings.HasSuffix(path, ".html") {
 		w.Header().Set("cache-control", "no-cache")
 	}
@@ -90,4 +138,8 @@ func (h serveFiles) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	srv := http.FileServer(http.FS(h.fsys))
 	srv.ServeHTTP(w, r)
 
+}
+
+func isLeanLatestPath(path string) bool {
+	return path == "/lean-latest" || path == "/lean-latest/" || path == "/lean-latest.html"
 }

--- a/cmd/hiveview/serve_test.go
+++ b/cmd/hiveview/serve_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestServeFilesLeanLatestFlag(t *testing.T) {
+	fsys := fstest.MapFS{
+		"lean-latest.html": {Data: []byte("ok")},
+	}
+
+	tests := []struct {
+		name              string
+		path              string
+		enableLeanLatest  bool
+		wantStatus        int
+		wantLocation      string
+		wantCacheDisabled bool
+	}{
+		{
+			name:       "disabled route",
+			path:       "/lean-latest",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "disabled trailing slash",
+			path:       "/lean-latest/",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "disabled html file",
+			path:       "/lean-latest.html",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:              "enabled route",
+			path:              "/lean-latest",
+			enableLeanLatest:  true,
+			wantStatus:        http.StatusOK,
+			wantCacheDisabled: true,
+		},
+		{
+			name:              "enabled html file",
+			path:              "/lean-latest.html",
+			enableLeanLatest:  true,
+			wantStatus:        http.StatusOK,
+			wantCacheDisabled: true,
+		},
+		{
+			name:             "enabled trailing slash redirects",
+			path:             "/lean-latest/",
+			enableLeanLatest: true,
+			wantStatus:       http.StatusMovedPermanently,
+			wantLocation:     "/lean-latest",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := serveFiles{
+				fsys:             fsys,
+				enableLeanLatest: test.enableLeanLatest,
+			}
+			req := httptest.NewRequest(http.MethodGet, test.path, nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status mismatch: got %d, want %d", rec.Code, test.wantStatus)
+			}
+			if loc := rec.Header().Get("Location"); loc != test.wantLocation {
+				t.Fatalf("location mismatch: got %q, want %q", loc, test.wantLocation)
+			}
+			if cache := rec.Header().Get("cache-control"); test.wantCacheDisabled && cache != "no-cache" {
+				t.Fatalf("cache-control mismatch: got %q, want no-cache", cache)
+			}
+		})
+	}
+}
+
+func TestServeFeatures(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "disabled", true: "enabled"}[enabled], func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/features.json", nil)
+
+			serveFeatures{enableLeanLatest: enabled}.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status mismatch: got %d, want %d", rec.Code, http.StatusOK)
+			}
+			if cache := rec.Header().Get("cache-control"); cache != "no-cache" {
+				t.Fatalf("cache-control mismatch: got %q, want no-cache", cache)
+			}
+
+			var features map[string]bool
+			if err := json.NewDecoder(rec.Body).Decode(&features); err != nil {
+				t.Fatal(err)
+			}
+			if features["leanLatest"] != enabled {
+				t.Fatalf("leanLatest mismatch: got %v, want %v", features["leanLatest"], enabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added a status page designed for the lean simulator to display the most recent results of each suite in an easy to read grid fashion. The page is served under /lean-latest and is enabled with optional flag --lean-latest. Accessed through the address or a button at the top of the hive bar enabled only when lean-latest is turned on.

A preview of the page:
<img width="2560" height="1318" alt="image" src="https://github.com/user-attachments/assets/251e4c96-1701-4b21-a86d-ef0435f01e17" />

