### PR TITLE
fix(discv5): add discovery port configuration for reth client

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -165,6 +165,10 @@ fi
 # Configure NAT and disable pruning
 FLAGS="$FLAGS --nat none --block-interval 500000"
 
+if [ "$HIVE_DISCV5" != "" ]; then
+    FLAGS="$FLAGS --discovery.v5.port=30303"
+fi
+
 # Launch the main client.
 echo "Running reth with flags: $FLAGS"
 RUST_LOG=info $reth node $FLAGS


### PR DESCRIPTION
Hive is testing Reth’s discv5 on UDP port 30303.

Reth’s discv5 defaults to UDP port 9200.

Hive’s Reth wrapper sees `HIVE_DISCV5=1` but does not pass a Reth flag to move discv5 onto 30303, so the test sends PING/TALKREQ/FINDNODE to the wrong port and times out.