### PR TITLE
clients/zeam: hyphenated zeam CLI flags (zeam #806)

### DIFF
--- a/clients/zeam/zeam.sh
+++ b/clients/zeam/zeam.sh
@@ -56,12 +56,12 @@ materialize_runtime_local_ip
 
 FLAGS=(
     node
-    --custom_genesis "$ASSET_ROOT"
-    --validator_config "$ASSET_ROOT"
+    --custom-genesis "$ASSET_ROOT"
+    --validator-config "$ASSET_ROOT"
     --data-dir /data
     --node-id "$NODE_ID"
     --api-port 5052
-    --metrics_enable
+    --metrics-enable
     --metrics-port 8080
     --node-key "$ASSET_ROOT/node.key"
 )


### PR DESCRIPTION
## Summary

Updates the Hive Lean `zeam` client launcher to pass the hyphenated CLI flags introduced in [blockblaz/zeam#806](https://github.com/blockblaz/zeam/pull/806) (merged).

## Flag mapping

| Before | After |
|--------|--------|
| `--custom_genesis` | `--custom-genesis` |
| `--validator_config` | `--validator-config` |
| `--metrics_enable` | `--metrics-enable` |

Other flags in this script were already hyphenated (`--data-dir`, `--node-id`, etc.).

## Testing

Not run (shell-only change; Hive CI exercises client scripts as applicable).