### PR TITLE
clients, cmd/hivechain: Source depositContractAddress from HIVE_DEPOSIT_CONTRACT_ADDRESS

### DIFF
--- a/clients/besu/mapper.jq
+++ b/clients/besu/mapper.jq
@@ -99,7 +99,7 @@ def to_int:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000",
     "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
     "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
   }|remove_empty

--- a/clients/erigon/mapper.jq
+++ b/clients/erigon/mapper.jq
@@ -107,6 +107,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
   }|remove_empty
 }

--- a/clients/ethrex/mapper.jq
+++ b/clients/ethrex/mapper.jq
@@ -107,6 +107,6 @@ def to_bool:
         "baseFeeUpdateFraction": (if env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 8832827 end)
       }
     },
-    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
   }|remove_empty
 }

--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -112,6 +112,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
   }|remove_empty
 }

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -161,7 +161,7 @@ def clique_engine:
     "eip7702TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
     "eip7623TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
 
-    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000",
 
     # Osaka
     "eip7594TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,

--- a/clients/nimbus-el/mapper.jq
+++ b/clients/nimbus-el/mapper.jq
@@ -127,6 +127,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000",
   }|remove_empty
 }

--- a/clients/reth/mapper.jq
+++ b/clients/reth/mapper.jq
@@ -107,6 +107,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
   }|remove_empty
 }

--- a/cmd/hivechain/output_forkenv.go
+++ b/cmd/hivechain/output_forkenv.go
@@ -14,6 +14,9 @@ func (g *generator) writeForkEnv() error {
 	env["HIVE_CHAIN_ID"] = fmt.Sprint(cfg.ChainID)
 	env["HIVE_NETWORK_ID"] = fmt.Sprint(cfg.ChainID)
 
+	// system contracts
+	env["HIVE_DEPOSIT_CONTRACT_ADDRESS"] = cfg.DepositContractAddress.Hex()
+
 	// config consensus algorithm
 	if cfg.Clique != nil {
 		env["HIVE_CLIQUE_PERIOD"] = fmt.Sprint(cfg.Clique.Period)


### PR DESCRIPTION
The EL client genesis/chainspec mappers hardcoded the mainnet deposit contract address (`0x000…7705Fa`), so every client reported it back in `eth_config` regardless of the chain under test. That breaks the `rpc-compat` `eth_config/get-config` fixture, which expects the zero address.
