### PR TITLE
simulators/lean: follow lean_spec types/aggregation -> participation rename

### DIFF
--- a/simulators/lean/helper/lean_spec_client_runner.py
+++ b/simulators/lean/helper/lean_spec_client_runner.py
@@ -48,7 +48,7 @@ from lean_spec.subspecs.validator import ValidatorRegistry
 from lean_spec.subspecs.validator.registry import ValidatorEntry
 from lean_spec.subspecs.xmss import SecretKey
 from lean_spec.types import Bytes32
-from lean_spec.types.aggregation import AggregationBits, ValidatorIndices
+from lean_spec.types.participation import AggregationBits, ValidatorIndices
 from lean_spec.types.collections import SSZList, SSZVector, _validate_offsets
 from lean_spec.types.constants import OFFSET_BYTE_LENGTH
 from lean_spec.types.container import Container


### PR DESCRIPTION
## What

Update one import in `simulators/lean/helper/lean_spec_client_runner.py` to follow the rename of `lean_spec.types.aggregation` → `lean_spec.types.participation`.

## Why

leanSpec PR [#719](https://github.com/leanEthereum/leanSpec/pull/719) (merged 2026-05-15, commit `386cd58`) renamed `src/lean_spec/types/aggregation.py` to `src/lean_spec/types/participation.py`. The lean helper image installs leanSpec from `devnet4_tag=main` (`simulators/lean/Dockerfile:55`), so every image rebuild after that merge picks up the new module name. Meanwhile the runner script, added by #1487 on 2026-05-12, still does:

```python
from lean_spec.types.aggregation import AggregationBits, ValidatorIndices
```

The `lean-spec-local-helper` container therefore crashes during `python /app/hive/lean_spec_client_runner.py` with:

```
File "/app/hive/lean_spec_client_runner.py", line 51, in <module>
    from lean_spec.types.aggregation import AggregationBits, ValidatorIndices
ModuleNotFoundError: No module named 'lean_spec.types.aggregation'
```

## Observed impact

On <https://hive.leanroadmap.org/> this manifests starting 2026-05-16 ~09 UTC as a collapse of every test that calls `start_post_genesis_sync_context` (i.e. any test that needs the helper mesh):

| Suite | Aggregate passes before | Aggregate passes after |
|---|---|---|
| `sync` | 22/25 | 1/25 |
| `reqresp` | 131/169 | 15/169 |

The only `reqresp` survivors are the two tests that bypass the helper and only use `MockNode` (`incompatible_finalized_root`, `incompatible_fork_or_network`).

Because the helper dies before any client-under-test is launched, the failing test records have no `clientInfo` and are not attributed to any client on the dashboard. This makes per-client tallies (e.g. ethlambda's "tests run") visibly drop without any client-side regression.
