### PR TITLE
simulators/ethereum/engine: Enforce expected blobs order by setting maxFeePerBlobGas

### DIFF
--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -277,7 +277,7 @@ var Tests = []test.Spec{
 			SendBlobTransactions{
 				TransactionCount:              5,
 				BlobsPerTransaction:           cancun.MAX_BLOBS_PER_BLOCK - 1,
-				BlobTransactionMaxBlobGasCost: big.NewInt(100),
+				BlobTransactionMaxBlobGasCost: big.NewInt(120),
 				AccountIndex:                  0,
 			},
 			// Then send the single-blob transactions from account B


### PR DESCRIPTION
Test `Blob Transaction Ordering, Multiple Accounts (Cancun)` sends a bunch of blob txs, all with the same fees and expects a specific tx ordering by the EL clients, but since txpool is implementation dependent the assumption that the tie-break is equal in all client is weak, for example Besu does not pass the test because the internal order of the txs is different and it prefers to add the txs with the single blob first.

To make the test more predictable in putting txs with more blobs first, we can simply raise a bit their `maxFeePerBlobGas` value, as it was already done for `Blob Transaction Ordering, Multiple Clients` test, probably for the same reason.