### PR TITLE
simulators/lean: fix advanced_head validator collision

### DIFF
--- a/simulators/lean/src/scenarios/reqresp.rs
+++ b/simulators/lean/src/scenarios/reqresp.rs
@@ -1,5 +1,6 @@
 use crate::utils::helper::{
     start_post_genesis_sync_context, HelperGossipForkDigestProfile, PostGenesisSyncTestData,
+    LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
 };
 use crate::utils::libp2p_mock::{
     client_multiaddr, compute_client_peer_id, decode_request, encode_request, encode_request_raw,
@@ -137,7 +138,10 @@ dyn_async! {
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
                         client_role: ClientUnderTestRole::Validator,
-                        source_helper_validator_indices: None,
+                        // Helper owns V1+V2 so client (default V0) has exclusive proposer slots; see #1470.
+                        source_helper_validator_indices: Some(
+                            LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0.to_string(),
+                        ),
                         helper_peer_count: 2,
                         helper_fork_digest_profile: if selected_lean_devnet() == LeanDevnet::Devnet4 {
                             HelperGossipForkDigestProfile::SelectedDevnet
@@ -633,12 +637,16 @@ dyn_async! {
 
         sleep(Duration::from_secs(10)).await;
 
-        let source_fork_choice = context.load_live_helper_fork_choice().await;
-
+        // Compare against the helper's *live* head re-fetched each iteration
+        // rather than a single T+10s snapshot. The helper keeps producing
+        // blocks (it's still aggregating V1+V2) so a frozen snapshot becomes
+        // unreachable as soon as the helper moves on; equality with a moving
+        // target is the right invariant for "client has caught up".
         let mut caught_up = false;
         let deadline = std::time::Instant::now() + Duration::from_secs(REQRESP_SYNC_TIMEOUT_SECS);
 
         while std::time::Instant::now() < deadline {
+            let source_fork_choice = context.load_live_helper_fork_choice().await;
             let client_fork_choice = load_fork_choice_response(&context.client_under_test).await;
 
             if client_fork_choice.head == source_fork_choice.head {

--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -35,6 +35,10 @@ const LEAN_VALIDATOR_INDICES_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_VALIDATOR_I
 const LEAN_RUNTIME_ASSET_ROOT_ENVIRONMENT_VARIABLE: &str = "LEAN_RUNTIME_ASSET_ROOT";
 const LEAN_SPEC_SOURCE_NODE_ID: &str = "lean_spec_0";
 const LEAN_SPEC_SOURCE_VALIDATORS: &str = "0,1,2";
+/// Helper validator subset that excludes V0, used by tests where the
+/// client-under-test owns V0 itself. Keep in sync with
+/// [`LEAN_SPEC_SOURCE_VALIDATORS`] if the validator count ever changes.
+pub(crate) const LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0: &str = "1,2";
 const LEAN_SPEC_SOURCE_PEER_ID: &str = "16Uiu2HAmHzBkRq62mG95vsjKMuYQBezZCtjPXYWUoyVxMxi71aB3";
 const DEFAULT_HELPER_GOSSIP_FORK_DIGEST: &str = "devnet0";
 const DEFAULT_HELPER_P2P_PORT: u16 = 9001;


### PR DESCRIPTION
The `reqresp/status/advanced_head` test had a hash-ordering race that flipped pass/fail per client.

Helper runs validators 0,1,2; client runs as `ClientUnderTestRole::Validator` which defaults to V0. Both nodes propose competing blocks at every V0 slot. The leanSpec tie-break (larger root wins on equal weight) then decides the canonical chain by hash, so whether the helper's T+10s snapshot ever matches the client's head is a coin flip — about half the clients fail this test on any given run.

Fix: have the helper own only V1+V2 in this test so V0 belongs exclusively to the client. No proposer collision, no race.

Closes #1470.