### PR TITLE
simulators/ethereum/engine: bump PayloadProductionClientDelay 1s -> 2s

### DIFF
--- a/simulators/ethereum/engine/clmock/clmock.go
+++ b/simulators/ethereum/engine/clmock/clmock.go
@@ -32,8 +32,14 @@ var (
 	DefaultBlockTimestampIncrement         = big.NewInt(1)
 
 	// Time delay between ForkchoiceUpdated and GetPayload to allow the clients
-	// to produce a new Payload
-	DefaultPayloadProductionClientDelay = time.Second
+	// to produce a new Payload. Bumped from 1s to 2s to give the producer's
+	// txpool enough time to surface a transaction submitted in the same
+	// `OnPayloadProducerSelected` callback, otherwise the payload builder may
+	// snapshot an empty pending pool and return a payload with no
+	// transactions, breaking tests like
+	// `Invalid Missing Ancestor Syncing ReOrg, Transaction*`.
+	// See: https://github.com/ethereum/hive/issues/1351
+	DefaultPayloadProductionClientDelay = 2 * time.Second
 )
 
 type ExecutableDataHistory map[uint64]*typ.ExecutableData


### PR DESCRIPTION
## Summary

Bumps the default delay between `engine_forkchoiceUpdated` (with attributes) and `engine_getPayload` from 1s to 2s, to mitigate the empty-canonical-payload race tracked in #1351.

## Root cause

In `ProduceSingleBlock` ([clmock.go:565-605](https://github.com/ethereum/hive/blob/master/simulators/ethereum/engine/clmock/clmock.go#L565-L605)) the harness:

1. Runs `OnPayloadProducerSelected` — tests use this hook to send a tx via `eth_sendRawTransaction` to the just-selected producer.
2. Calls `RequestNextPayload` — issues `engine_forkchoiceUpdatedV3` with payload attributes; this kicks off the payload build on that producer.
3. Sleeps for `PayloadProductionClientDelay` (1s default).
4. Calls `GetNextPayload` — `engine_getPayloadV3` returns the built block.

`eth_sendRawTransaction` returns success once the tx is admitted to the txpool, but full indexing in the pending view that the payload builder reads can lag. With a 1s budget between FCU+attrs and getPayload, the builder occasionally snapshots an empty pool and returns a payload with zero transactions.

For the `Invalid Missing Ancestor Syncing ReOrg, Transaction*, ...` variants, that empty payload then trips `GenerateInvalidPayload` ([helper/customizer.go:721-723](https://github.com/ethereum/hive/blob/master/simulators/ethereum/engine/helper/customizer.go#L721-L723)):

```
FAIL: Unable to customize payload: no transactions available for modification
```

The flake has been observed against multiple clients (geth, erigon, reth — see #1351), confirming it is harness-side rather than client-side.

## Fix

Double the default delay to 2s. This widens the budget enough to cover the txpool admission + pending-promotion latency observed in practice. No interface changes, no per-test logic, no client-specific assumptions.

## Cost

Roughly +1s per produced block. Engine simulator tests typically produce on the order of tens of blocks per test case, so the total runtime increase per suite is modest. Tests that override `PayloadProductionClientDelay` explicitly are unaffected.

## Alternative considered

Polling `eth_getTransactionByHash` after `SendTransaction` to confirm tx visibility before returning. More targeted, but more code and an explicit assumption about when "visible" means "in pending"; bumping the default delay is a smaller change.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean in `simulators/ethereum/engine`.
- [ ] Run `engine-cancun` against geth and erigon and confirm `Invalid Missing Ancestor Syncing ReOrg, Transaction*` no longer flakes.
- [ ] Sanity-check overall suite runtimes haven't increased meaningfully.

Refs #1351