### PR TITLE
simulators/lean: fix gossip subscribe-before-status race

### DIFF
--- a/simulators/lean/src/scenarios/gossip.rs
+++ b/simulators/lean/src/scenarios/gossip.rs
@@ -176,17 +176,27 @@ dyn_async! {
     async fn test_gossipsub_subscribes_to_block_topic<'a>(clients: Vec<Client>, _: ()) {
         let (mut mock, _client, fork_digest) = setup_mock_bootnode(clients).await;
 
-        let mut subscribed = false;
+        let block_topic_hash = lean_block_topic(&fork_digest).hash();
+
+        // Check events captured during setup_mock_bootnode's wait_for_request
+        // loop first.  Clients that send their gossipsub SUBSCRIBE before the
+        // reqresp Status handshake arrives would otherwise have their
+        // subscription silently dropped before this loop starts.
+        let mut subscribed = mock
+            .seen_subscriptions
+            .get(&block_topic_hash)
+            .map(|peers| !peers.is_empty())
+            .unwrap_or(false);
+
         let deadline = std::time::Instant::now() + Duration::from_secs(GOSSIPSUB_TIMEOUT_SECS);
 
-        while std::time::Instant::now() < deadline {
+        while !subscribed && std::time::Instant::now() < deadline {
             match tokio::time::timeout(Duration::from_secs(1), mock.swarm.select_next_some()).await {
                 Ok(SwarmEvent::Behaviour(MockBehaviourEvent::Gossipsub(
-                    libp2p::gossipsub::Event::Subscribed { peer_id: _, topic } ,
+                    libp2p::gossipsub::Event::Subscribed { peer_id: _, topic },
                 ))) => {
-                    if topic == lean_block_topic(&fork_digest).hash() {
+                    if topic == block_topic_hash {
                         subscribed = true;
-                        break;
                     }
                 }
                 Ok(_) => continue,

--- a/simulators/lean/src/utils/libp2p_mock.rs
+++ b/simulators/lean/src/utils/libp2p_mock.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Cursor, Write};
 use std::time::Duration;
 
@@ -9,7 +9,7 @@ use futures::prelude::*;
 use libp2p::{
     gossipsub::{
         Behaviour as GossipsubBehaviour, Config as GossipsubConfig, Event as GossipsubEvent,
-        IdentTopic, MessageAuthenticity,
+        IdentTopic, MessageAuthenticity, TopicHash,
     },
     request_response::{
         self, Behaviour as RequestResponseBehaviour, Codec, Event as ReqRespEvent,
@@ -484,6 +484,11 @@ pub struct MockNode {
     >,
     gossip_messages: Vec<(PeerId, IdentTopic, Vec<u8>)>,
     secret_key_bytes: Option<[u8; 32]>,
+    /// Gossipsub Subscribed events captured while draining events for other
+    /// purposes (e.g. during `wait_for_request`). Tests that look for a peer
+    /// subscription check this set first so they don't miss events that
+    /// arrived before the test loop started.
+    pub seen_subscriptions: HashMap<TopicHash, HashSet<PeerId>>,
 }
 
 impl MockNode {
@@ -534,6 +539,7 @@ impl MockNode {
             pending_requests: HashMap::new(),
             gossip_messages: Vec::new(),
             secret_key_bytes: Some(secret_key_bytes),
+            seen_subscriptions: HashMap::new(),
         })
     }
 
@@ -653,6 +659,12 @@ impl MockNode {
     }
 
     /// Wait for an incoming request and return it along with the response channel.
+    ///
+    /// Gossipsub `Subscribed` events that arrive while waiting are buffered
+    /// into `self.seen_subscriptions` so that tests can check them
+    /// retroactively.  Without this, clients that send their gossipsub
+    /// SUBSCRIBE before the reqresp Status handshake completes would have
+    /// their subscription silently dropped.
     pub async fn wait_for_request(
         &mut self,
     ) -> Option<(
@@ -676,6 +688,14 @@ impl MockNode {
                     },
                 ))) => {
                     return Some((peer, request_id, request, channel));
+                }
+                Some(SwarmEvent::Behaviour(MockBehaviourEvent::Gossipsub(
+                    GossipsubEvent::Subscribed { peer_id, topic },
+                ))) => {
+                    self.seen_subscriptions
+                        .entry(topic)
+                        .or_default()
+                        .insert(peer_id);
                 }
                 Some(_) => continue,
                 None => return None,


### PR DESCRIPTION
Fixes the `gossip: client subscribes to block topic` test which fails for every client except ethlambda (zeam, grandine, gean, ream, lantern, nlean, qlean).

## Root cause

`wait_for_request()` drives `swarm.next()` in a loop until the reqresp Status handshake arrives, discarding every other event with `Some(_) => continue`. Clients send their gossipsub `SUBSCRIBE` within ~1 ms of QUIC connect — i.e. inside the same drain loop — so the event is consumed before `setup_mock_bootnode` returns. After Status, gossipsub doesn't re-send SUBSCRIBE (no subscription change, no heartbeat-driven re-broadcast), so the test's 30 s `select_next_some` poll never gets another chance.

Re-verified the analysis with logs from all 8 clients. The fix is sound but the PR description's explanation of why ethlambda passes was wrong. Corrected analysis below.

## Cross-client timing (failing test 388 run)

| Client | Result | Connect → Status response | Stayed connected? |
|---|---|---|---|
| ethlambda | **PASS** | ~2 ms | **No** — disconnects, redials in 12 s |
| zeam | FAIL | ~2 ms | Yes (until test timeout) |
| grandine | FAIL | ~2 ms | Yes |
| ream | FAIL | ~2 ms | Yes |
| gean / lantern / nlean / qlean | FAIL | similar | Yes |

So speed of the Status handshake is **not** what distinguishes ethlambda — every client sends Status within milliseconds of QUIC connect. What's actually different is that ethlambda tears down the connection right after Status:

```
08:35:48.406910 Peer connected
08:35:48.408403 Received status response
08:35:48.408683 Peer disconnected reason=error
08:35:48.408709 Scheduled bootnode redial in 12s
```

The first connection's SUBSCRIBE is consumed by `wait_for_request` for ethlambda too. It passes because the **redial 12 s later** lands inside the test's 30 s polling window, and the SUBSCRIBE on that fresh connection is observed live.

## Confirming the race actually exists

Grandine's log proves gossipsub is in fact exchanging subscriptions both ways:

```
08:40:30.539888 Connected to peer
08:40:30.539910 Sending Status request for handshake
08:40:30.541243 A peer subscribed to topic=/leanconsensus/12345678/block/ssz_snappy
08:40:30.541885 Received Status response
```

Grandine sees the **mock**'s SUBSCRIBE at +1.4 ms. By symmetry, the mock receives grandine's SUBSCRIBE in the same ~1 ms window — i.e. it lands inside `wait_for_request`'s drain loop, not after `setup_mock_bootnode` returns. After Status, gossipsub doesn't re-send SUBSCRIBE (no subscription change, no heartbeat-driven SUBSCRIBE), so the test's 30 s `select_next_some` loop never gets another shot. Times out.

## Alternative root causes ruled out

- **Mesh / gossipsub negotiation failing**: ruled out — grandine logs the mock's SUBSCRIBE, so the gossipsub stream is up and bidirectional.
- **Fork-digest mismatch**: ruled out — the immediate-next tests (`ignores wrong fork digest`, `ignores malformed ssz`) on the same digest pass for every client that fails 388, because those tests give the mesh 3 s with `process_events_for` before asserting.
- **QUIC/peer-id auth**: ruled out — Status handshake completes for every failing client.
- **Client never sends SUBSCRIBE**: ruled out — same as above (mesh forms bidirectionally).

## Why the fix still works

Independent of which side the SUBSCRIBE lands on or the exact timing:
- If SUBSCRIBE arrives during `wait_for_request` → now buffered into `seen_subscriptions`, test reads it before its loop. ✅
- If SUBSCRIBE arrives after `wait_for_request` returns → unchanged behaviour, test loop catches it live. ✅

The only behavioural change to `wait_for_request` is that one previously-discarded event variant is now recorded. No other event handling is altered.
Cross-checked with all client logs — handshake timing is ~2 ms for every client; the differentiator is connection lifecycle, not handshake speed. Detailed trace in PR comment.

## Fix

Buffer `GossipsubEvent::Subscribed` events into `MockNode::seen_subscriptions` inside `wait_for_request` instead of discarding them. `test_gossipsub_subscribes_to_block_topic` checks the buffer immediately after `setup_mock_bootnode` returns, before starting its 30 s polling loop. No other event handling is altered.