### PR TITLE
clients: alias missing devnet5 image tags to devnet4

### DIFF
--- a/clients/gean/Dockerfile
+++ b/clients/gean/Dockerfile
@@ -1,7 +1,8 @@
 ARG devnet4_baseimage=ghcr.io/geanlabs/gean
 ARG devnet4_tag=devnet4
 ARG devnet5_baseimage=ghcr.io/geanlabs/gean
-ARG devnet5_tag=devnet5
+# TODO: this is a placeholder until a devnet5 image is published
+ARG devnet5_tag=devnet4
 
 FROM $devnet5_baseimage:$devnet5_tag AS devnet5
 FROM $devnet4_baseimage:$devnet4_tag

--- a/clients/grandine_lean/Dockerfile
+++ b/clients/grandine_lean/Dockerfile
@@ -1,7 +1,8 @@
 ARG devnet4_baseimage=sifrai/lean
 ARG devnet4_tag=devnet-4
 ARG devnet5_baseimage=sifrai/lean
-ARG devnet5_tag=devnet-5
+# TODO: this is a placeholder until a devnet5 image is published
+ARG devnet5_tag=devnet-4
 
 FROM $devnet5_baseimage:$devnet5_tag AS devnet5
 FROM $devnet4_baseimage:$devnet4_tag

--- a/clients/lantern/Dockerfile
+++ b/clients/lantern/Dockerfile
@@ -1,6 +1,7 @@
 ARG baseimage=piertwo/lantern
 ARG devnet4_tag=v0.0.4
-ARG devnet5_tag=devnet5
+# TODO: this is a placeholder until a devnet5 image is published
+ARG devnet5_tag=v0.0.4
 
 FROM ${baseimage}:${devnet5_tag} AS devnet5
 FROM ${baseimage}:${devnet4_tag}

--- a/clients/nlean/Dockerfile
+++ b/clients/nlean/Dockerfile
@@ -1,7 +1,8 @@
 ARG devnet4_baseimage=ghcr.io/nleaneth/nlean
 ARG devnet4_tag=devnet4
 ARG devnet5_baseimage=ghcr.io/nleaneth/nlean
-ARG devnet5_tag=devnet5
+# TODO: this is a placeholder until a devnet5 image is published
+ARG devnet5_tag=devnet4
 
 FROM $devnet5_baseimage:$devnet5_tag AS devnet5
 FROM $devnet4_baseimage:$devnet4_tag

--- a/clients/qlean/Dockerfile
+++ b/clients/qlean/Dockerfile
@@ -1,7 +1,8 @@
 ARG devnet4_baseimage=qdrvm/qlean-mini
 ARG devnet4_tag=devnet-4
 ARG devnet5_baseimage=qdrvm/qlean-mini
-ARG devnet5_tag=devnet-5
+# TODO: this is a placeholder until a devnet5 image is published
+ARG devnet5_tag=devnet-4
 
 FROM $devnet5_baseimage:$devnet5_tag AS devnet5
 FROM $devnet4_baseimage:$devnet4_tag

--- a/clients/zeam/Dockerfile
+++ b/clients/zeam/Dockerfile
@@ -1,5 +1,6 @@
 FROM blockblaz/zeam:devnet4 AS devnet4-binary
-FROM blockblaz/zeam:devnet5 AS devnet5-binary
+# TODO: this is a placeholder until a devnet5 image is published
+FROM blockblaz/zeam:devnet4 AS devnet5-binary
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
## Context

PR #1515 introduced a multi-stage devnet5 build step in every lean client
Dockerfile. Six of the eight lean client teams have not yet published a
devnet5 image to their container registries, so `docker build` fails for
those clients and hive silently drops them from runs.

The visible symptom on hive.leanroadmap.org: starting at the PR's merge
time (2026-05-28T07:36:22Z), the client pool collapsed from 8 to 2
(ethlambda + ream). The `client-interop` suite, which scales with the
number of client pairs, dropped from ~193 tests per run to 13.

## Affected clients and current registry state

| Client          | Registry                          | devnet5 image published? |
|-----------------|-----------------------------------|--------------------------|
| ethlambda       | ghcr.io/lambdaclass/ethlambda     | yes                      |
| ream            | ghcr.io/reamlabs/ream             | yes (latest-devnet5)     |
| gean            | ghcr.io/geanlabs/gean             | no                       |
| grandine_lean   | sifrai/lean                       | no                       |
| lantern         | piertwo/lantern                   | no                       |
| nlean           | ghcr.io/nleaneth/nlean            | no                       |
| qlean           | qdrvm/qlean-mini                  | no                       |
| zeam            | blockblaz/zeam                    | no                       |

(Verified against each registry's tag listing on 2026-05-28.)

## Change

For each missing client, alias the `devnet5_tag` ARG (or, for zeam, the
hard-coded `FROM` line) to the corresponding devnet4 tag. Each change is
marked with a one-line TODO comment so maintainers know to update the
placeholder to point at their devnet5 image when it is published.

The lean simulator selects which binary to run via client name suffix
(`X_devnet4` vs `X_devnet5`), and the lean client YAML files in
`simulators/lean/clients/` don't pass `build_args:`. So:

- `--client X_devnet4` runs each team's devnet4 binary, as today
- `--client X_devnet5` runs the same binary as a stand-in until the team
  updates the placeholder
- Maintainers can also override at run time with
  `--client.build-args X:devnet5_tag=<real-tag>`

## Effect

Restores the 8-client devnet4 pool on hive.leanroadmap.org. The devnet5
profile remains technically buildable but the six placeholder clients
run their devnet4 binary until each team publishes its real devnet5
image and updates the tag here.

## Follow-up for client teams

The six teams should publish a devnet5 image to their respective
registries and update the `devnet5_tag` ARG (or the `FROM` line, for
zeam) to point at it.