### PR TITLE
fix(reth): add flag for startup to mark idle

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -163,7 +163,7 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
 fi
 
 # Configure NAT and disable pruning
-FLAGS="$FLAGS --nat none --block-interval 500000"
+FLAGS="$FLAGS --nat none --block-interval 500000 --debug.startup-sync-state-idle"
 
 # Launch the main client.
 echo "Running reth with flags: $FLAGS"


### PR DESCRIPTION
this flag tells reth to mark startup sync as idle when no backfill is running, so the transaction manager stops treating the node as “initially syncing.” should fix the generic/eth devp2p tests