### PR TITLE
fix(ethrex): parenthesize // in mapper.jq depositContractAddress

### DIFF
--- a/clients/ethrex/mapper.jq
+++ b/clients/ethrex/mapper.jq
@@ -107,6 +107,6 @@ def to_bool:
         "baseFeeUpdateFraction": (if env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 8832827 end)
       }
     },
-    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
+    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000")
   }|remove_empty
 }


### PR DESCRIPTION
#1507 added this to clients/ethrex/mapper.jq:

```jq
"depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
```

jq doesn't allow a bare `//` as an object value (object values are parsed with a restricted grammar; binary operators have to be parenthesized), so the mapper fails to compile:

```
jq: error: syntax error, unexpected //, expecting '}' at line 110
```

That means no genesis.json gets written and the ethrex client can't start, so every test fails with `could not start client ... terminated unexpectedly`.

Quick repro:

```
echo '{}' | jq '{ "a": env.X // "y" }'    # error
echo '{}' | jq '{ "a": (env.X // "y") }'  # ok
```

Fix is just wrapping it in parens, like the other fields in the file already do. Confirmed the mapper compiles and runs after the change.