### PR TITLE
simulators/lean: include nlean in ENR bootnode allowlist

### DIFF
--- a/simulators/lean/src/utils/util.rs
+++ b/simulators/lean/src/utils/util.rs
@@ -294,6 +294,7 @@ pub(crate) fn bootnode_enr_for_client<'a>(
 pub(crate) fn client_uses_enr_bootnodes(client_kind: &str) -> bool {
     client_kind.starts_with("ethlambda")
         || client_kind.starts_with("lantern")
+        || client_kind.starts_with("nlean")
         || client_kind.starts_with("qlean")
         || client_kind.starts_with("zeam")
 }


### PR DESCRIPTION
## Summary

Add `nlean` to `client_uses_enr_bootnodes` so the lean simulator emits ENR-formatted bootnodes to nlean instead of multiaddrs.

## Why

`nlean`'s `nodes.yaml` reader (`NodeApp.ApplyBootstrapPeersFromNodesYaml`) accepts ENR strings only — it base64-decodes each entry and looks up RLP-encoded ENR fields. When `client_uses_enr_bootnodes` returns `false`, `lean_bootnodes_for_client` emits multiaddrs (`/ip4/.../udp/9000/quic-v1/p2p/<peerId>`), which fail base64 decoding and are silently dropped. The node logs `Connecting to 0 bootstrap peers.`, falls back to mDNS, and ends up with at most one peer.

## Impact (observed on https://hive.leanroadmap.org/lean-latest)

In every `client-interop` topology containing nlean, nlean stays at `finalized_slot=0` for the full 180 s window:

```
client-interop run ethlambda_devnet4 and nlean_devnet4 / ethlambda_devnet4,ethlambda_devnet4,nlean_devnet4
  Last observations: ethlambda_0(ethlambda) finalized_slot=36; ethlambda_1(ethlambda) finalized_slot=36; nlean_0(nlean) finalized_slot=0
```

The two ethlambdas finalize fine because they have proper bootnodes between themselves. nlean imports blocks via the single mDNS peer, but its proposed blocks all carry `AggregatedAttestations: 0, SignatureProofs: 0` — there is no second peer to receive its attestations from, and gossip mesh propagation across one hop is insufficient for justification to advance.

## Why this fix is correct

`ethlambda`, `lantern`, `qlean`, and `zeam` are already on the allowlist for the exact same reason: their `nodes.yaml` parsers all expect ENR strings (`parse_enrs` in ethlambda, `genesis_parse_nodes_file` in lantern, `readNodesYaml`/`enr::decode` in qlean-mini, `ENR.decodeTxtInto` in zeam). nlean follows the same convention; it was simply missed when the allowlist was added.

`ream` is intentionally not on the allowlist because it consumes `--bootnodes "$HIVE_BOOTNODES"` directly and `Bootnodes::FromStr` auto-detects ENR vs multiaddr.