### PR TITLE
simulators/lean: document make build prerequisite and add example commands

### DIFF
--- a/simulators/lean/README.md
+++ b/simulators/lean/README.md
@@ -20,6 +20,23 @@ LeanSpec helper image generates and caches a small fixed set of validator keys
 at image-build time so the tests do not need to regenerate them on every
 container start.
 
+## Prerequisites
+
+The lean simulator is part of the Rust workspace, so its source is compiled
+inside a Docker image when you invoke `./hive --sim lean …`. Before running
+any simulation, build the workspace locally from the repo root:
+
+```
+make build
+```
+
+This wraps `cargo build --workspace --all-targets` and surfaces Rust
+compilation errors in seconds, instead of waiting for them to fail inside a
+slow Docker build. It is the same `build` target CI exercises through
+`make lint` (see the root `Makefile`).
+
+## Selecting a devnet profile
+
 Select the Lean devnet profile through the standard Hive client-file config.
 Reusable devnet profiles live in `simulators/lean/clients/`:
 
@@ -33,6 +50,55 @@ The lean simulator resolves the active devnet from the selected client name
 (`ream_devnet4`, `ethlambda_devnet3`, `gean_devnet3`, and so on) and validates
 it against the central support matrix in
 `simulators/lean/config/lean-devnets.txt`.
+
+## Examples
+
+### Sync example
+
+Run the default lean suites (RPC + sync) against a single `ream_devnet4`
+node, forcing fresh client and simulator images, and write results under
+`./workspace/logs`:
+
+```
+./hive --sim lean \
+    --client-file simulators/lean/clients/devnet4.yaml \
+    --client ream_devnet4 \
+    --docker.output \
+    --docker.nocache \
+    --results-root ./workspace/logs
+```
+
+### Client-interop example
+
+Run only the `client-interop` suite between `ream_devnet4` and
+`lantern_devnet4`, rebuilding only the `ream_devnet4` image so iterating on
+one client does not invalidate the others. Results go to a separate
+`logs-tracer` directory, and stdout/stderr are tee'd to `/tmp/hive-tracer.log`
+for later inspection:
+
+```
+./hive --sim lean \
+    --client-file simulators/lean/clients/devnet4.yaml \
+    --client ream_devnet4,lantern_devnet4 \
+    --sim.limit "client-interop" \
+    --docker.output \
+    --docker.nocache="hive/clients/ream_devnet4" \
+    --results-root ./workspace/logs-tracer 2>&1 | tee /tmp/hive-tracer.log
+```
+
+### Flag reference
+
+| Flag | Purpose |
+| --- | --- |
+| `--sim` | Selects the simulator under `simulators/<name>/` (here, `lean`). |
+| `--client-file` | YAML listing `client` + `nametag` pairs to launch (e.g. `simulators/lean/clients/devnet4.yaml`). |
+| `--client` | Comma-separated subset of clients from `--client-file` to actually run. |
+| `--sim.limit` | Regex filter; only test names matching are run (sets `HIVE_TEST_PATTERN`). |
+| `--docker.output` | Streams container stdout/stderr to the host — required to see Rust panics or lean client logs while iterating. |
+| `--docker.nocache` | Regex of Docker image names to rebuild from scratch (e.g. `hive/clients/ream_devnet4`). Bare `--docker.nocache` rebuilds everything. |
+| `--results-root` | Directory where Hive writes per-run logs and the `hive.json` viewable with `hiveview`. |
+
+The full flag list lives in [`docs/commandline.md`](../../docs/commandline.md).
 
 This gives us a simple onboarding path for new lean clients while leaving a clear place to grow:
 


### PR DESCRIPTION
## Summary

- Adds a **Prerequisites** section to `simulators/lean/README.md` telling contributors to run `make build` from the repo root before invoking `./hive --sim lean …`. The lean simulator is part of the Rust workspace and gets compiled inside a Docker image when Hive runs it; `make build` (which wraps `cargo build --workspace --all-targets`) surfaces compile errors in seconds instead of waiting for them to fail inside a slow Docker build. I hit exactly that loop on my first run and only learned afterward that the pre-flight build step wasn't documented.
- Adds two worked **Examples** (sync against a single client, and a `client-interop` run between two clients with scoped `--docker.nocache` and tee'd logs) so new contributors can copy-paste a realistic invocation instead of inferring flag combinations from `docs/commandline.md`.
- Adds a short **Flag reference** table covering only the flags used in those two examples (`--sim`, `--client-file`, `--client`, `--sim.limit`, `--docker.output`, `--docker.nocache`, `--results-root`), with a pointer to `docs/commandline.md` for the full list.

No code changes — README only.

## Test plan

- [ ] `make build` succeeds from a clean checkout (validates the prerequisite the README now claims).
- [ ] The sync example command starts the lean simulator end-to-end and writes results under `./workspace/logs`.
- [ ] README renders correctly on github.com — fenced code blocks and the flag-reference table.
- [ ] `git diff master...HEAD` shows only `simulators/lean/README.md`.