### PR TITLE
clients/erigon: import all per-block files in a single process

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -91,14 +91,14 @@ else
     echo "Warning: chain.rlp not found."
 fi
 
-# Load the remainder of the test chain
+# Load the remainder of the test chain.
+# Import all per-block files in a single erigon process (matching geth.sh):
+# restarting erigon per file makes block-heavy tests (e.g. walletReorganizeOwners,
+# ForkStressTest) blow past Hive's container-startup timeout.
 echo "Loading remaining individual blocks..."
 if [ -d /blocks ]; then
     echo "Loading remaining individual blocks..."
-    for file in $(ls /blocks | sort -n); do
-        echo "Importing " $file
-        $erigon $FLAGS import /blocks/$file
-    done
+    (cd /blocks && $erigon $FLAGS import $(ls | sort -n))
 else
     echo "Warning: blocks folder not found."
 fi

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -91,8 +91,6 @@ else
     echo "Warning: chain.rlp not found."
 fi
 
-# Load the remaining blocks in a single erigon process (like geth.sh): a process
-# per block file blows past Hive's container-startup timeout on block-heavy tests.
 echo "Loading remaining individual blocks..."
 if [ -d /blocks ]; then
     (cd /blocks && $erigon $FLAGS import $(ls | sort -n))

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -91,6 +91,7 @@ else
     echo "Warning: chain.rlp not found."
 fi
 
+# Load the remainder of the test chain
 echo "Loading remaining individual blocks..."
 if [ -d /blocks ]; then
     (cd /blocks && $erigon $FLAGS import $(ls | sort -n))

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -91,13 +91,10 @@ else
     echo "Warning: chain.rlp not found."
 fi
 
-# Load the remainder of the test chain.
-# Import all per-block files in a single erigon process (matching geth.sh):
-# restarting erigon per file makes block-heavy tests (e.g. walletReorganizeOwners,
-# ForkStressTest) blow past Hive's container-startup timeout.
+# Load the remaining blocks in a single erigon process (like geth.sh): a process
+# per block file blows past Hive's container-startup timeout on block-heavy tests.
 echo "Loading remaining individual blocks..."
 if [ -d /blocks ]; then
-    echo "Loading remaining individual blocks..."
     (cd /blocks && $erigon $FLAGS import $(ls | sort -n))
 else
     echo "Warning: blocks folder not found."


### PR DESCRIPTION
## Problem

The erigon client restarts a full erigon process for **every** file in `/blocks`, whereas `clients/go-ethereum/geth.sh` imports them all in a single invocation:

```bash
# clients/erigon/erigon.sh (before)
for file in $(ls /blocks | sort -n); do
    $erigon $FLAGS import /blocks/$file
done
```

On block-heavy BlockchainTests (`walletReorganizeOwners`, `ForkStressTest`) the per-process startup overhead (~0.5s × hundreds of blocks) pushes total client startup past Hive's 180s container-startup timeout, producing intermittent `client did not start: timed out waiting for container startup` failures — e.g. `legacy-cancun` `walletReorganizeOwners_{Cancun,Istanbul,London,Paris}` ([example run](https://hive.ethpandaops.io/#/test/generic/1779833679-c7f17208e0b5dbf959b3448bbdaed60e), ~181s each; the Shanghai/Berlin variants and `ForkStressTest_*` sit at 146–150s, right at the cliff).

## Fix

Import all per-block files in one erigon process, matching `geth.sh`:

```bash
(cd /blocks && $erigon $FLAGS import $(ls | sort -n))
```

This collapses hundreds of process startups into one (~150s → ~10s for `walletReorganizeOwners`).

## Dependency

**Requires erigontech/erigon#21513** (merged). Older erigon `import` only processed the first file argument, so `import $(ls | sort -n)` would import only the first block. That fix must merge and ship in the erigon image before this lands — hence **draft**.
