### PR TITLE
clients/ethrex: import block files individually

### DIFF
--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -53,9 +53,17 @@ else
 fi
 
 # Load the remainder of the test chain
+# Iterate per file rather than passing the directory: some test fixtures
+# (e.g. EEST consume-rlp fork-transition tests) deliberately include
+# rejected blocks alongside valid ones, and ethrex's `import` aborts the
+# whole chain on the first failure. Looping here keeps `import` strict
+# while still applying later valid blocks. Mirrors erigon/ethereumjs/nimbus.
 if [ -d /blocks ]; then
     echo "Loading remaining individual blocks..."
-    $ethrex $FLAGS $HIVE_ETHREX_FLAGS import /blocks
+    for file in $(ls /blocks | sort -n); do
+        echo "Importing /blocks/$file..."
+        $ethrex $FLAGS $HIVE_ETHREX_FLAGS import "/blocks/$file"
+    done
 else
     echo "Warning: blocks folder not found."
 fi


### PR DESCRIPTION
- ethrex's `import` aborts on the first invalid block, so when the consume-rlp simulator drops a directory containing both rejected and valid blocks (e.g. EEST fork-transition tests with `exception=...`), later valid blocks never get applied and the head stays at genesis.
- Loop over the files instead of passing the directory. `set +ex` above this block already keeps a per-file failure from killing the script.
- Matches the pattern used by `clients/erigon`, `clients/ethereumjs`, and `clients/nimbus-el`.
