### PR TITLE
clients: fix deposit contract address in remaining mappers

### DIFF
--- a/clients/erigon/mapper.jq
+++ b/clients/erigon/mapper.jq
@@ -107,6 +107,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
+    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000")
   }|remove_empty
 }

--- a/clients/go-ethereum/mapper.jq
+++ b/clients/go-ethereum/mapper.jq
@@ -112,6 +112,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
+    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000")
   }|remove_empty
 }

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -161,7 +161,7 @@ def clique_engine:
     "eip7702TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
     "eip7623TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
 
-    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000",
+    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"),
 
     # Osaka
     "eip7594TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,

--- a/clients/nimbus-el/mapper.jq
+++ b/clients/nimbus-el/mapper.jq
@@ -127,6 +127,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000",
+    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"),
   }|remove_empty
 }

--- a/clients/reth/mapper.jq
+++ b/clients/reth/mapper.jq
@@ -107,6 +107,6 @@ def to_bool:
     "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
-    "depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
+    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000")
   }|remove_empty
 }


### PR DESCRIPTION
## Problem

PR #1507 introduced an unparenthesized jq alternative (`//`) operator in the `depositContractAddress` object value:

```jq
"depositContractAddress": env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000"
```

jq parses object construction values with a restricted grammar (`ExpD`) that **does not allow the `//` operator**, so this is a hard compile error that breaks the *entire* mapper:

```
jq: error: syntax error, unexpected //, expecting '}'
```

## Fix

besu (#1523) and ethrex (#1524) were already fixed by wrapping the expression in parentheses. This applies the same fix to the remaining affected clients introduced in #1507:

- go-ethereum
- reth
- erigon
- nethermind
- nimbus-el

```jq
"depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x0000000000000000000000000000000000000000")
```