### PR TITLE
fix grandine_lean peer id derivation mismatch

### DIFF
--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -29,6 +29,7 @@ const LEAN_GENESIS_VALIDATORS_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_GENESIS_VA
 const LEAN_GENESIS_VALIDATOR_ENTRIES_ENVIRONMENT_VARIABLE: &str =
     "HIVE_LEAN_GENESIS_VALIDATOR_ENTRIES";
 const NODE_ID_ENVIRONMENT_VARIABLE: &str = "HIVE_NODE_ID";
+const CLIENT_PRIVATE_KEY_ENVIRONMENT_VARIABLE: &str = "HIVE_CLIENT_PRIVATE_KEY";
 const IS_AGGREGATOR_ENVIRONMENT_VARIABLE: &str = "HIVE_IS_AGGREGATOR";
 const LEAN_GENESIS_TIME_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_GENESIS_TIME";
 const LEAN_VALIDATOR_INDICES_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_VALIDATOR_INDICES";
@@ -890,6 +891,13 @@ fn client_under_test_environment(
     environment.insert(
         LEAN_GENESIS_TIME_ENVIRONMENT_VARIABLE.to_string(),
         genesis_time.to_string(),
+    );
+    // Pin the libp2p peer id to the value `compute_client_peer_id` derives,
+    // so MockNode dials the client at its actual peer id instead of an
+    // unrelated one (which surfaces as `Outbound failure: DialFailure`).
+    environment.insert(
+        CLIENT_PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(),
+        crate::utils::libp2p_mock::deterministic_client_private_key_hex(client_type),
     );
     if source_genesis_validator_entries
         .iter()

--- a/simulators/lean/src/utils/libp2p_mock.rs
+++ b/simulators/lean/src/utils/libp2p_mock.rs
@@ -229,15 +229,33 @@ pub fn encode_gossip_data<T: Encode>(item: &T) -> Vec<u8> {
 
 // === Peer ID Computation ===
 
-/// Compute the deterministic PeerId for a lean client based on its name.
-/// This matches the logic in `prepare_lean_client_assets.py`:
-///   key = sha256(f"{client_kind}:{node_id}:node").hexdigest()
-/// where NODE_ID defaults to "{client_kind}_0".
-pub fn compute_client_peer_id(client_name: &str) -> PeerId {
-    let base_name = client_name.split('_').next().unwrap_or(client_name);
-    let label = format!("{base_name}:{base_name}_0:node");
+/// Resolve the canonical lean client kind from a hive client type string.
+/// Falls back to the raw input when the client is not in the supported set so
+/// out-of-tree client kinds still get a stable derivation.
+fn client_kind_label(client_name: &str) -> String {
+    crate::utils::util::lean_client_kind(client_name)
+        .map(|kind| kind.to_string())
+        .unwrap_or_else(|_| client_name.to_string())
+}
+
+/// Hex-encoded deterministic secp256k1 secret for a lean client, matching
+/// `prepare_lean_client_assets.py::deterministic_private_key`:
+///   key = sha256(f"{client_kind}:{client_kind}_0:node").hexdigest()
+///
+/// Inject this as `HIVE_CLIENT_PRIVATE_KEY` when starting the client so the
+/// libp2p peer id matches what `compute_client_peer_id` expects.
+pub fn deterministic_client_private_key_hex(client_name: &str) -> String {
+    let kind = client_kind_label(client_name);
+    let label = format!("{kind}:{kind}_0:node");
     let hash = Sha256::digest(label.as_bytes());
-    let mut key_bytes = hash.to_vec();
+    alloy_primitives::hex::encode(hash)
+}
+
+/// Compute the deterministic PeerId for a lean client based on its name.
+pub fn compute_client_peer_id(client_name: &str) -> PeerId {
+    let hex = deterministic_client_private_key_hex(client_name);
+    let mut key_bytes =
+        alloy_primitives::hex::decode(&hex).expect("derived private key hex is valid");
 
     let secret_key = SecretKey::try_from_bytes(&mut key_bytes)
         .expect("Failed to create secp256k1 secret key from deterministic bytes");


### PR DESCRIPTION
Match MockNode's compute_client_peer_id to the Python helper's deterministic key derivation by using lean_client_kind instead of split('_').next(), so compound names  like grandine_lean produce the right peer id. Inject HIVE_CLIENT_PRIVATE_KEY in client_under_test_environment so the lean client actually boots with that key, which  
fixes Outbound failure: DialFailure in the BlocksByRoot reqresp tests.  