### PR TITLE
simulators/lean: stop dropping Gossipsub::Subscribed events in mock

### DIFF
--- a/simulators/lean/src/scenarios/gossip.rs
+++ b/simulators/lean/src/scenarios/gossip.rs
@@ -175,16 +175,21 @@ async fn setup_mock_bootnode(clients: Vec<Client>) -> (MockNode, Client, String)
 dyn_async! {
     async fn test_gossipsub_subscribes_to_block_topic<'a>(clients: Vec<Client>, _: ()) {
         let (mut mock, _client, fork_digest) = setup_mock_bootnode(clients).await;
+        let target_topic = lean_block_topic(&fork_digest).hash();
 
-        let mut subscribed = false;
+        if mock.has_observed_subscription(&target_topic) {
+            return;
+        }
+
         let deadline = std::time::Instant::now() + Duration::from_secs(GOSSIPSUB_TIMEOUT_SECS);
+        let mut subscribed = false;
 
         while std::time::Instant::now() < deadline {
             match tokio::time::timeout(Duration::from_secs(1), mock.swarm.select_next_some()).await {
                 Ok(SwarmEvent::Behaviour(MockBehaviourEvent::Gossipsub(
                     libp2p::gossipsub::Event::Subscribed { peer_id: _, topic } ,
                 ))) => {
-                    if topic == lean_block_topic(&fork_digest).hash() {
+                    if topic == target_topic {
                         subscribed = true;
                         break;
                     }

--- a/simulators/lean/src/utils/libp2p_mock.rs
+++ b/simulators/lean/src/utils/libp2p_mock.rs
@@ -484,6 +484,9 @@ pub struct MockNode {
     >,
     gossip_messages: Vec<(PeerId, IdentTopic, Vec<u8>)>,
     secret_key_bytes: Option<[u8; 32]>,
+    /// Subscription announcements seen on any swarm-poll path; test setup
+    /// drains events past the test's own `select_next_some` loop.
+    observed_subscriptions: std::collections::HashSet<(PeerId, libp2p::gossipsub::TopicHash)>,
 }
 
 impl MockNode {
@@ -534,7 +537,23 @@ impl MockNode {
             pending_requests: HashMap::new(),
             gossip_messages: Vec::new(),
             secret_key_bytes: Some(secret_key_bytes),
+            observed_subscriptions: std::collections::HashSet::new(),
         })
+    }
+
+    pub fn has_observed_subscription(&self, topic_hash: &libp2p::gossipsub::TopicHash) -> bool {
+        self.observed_subscriptions
+            .iter()
+            .any(|(_, t)| t == topic_hash)
+    }
+
+    fn record_subscription_event(&mut self, event: &SwarmEvent<MockBehaviourEvent>) {
+        if let SwarmEvent::Behaviour(MockBehaviourEvent::Gossipsub(
+            libp2p::gossipsub::Event::Subscribed { peer_id, topic },
+        )) = event
+        {
+            self.observed_subscriptions.insert((*peer_id, topic.clone()));
+        }
     }
 
     pub fn new_status_only() -> Result<Self, String> {
@@ -677,7 +696,10 @@ impl MockNode {
                 ))) => {
                     return Some((peer, request_id, request, channel));
                 }
-                Some(_) => continue,
+                Some(event) => {
+                    self.record_subscription_event(&event);
+                    continue;
+                }
                 None => return None,
             }
         }
@@ -769,7 +791,9 @@ impl MockNode {
                     self.gossip_messages
                         .push((propagation_source, topic, message.data));
                 }
-                Ok(SwarmEvent::Behaviour(MockBehaviourEvent::Gossipsub(_))) => {}
+                Ok(event @ SwarmEvent::Behaviour(MockBehaviourEvent::Gossipsub(_))) => {
+                    self.record_subscription_event(&event);
+                }
                 Ok(SwarmEvent::Behaviour(MockBehaviourEvent::Identify(_))) => {}
                 Ok(SwarmEvent::Behaviour(MockBehaviourEvent::Ping(_))) => {}
                 Ok(_) => {}


### PR DESCRIPTION
## Problem

The lean gossip suite test \`gossip: client subscribes to block topic\` currently fails for **6 of 8 clients** (nlean, grandine_lean, ream, lantern, gean, qlean) on the public hive instance — and only ethlambda and zeam pass. The fail mode is purely an artifact of the mock implementation, not the clients.

\`MockNode::wait_for_request\` (used by every gossip test in \`setup_mock_bootnode\`) drains the swarm's event queue waiting for the client's Status req/resp:

\`\`\`rust
loop {
    match self.swarm.next().await {
        Some(SwarmEvent::Behaviour(MockBehaviourEvent::Reqresp(...))) => return ...,
        Some(_) => continue,           // ← discards everything else, including
                                       //   Gossipsub::Event::Subscribed
        None => return None,
    }
}
\`\`\`

Clients that send their gossipsub \`SUBSCRIBE\` on connection establishment (the path \`rust-libp2p\`/\`go-libp2p\`/\`dotnet-libp2p\` all take by default) push the SUBSCRIBE before the Status req/resp opens its stream. The corresponding \`Event::Subscribed\` arrives at the mock during the \`wait_for_request\` drain and gets thrown away. The test then sits in its own \`select_next_some\` loop for 30s and asserts.

ethlambda and zeam happen to send Status first and SUBSCRIBE afterwards, so their \`Event::Subscribed\` lands in the test loop and they pass — but both orderings are spec-compliant. Status is a req/resp app-layer protocol on a separate stream from gossipsub \`/meshsub/1.x\`; neither libp2p nor the gossipsub spec dictates an ordering between them.

## Fix

Stop dropping the Subscribed event. Record it on \`MockNode\` whenever any swarm-poll path observes one, and let tests query the recorded set:

- New field \`observed_subscriptions: HashSet<(PeerId, TopicHash)>\` on \`MockNode\`.
- Internal \`record_subscription_event\` helper folds in any \`Event::Subscribed\`.
- Call it from both \`wait_for_request\` and \`process_events_for\`.
- Public \`has_observed_subscription(&topic_hash) -> bool\` accessor.
- \`test_gossipsub_subscribes_to_block_topic\` now checks \`has_observed_subscription\` first; if the SUBSCRIBE already arrived during setup it returns immediately, otherwise it falls back to the existing event-loop wait.

## Verification

Local 4-client gossip suite (ethlambda, grandine_lean, nlean, zeam): **11/11 pass**, including \`subscribes to block topic\` for nlean (which fails on master).