### PR TITLE
cmd/hiveview: order clients based on ranking across all sections

### DIFF
--- a/cmd/hiveview/assets/lib/app-lean-latest.js
+++ b/cmd/hiveview/assets/lib/app-lean-latest.js
@@ -616,13 +616,13 @@ function applyClientRanking(matrices, ranking) {
     matrices.forEach(matrix => {
         matrix.clients = matrix.clients.slice().sort((a, b) => {
             const diff = rankOf(a.name) - rankOf(b.name);
-            return diff !== 0 ? diff : (a.label || a.name).localeCompare(b.label || b.name);
+            return diff !== 0 ? diff : (b.label || b.name).localeCompare(a.label || a.name);
         });
 
         if (matrix.rowRoleLabel) {
             matrix.rows = matrix.rows.slice().sort((a, b) => {
                 const diff = rankOf(a.name) - rankOf(b.name);
-                return diff !== 0 ? diff : a.name.localeCompare(b.name);
+                return diff !== 0 ? diff : b.name.localeCompare(a.name);
             });
         }
     });
@@ -699,7 +699,7 @@ function compareClientScores(totals, a, b) {
     if (leftTotal !== rightTotal) {
         return rightTotal - leftTotal;
     }
-    return a.localeCompare(b);
+    return b.localeCompare(a);
 }
 
 function scorePercent(score) {

--- a/cmd/hiveview/assets/lib/app-lean-latest.js
+++ b/cmd/hiveview/assets/lib/app-lean-latest.js
@@ -526,7 +526,8 @@ function renderLeanLatest(matrices, devnet) {
         return;
     }
 
-    renderClientScores(matrices);
+    const clientRanking = renderClientScores(matrices);
+    applyClientRanking(matrices, clientRanking);
 
     const suiteNames = new Set(matrices.map(matrix => matrix.linkSuiteName || matrix.suiteName));
     const failingSuites = new Set(
@@ -550,13 +551,13 @@ function renderClientScores(matrices) {
     const section = $('#lean-client-score-section');
     const content = $('#lean-client-score-content').empty();
     if (!section.length) {
-        return;
+        return [];
     }
 
     const scores = buildClientScores(matrices);
     if (scores.clients.length === 0 || scores.rows.length === 0) {
         section.hide();
-        return;
+        return [];
     }
 
     section.show();
@@ -601,6 +602,30 @@ function renderClientScores(matrices) {
 
     scroll.append(table);
     content.append(scroll);
+    return scores.clients.slice();
+}
+
+function applyClientRanking(matrices, ranking) {
+    if (!ranking || ranking.length === 0) {
+        return;
+    }
+    const rank = new Map();
+    ranking.forEach((name, index) => rank.set(name, index));
+    const rankOf = name => (rank.has(name) ? rank.get(name) : Number.MAX_SAFE_INTEGER);
+
+    matrices.forEach(matrix => {
+        matrix.clients = matrix.clients.slice().sort((a, b) => {
+            const diff = rankOf(a.name) - rankOf(b.name);
+            return diff !== 0 ? diff : (a.label || a.name).localeCompare(b.label || b.name);
+        });
+
+        if (matrix.rowRoleLabel) {
+            matrix.rows = matrix.rows.slice().sort((a, b) => {
+                const diff = rankOf(a.name) - rankOf(b.name);
+                return diff !== 0 ? diff : a.name.localeCompare(b.name);
+            });
+        }
+    });
 }
 
 function buildClientScores(matrices) {


### PR DESCRIPTION
<img width="507" height="998" alt="image" src="https://github.com/user-attachments/assets/fed180ee-139e-433a-98f8-08ba781bdb81" />

We would like a client to follow one column vertically across the lean latest page.