### PR TITLE
simulators/lean: accept attestation_keypair/proposal_keypair validator schema

### DIFF
--- a/simulators/lean/helper/prepare_lean_client_assets.py
+++ b/simulators/lean/helper/prepare_lean_client_assets.py
@@ -75,6 +75,13 @@ def parse_runtime_validator_indices() -> list[int] | None:
 
 def load_source_validator(index: int) -> dict[str, str]:
     validator = json.loads((SOURCE_KEYS_DIR / f"{index}.json").read_text(encoding="utf-8"))
+    if {"attestation_keypair", "proposal_keypair"}.issubset(validator):
+        return {
+            "attestation_public": validator["attestation_keypair"]["public_key"],
+            "attestation_secret": validator["attestation_keypair"]["secret_key"],
+            "proposal_public": validator["proposal_keypair"]["public_key"],
+            "proposal_secret": validator["proposal_keypair"]["secret_key"],
+        }
     if {
         "attestation_public",
         "attestation_secret",


### PR DESCRIPTION
## Summary

leansig-test-keys release `latest` was reuploaded 2026-05-21 08:08 UTC ([leanEthereum/leansig-test-keys#7](https://github.com/leanEthereum/leansig-test-keys/pull/7), *regenerate keys at leanSpec@d6844a0*) with a new nested schema:

```json
{
  "attestation_keypair": { "public_key": "...", "secret_key": "..." },
  "proposal_keypair":    { "public_key": "...", "secret_key": "..." }
}
```

`prepare_lean_client_assets.load_source_validator` only knew the older flat shapes (`{attestation_public, attestation_secret, proposal_public, proposal_secret}` and the legacy `{public, secret}`), so every client launched by the lean simulator raised:

```
ValueError: Unsupported validator key format for /app/hive/prod_scheme_devnet4/0.json
```

The Rust harness then panicked at `simulators/lean/src/utils/util.rs:547` (`Unable to prepare runtime assets for ${client}`) before the client binary started, so the failure isn't attributable to any `client_kind`. On https://hive.leanroadmap.org/ this surfaces as `client-interop` `1/64` with `clients:[]` from 2026‑05‑21 09:00 UTC onwards — every topology pair fails identically; the lone pass is the `matrix` topology-setup case which runs before any client startup. Other suites that go through `start_interop_client` / `prepare_client_runtime_files` hit the same path.

## What this changes

A new branch in `load_source_validator` that maps the nested keypair shape onto the same flat dict the rest of the file already consumes:

```python
if {"attestation_keypair", "proposal_keypair"}.issubset(validator):
    return {
        "attestation_public": validator["attestation_keypair"]["public_key"],
        "attestation_secret": validator["attestation_keypair"]["secret_key"],
        "proposal_public":    validator["proposal_keypair"]["public_key"],
        "proposal_secret":    validator["proposal_keypair"]["secret_key"],
    }
```

The two pre-existing branches are left intact, so pinning `devnet3_keys_tag` / `devnet4_keys_tag` to an older release still works.

## Test plan

- [x] Smoke-test the patched `load_source_validator` against both real release tarballs (`leansig-test-keys/releases/download/latest/prod_scheme.tar.gz` and `.../leanSpec-2c691ba6/prod_scheme.tar.gz`): both schemas now parse and produce the four flat string fields downstream code expects.
- [ ] Once merged, confirm `client-interop` recovers on https://hive.leanroadmap.org/ at the next dashboard rebuild.