### PR TITLE
clients/ethrex: feature-detect --http.api flag

### DIFF
--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -103,7 +103,15 @@ if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
 fi
 
 # Configure RPC.
-FLAGS="$FLAGS --http.addr=0.0.0.0  --authrpc.addr=0.0.0.0"
+# Hive tests exercise admin/debug/txpool namespaces over the public HTTP port.
+# Newer ethrex builds default the HTTP allowlist to eth,net,web3, so we have to
+# opt those namespaces in via --http.api. Older builds don't know that flag, so
+# probe --help to keep this launcher working against both.
+HTTP_API_FLAG=""
+if "$ethrex" --help 2>&1 | grep -q -- '--http.api'; then
+    HTTP_API_FLAG="--http.api=eth,net,web3,debug,admin,txpool"
+fi
+FLAGS="$FLAGS --http.addr=0.0.0.0 --authrpc.addr=0.0.0.0 $HTTP_API_FLAG"
 
 # We don't support pre merge
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then


### PR DESCRIPTION
## Summary

Newer ethrex builds harden the HTTP JSON-RPC by default: the namespace allowlist is now `eth,net,web3`, and admin/debug/txpool must be opted in via `--http.api`. Hive's rpc-compat / engine / sync suites exercise those namespaces over the public HTTP port, so without this change those suites would start returning `MethodNotFound` against new ethrex images.

This PR teaches the ethrex launcher to feature-detect `--http.api`: it probes `ethrex --help` and only passes the flag when the binary supports it. Old ethrex images (which expose every namespace by default) keep working unchanged; new ethrex images (where the flag is required) get the opt-in.

```bash
HTTP_API_FLAG=""
if "$ethrex" --help 2>&1 | grep -q -- '--http.api'; then
    HTTP_API_FLAG="--http.api=eth,net,web3,debug,admin,txpool"
fi
FLAGS="$FLAGS --http.addr=0.0.0.0 --authrpc.addr=0.0.0.0 $HTTP_API_FLAG"
```

The grep-on-help approach avoids hard-coding which ethrex versions support the flag and works regardless of build order across hive and ethrex.

## Context

Paired with https://github.com/lambdaclass/ethrex/pull/6627, which lands the `--http.api` default-allowlist change on the ethrex side. Either PR can merge first; whichever lands second will not break the other.

## Test plan

- [ ] Run an rpc-compat suite that hits `debug_*` / `admin_*` / `txpool_*` against a pre-flag ethrex image (flag absent, namespaces served by default) and confirm green.
- [ ] Run the same suite against a post-flag ethrex image (flag present, namespaces opted in) and confirm green.