### PR TITLE
clients: enable testing namespace and pin gas-limit target

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -152,13 +152,13 @@ FLAGS="$FLAGS --snapsync-server-enabled"
 # Configure RPC.
 RPCFLAGS="--host-allowlist=*"
 if [ "$HIVE_GRAPHQL_ENABLED" == "" ]; then
-    RPCFLAGS="$RPCFLAGS --rpc-http-enabled --rpc-http-api=DEBUG,TRACE,ETH,NET,WEB3,ADMIN --rpc-http-host=0.0.0.0"
+    RPCFLAGS="$RPCFLAGS --rpc-http-enabled --rpc-http-api=DEBUG,TRACE,ETH,NET,WEB3,ADMIN,TESTING --rpc-http-host=0.0.0.0"
 else
     RPCFLAGS="$RPCFLAGS --graphql-http-enabled --graphql-http-host=0.0.0.0 --graphql-http-port=8545"
 fi
 
 # Enable WebSocket.
-RPCFLAGS="$RPCFLAGS --rpc-ws-enabled --rpc-ws-api=DEBUG,TRACE,ETH,NET,WEB3,ADMIN --rpc-ws-host=0.0.0.0"
+RPCFLAGS="$RPCFLAGS --rpc-ws-enabled --rpc-ws-api=DEBUG,TRACE,ETH,NET,WEB3,ADMIN,TESTING --rpc-ws-host=0.0.0.0"
 
 # Enable merge support if needed
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -127,7 +127,7 @@ if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
 fi
 
 # Configure RPC.
-FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,trace,eth,net,txpool,web3"
+FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,trace,eth,net,txpool,web3,testing"
 FLAGS="$FLAGS --ws --ws.port=8546"
 
 # Increase blob slots for tests

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -138,13 +138,8 @@ if [ "$HIVE_MINER_EXTRA" != "" ]; then
 fi
 
 # Configure RPC.
-FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,miner,net,txpool,web3"
-FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth,miner,net,txpool,web3"
-
-if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
-    echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
-    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret /jwtsecret"
-fi
+FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,miner,net,txpool,web3,testing"
+FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth,miner,net,txpool,web3,testing"
 
 # Configure GraphQL.
 if [ "$HIVE_GRAPHQL_ENABLED" != "" ]; then

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -141,6 +141,11 @@ fi
 FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,miner,net,txpool,web3,testing"
 FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth,miner,net,txpool,web3,testing"
 
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
+    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret /jwtsecret"
+fi
+
 # Configure GraphQL.
 if [ "$HIVE_GRAPHQL_ENABLED" != "" ]; then
     FLAGS="$FLAGS --graphql"

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -136,6 +136,9 @@ fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then
     FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"
 fi
+if [ "$HIVE_TARGET_GAS_LIMIT" != "" ]; then
+    FLAGS="$FLAGS --miner.gaslimit $HIVE_TARGET_GAS_LIMIT"
+fi
 
 # Configure RPC.
 FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,miner,net,txpool,web3,testing"

--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -46,14 +46,14 @@ def json_rpc_config:
     {
       "JsonRpc": {
         "JwtSecretFile": "/jwt.secret",
-        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin"],
+        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin", "Testing"],
         "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|debug;net;eth;subscribe;engine;web3;client;admin|no-auth", "http://0.0.0.0:8551|http;ws|debug;net;eth;subscribe;engine;web3;client;admin"]
       }
     }
   else
     {
       "JsonRpc": {
-        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin"]
+        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin", "Testing"]
       }
     }
   end
@@ -72,6 +72,18 @@ def txpool_config:
     {
       "TxPool": {
         "BlobsSupport": "StorageWithReorgs"
+      }
+    }
+  else
+    {}
+  end
+;
+
+def blocks_config:
+  if env.HIVE_TARGET_GAS_LIMIT != null then
+    {
+      "Blocks": {
+        "TargetBlockGasLimit": (env.HIVE_TARGET_GAS_LIMIT | tonumber)
       }
     }
   else
@@ -116,4 +128,4 @@ def base_config:
 ;
 
 # This is the main expression that outputs the config.
-base_config * keystore_config * merge_config * json_rpc_config * sync_config * txpool_config
+base_config * keystore_config * merge_config * json_rpc_config * sync_config * txpool_config * blocks_config

--- a/clients/nethermind/test.json
+++ b/clients/nethermind/test.json
@@ -22,7 +22,8 @@
       "Net",
       "Parity",
       "Health",
-      "Rpc"
+      "Rpc",
+      "Testing"
     ]
   },
   "Network": {

--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -153,8 +153,8 @@ if [ -n "${HIVE_CLIQUE_PRIVATEKEY}" ] || [ -n "${HIVE_CLIQUE_PERIOD}" ]; then
 fi
 
 # Configure RPC.
-FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,trace,eth,net,web3"
-FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.api=admin,debug,trace,eth,net,web3"
+FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,trace,eth,net,web3,testing"
+FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.api=admin,debug,trace,eth,net,web3,testing"
 
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     JWT_SECRET="7365637265747365637265747365637265747365637265747365637265747365"


### PR DESCRIPTION
## Summary

Two related fixes for the `rpc-compat` simulator so the `testing_*` namespace fixtures from [`execution-apis`](https://github.com/ethereum/execution-apis) replay byte-exact across clients. The PR bundles three commits already on the `testing-namespace` branch:

1. **`Add testing namespace to clients`** — adds `testing` to the JSON-RPC allowlist for besu, erigon, go-ethereum, nethermind, and reth. Without this, `testing_buildBlockV1` / `testing_commitBlockV1` requests get `namespace 'testing' is disabled` errors.
2. **`fix: restore HIVE_TERMINAL_TOTAL_DIFFICULTY authrpc block in geth.sh`** — restores the engine-API auth-rpc setup that the previous commit accidentally removed.
3. **`clients/go-ethereum, clients/nethermind: pin gas-limit target via HIVE_TARGET_GAS_LIMIT`** (new in this PR) — plumbs a new `HIVE_TARGET_GAS_LIMIT` env var through `clients/go-ethereum/geth.sh` (`--miner.gaslimit`) and `clients/nethermind/mkconfig.jq` (`Blocks.TargetBlockGasLimit`).

## Why the gas-limit pin matters

geth's `CalcGasLimit` moves the parent gas limit toward `miner.gaslimit` (default 60M) by 1/1024 per block. Nethermind keeps the parent gas limit unchanged unless `Blocks.TargetBlockGasLimit` is set. Under `rpc-compat`'s ~75M-gas-limit chain head, the two clients diverge from block 1 onward, so blocks produced by `testing_buildBlockV1` / `testing_commitBlockV1` get different hashes per client and the strict-match tests fail on Nethermind. Pinning both clients to the same target makes them produce identical blocks.

## Companion PRs

- **Spec + fixtures + `HIVE_TARGET_GAS_LIMIT` definition**: ethereum/execution-apis#801
- **Original spec proposal**: ethereum/execution-apis#787
- **go-ethereum**: ethereum/go-ethereum#34995
- **Nethermind**: NethermindEth/nethermind#11649

## Test plan

- [x] hive `rpc-compat` against geth (`Dockerfile.local`): 216/216 pass
- [x] hive `rpc-compat` against Nethermind (master + the small nullability fix from NethermindEth/nethermind#11649): all 9 `testing_*` tests pass; 7 unrelated pre-existing failures remain (6 `eth_simulateV1` validation cases, 1 `txpool_content`)