### PR TITLE
simulators/lean: bad peer sync test

### DIFF
--- a/simulators/lean/Dockerfile
+++ b/simulators/lean/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:bookworm AS rust-builder
+FROM rust:1.92.0-bookworm AS rust-builder
 
 WORKDIR /workspace
 
-ENV RUST_MIN_STACK=33554432
+ENV RUST_MIN_STACK=67108864
 
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock

--- a/simulators/lean/src/scenarios/sync.rs
+++ b/simulators/lean/src/scenarios/sync.rs
@@ -1,7 +1,9 @@
 use crate::utils::helper::{
-    start_checkpoint_sync_client_context, start_checkpoint_sync_helper_mesh,
-    start_post_genesis_sync_context, HelperGossipForkDigestProfile, PostGenesisSyncContext,
-    PostGenesisSyncTestData, LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
+    start_bad_checkpoint_peer, start_checkpoint_sync_client_context,
+    start_checkpoint_sync_helper_mesh, start_post_genesis_sync_context,
+    start_post_genesis_sync_context_with_extra_bootnodes_after_helper_agreement,
+    HelperGossipForkDigestProfile, PostGenesisSyncContext, PostGenesisSyncTestData,
+    RunningBadCheckpointPeer, LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
 };
 use crate::utils::util::{
     default_genesis_time, fork_choice_head_slot, lean_clients, load_fork_choice_response,
@@ -17,6 +19,8 @@ const CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS: u64 = 180;
 const HEAD_SYNC_TIMEOUT_SECS: u64 = CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS;
 const HEAD_BEHIND_FINALIZED_STARTUP_TIMEOUT_SECS: u64 = 600;
 const HEAD_BEHIND_FINALIZED_HELPER_PROGRESS_TIMEOUT_SECS: u64 = 420;
+const BAD_CHECKPOINT_PEER_AHEAD_TIMEOUT_SECS: u64 = 120;
+const BAD_CHECKPOINT_PEER_MIN_SLOT_LEAD: u64 = 4;
 const SYNC_HELPER_PEER_COUNT: usize = 2;
 const HEAD_SYNC_MAX_SLOT_LAG: u64 = 2;
 
@@ -223,6 +227,36 @@ async fn wait_for_helper_finalized_above_client_head(
     }
 }
 
+async fn wait_for_honest_helper_finalized_agreement(
+    context: &mut PostGenesisSyncContext,
+    minimum_finalized_slot: u64,
+    phase: &str,
+) -> ForkChoiceResponse {
+    let mut last_error = None;
+    let deadline =
+        Instant::now() + Duration::from_secs(HEAD_BEHIND_FINALIZED_HELPER_PROGRESS_TIMEOUT_SECS);
+
+    while Instant::now() < deadline {
+        match context
+            .try_load_agreed_helper_fork_choice(minimum_finalized_slot)
+            .await
+        {
+            Ok(fork_choice) => return fork_choice,
+            Err(err) => last_error = Some(err),
+        }
+
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    panic!(
+        "Honest LeanSpec helpers did not agree on a finalized checkpoint at or above slot {} within {} seconds while {}. Last observation: {}",
+        minimum_finalized_slot,
+        HEAD_BEHIND_FINALIZED_HELPER_PROGRESS_TIMEOUT_SECS,
+        phase,
+        last_error.unwrap_or_else(|| "no helper forkchoice responses were observed".to_string())
+    );
+}
+
 async fn wait_for_helper_justified_above_client_head(
     context: &mut PostGenesisSyncContext,
     client_head_slot: u64,
@@ -267,6 +301,127 @@ async fn wait_for_helper_justified_above_client_head(
             HEAD_BEHIND_FINALIZED_HELPER_PROGRESS_TIMEOUT_SECS,
             client_head_slot,
         )),
+    }
+}
+
+async fn wait_for_bad_peer_finalized_ahead(
+    bad_peer: &mut RunningBadCheckpointPeer,
+    source: &ForkChoiceResponse,
+) -> ForkChoiceResponse {
+    let source_finalized_slot = source.finalized.slot;
+    let deadline = Instant::now() + Duration::from_secs(BAD_CHECKPOINT_PEER_AHEAD_TIMEOUT_SECS);
+    let mut last_bad_fork_choice = None;
+    let mut last_error = None;
+
+    while Instant::now() < deadline {
+        let bad_fork_choice = match bad_peer.try_load_fork_choice().await {
+            Ok(fork_choice) => fork_choice,
+            Err(err) => {
+                last_error = Some(err);
+                sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+
+        if bad_fork_choice.finalized.slot
+            >= source_finalized_slot.saturating_add(BAD_CHECKPOINT_PEER_MIN_SLOT_LEAD)
+        {
+            return bad_fork_choice;
+        }
+
+        last_bad_fork_choice = Some(bad_fork_choice);
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    match last_bad_fork_choice {
+        Some(last) => {
+            let last_error = last_error
+                .as_deref()
+                .unwrap_or("no adversarial peer forkchoice request errors observed");
+            panic!(
+                "Adversarial peer never stayed at least {} finalized slots ahead of the honest helper network within {} seconds (honest finalized slot: {}, adversarial finalized slot: {}, adversarial head slot: {}, last error: {})",
+                BAD_CHECKPOINT_PEER_MIN_SLOT_LEAD,
+                BAD_CHECKPOINT_PEER_AHEAD_TIMEOUT_SECS,
+                source_finalized_slot,
+                last.finalized.slot,
+                fork_choice_head_slot(&last),
+                last_error,
+            );
+        }
+        None => {
+            let last_error = last_error
+                .as_deref()
+                .unwrap_or("no adversarial peer forkchoice request attempted");
+            panic!(
+                "Adversarial peer never produced a forkchoice response while waiting {} seconds for it to stay at least {} finalized slots ahead of the honest helper network (honest finalized slot: {}, last error: {})",
+                BAD_CHECKPOINT_PEER_AHEAD_TIMEOUT_SECS,
+                BAD_CHECKPOINT_PEER_MIN_SLOT_LEAD,
+                source_finalized_slot,
+                last_error,
+            );
+        }
+    }
+}
+
+async fn wait_for_bad_peer_fork_choice(
+    bad_peer: &mut RunningBadCheckpointPeer,
+    phase: &str,
+) -> ForkChoiceResponse {
+    let deadline = Instant::now() + Duration::from_secs(BAD_CHECKPOINT_PEER_AHEAD_TIMEOUT_SECS);
+    let mut last_error = None;
+
+    while Instant::now() < deadline {
+        match bad_peer.try_load_fork_choice().await {
+            Ok(fork_choice) => return fork_choice,
+            Err(err) => last_error = Some(err),
+        }
+
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    let last_error = last_error
+        .as_deref()
+        .unwrap_or("no adversarial peer forkchoice request attempted");
+    panic!(
+        "Unable to load adversarial peer forkchoice {phase} within {} seconds: {}",
+        BAD_CHECKPOINT_PEER_AHEAD_TIMEOUT_SECS, last_error,
+    );
+}
+
+fn assert_client_rejected_bad_checkpoint(
+    phase: &str,
+    source: &ForkChoiceResponse,
+    client: &ForkChoiceResponse,
+    bad_peer: &ForkChoiceResponse,
+) {
+    let source_head_slot = fork_choice_head_slot(source);
+    let client_head_slot = fork_choice_head_slot(client);
+    let bad_head_slot = fork_choice_head_slot(bad_peer);
+
+    if bad_peer.finalized.slot
+        >= source
+            .finalized
+            .slot
+            .saturating_add(BAD_CHECKPOINT_PEER_MIN_SLOT_LEAD)
+    {
+        assert_ne!(
+            (client.finalized.root, client.finalized.slot),
+            (bad_peer.finalized.root, bad_peer.finalized.slot),
+            "{phase}: client finalized the adversarial peer's bad checkpoint at slot {} instead of following the honest helper network finalized slot {}",
+            bad_peer.finalized.slot,
+            source.finalized.slot,
+        );
+    }
+
+    if bad_head_slot >= source_head_slot.saturating_add(BAD_CHECKPOINT_PEER_MIN_SLOT_LEAD) {
+        assert!(
+            !head_slot_is_caught_up(client_head_slot, bad_head_slot),
+            "{phase}: client tracked the adversarial peer head slot {} while the honest helper network head was at slot {} (client head slot: {}, allowed lag: {})",
+            bad_head_slot,
+            source_head_slot,
+            client_head_slot,
+            HEAD_SYNC_MAX_SLOT_LAG,
+        );
     }
 }
 
@@ -328,6 +483,30 @@ dyn_async! {
                     helper_fork_digest_profile,
                 },
                 test_sync_head_behind_finalized_recovery,
+            )
+            .await;
+
+            let bad_checkpoint_rejection_genesis_time = default_genesis_time();
+            run_data_test(
+                test,
+                "sync: head behind finalized rejects ahead bad checkpoint".to_string(),
+                "Starts the client under test alongside two honest local LeanSpec helpers and an isolated adversarial LeanSpec peer whose validly signed chain is artificially ahead, pauses the client until the honest network finalizes beyond its head, unpauses it, and checks that the client follows the agreeing honest peers instead of the bad checkpoint from the single ahead peer.".to_string(),
+                false,
+                PostGenesisSyncTestData {
+                    client_under_test: client.clone(),
+                    genesis_time: bad_checkpoint_rejection_genesis_time,
+                    wait_for_client_justified_checkpoint: false,
+                    use_checkpoint_sync: false,
+                    connect_client_to_lean_spec_mesh: true,
+                    client_role: ClientUnderTestRole::Validator,
+                    source_helper_validator_indices: Some(
+                        LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0.to_string(),
+                    ),
+                    split_helper_validators_across_mesh: false,
+                    helper_peer_count: SYNC_HELPER_PEER_COUNT,
+                    helper_fork_digest_profile,
+                },
+                test_sync_head_behind_finalized_rejects_ahead_bad_checkpoint,
             )
             .await;
 
@@ -451,30 +630,24 @@ dyn_async! {
             source_before_pause.finalized.slot > 0,
             "helper source should reach a non-genesis finalized checkpoint before pausing the client under test"
         );
-        context
-            .client_under_test
-            .pause()
-            .await
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Unable to pause client under test {} after reading head {:#x} at slot {}: {}",
-                    client_name, paused_client_head, paused_client_head_slot, err
-                )
-            });
+        if let Err(err) = context.client_under_test.pause().await {
+            let error = err.to_string();
+            panic!(
+                "Unable to pause client under test {} after reading head {:#x} at slot {}: {}",
+                client_name, paused_client_head, paused_client_head_slot, error
+            );
+        }
 
         let helper_justified_above_head =
             wait_for_helper_justified_above_client_head(&mut context, paused_client_head_slot).await;
 
-        context
-            .client_under_test
-            .unpause()
-            .await
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Unable to unpause client under test {} after pausing at head {:#x} slot {}: {}",
-                    client_name, paused_client_head, paused_client_head_slot, err
-                )
-            });
+        if let Err(err) = context.client_under_test.unpause().await {
+            let error = err.to_string();
+            panic!(
+                "Unable to unpause client under test {} after pausing at head {:#x} slot {}: {}",
+                client_name, paused_client_head, paused_client_head_slot, error
+            );
+        }
 
         let helper_justified_above_head =
             helper_justified_above_head.unwrap_or_else(|err| panic!("{err}"));
@@ -590,6 +763,126 @@ dyn_async! {
             client_head_slot,
             source_head_slot,
             HEAD_SYNC_MAX_SLOT_LAG
+        );
+    }
+}
+
+dyn_async! {
+    async fn test_sync_head_behind_finalized_rejects_ahead_bad_checkpoint<'a>(test: &'a mut Test, test_data: PostGenesisSyncTestData) {
+        let client_name = test_data.client_under_test.name.clone();
+        let mut bad_peer = start_bad_checkpoint_peer(&test_data).await;
+        let bad_peer_bootnode = bad_peer.bootnode_for_client(&client_name);
+
+        let mut context = timeout(
+            Duration::from_secs(HEAD_BEHIND_FINALIZED_STARTUP_TIMEOUT_SECS),
+            start_post_genesis_sync_context_with_extra_bootnodes_after_helper_agreement(
+                test,
+                &test_data,
+                vec![bad_peer_bootnode],
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "head-behind-finalized bad-checkpoint helper mesh and client startup for {} exceeded {} seconds",
+                client_name, HEAD_BEHIND_FINALIZED_STARTUP_TIMEOUT_SECS
+            )
+        });
+
+        let honest_helper_agreement_before_pause = wait_for_honest_helper_finalized_agreement(
+            &mut context,
+            1,
+            "preparing the bad-checkpoint rejection test before pausing the client",
+        )
+        .await;
+        let minimum_source_head_slot = fork_choice_head_slot(&honest_helper_agreement_before_pause);
+        let (source_before_pause, client_before_pause) =
+            wait_for_client_to_reach_source_head(&mut context, minimum_source_head_slot).await;
+        let bad_before_pause =
+            wait_for_bad_peer_finalized_ahead(&mut bad_peer, &source_before_pause).await;
+        assert_client_rejected_bad_checkpoint(
+            "before pause",
+            &source_before_pause,
+            &client_before_pause,
+            &bad_before_pause,
+        );
+
+        let paused_client_head_slot = fork_choice_head_slot(&client_before_pause);
+        let paused_client_head = client_before_pause.head;
+
+        context
+            .client_under_test
+            .pause()
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Unable to pause client under test {} after reading head {:#x} at slot {}: {}",
+                    client_name, paused_client_head, paused_client_head_slot, err
+                )
+            });
+
+        let helper_finalized_above_head = wait_for_honest_helper_finalized_agreement(
+            &mut context,
+            paused_client_head_slot.saturating_add(1),
+            "waiting for the honest helpers to finalize beyond the paused client head",
+        )
+        .await;
+        let bad_while_paused =
+            wait_for_bad_peer_fork_choice(&mut bad_peer, "while client is paused").await;
+
+        context
+            .client_under_test
+            .unpause()
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Unable to unpause client under test {} after pausing at head {:#x} slot {}: {}",
+                    client_name, paused_client_head, paused_client_head_slot, err
+                )
+            });
+
+        let recovery_finalized_boundary = helper_finalized_above_head.finalized.slot;
+
+        assert!(
+            recovery_finalized_boundary > paused_client_head_slot,
+            "helper finalized slot ({}) should advance beyond paused client head slot ({}) before recovery",
+            recovery_finalized_boundary,
+            paused_client_head_slot
+        );
+        assert_client_rejected_bad_checkpoint(
+            "while paused",
+            &helper_finalized_above_head,
+            &client_before_pause,
+            &bad_while_paused,
+        );
+
+        let (source_after_recovery, client_after_recovery) =
+            wait_for_client_to_reach_source_head(&mut context, 0).await;
+        let bad_after_recovery =
+            wait_for_bad_peer_finalized_ahead(&mut bad_peer, &source_after_recovery).await;
+        let source_head_slot = fork_choice_head_slot(&source_after_recovery);
+        let client_head_slot = fork_choice_head_slot(&client_after_recovery);
+
+        assert!(
+            client_head_slot.saturating_add(HEAD_SYNC_MAX_SLOT_LAG) >= recovery_finalized_boundary,
+            "unpaused client should advance within the allowed lag of the helper finalized boundary that passed its paused head (client slot: {}, helper finalized boundary: {}, paused client slot: {}, allowed lag: {})",
+            client_head_slot,
+            recovery_finalized_boundary,
+            paused_client_head_slot,
+            HEAD_SYNC_MAX_SLOT_LAG
+        );
+        assert!(
+            client_caught_up_to_source(&source_after_recovery, &client_after_recovery),
+            "unpaused client should catch up to the honest helper live head slot (client slot: {}, helper slot: {}, allowed lag: {} slots)",
+            client_head_slot,
+            source_head_slot,
+            HEAD_SYNC_MAX_SLOT_LAG
+        );
+        assert_client_rejected_bad_checkpoint(
+            "after recovery",
+            &source_after_recovery,
+            &client_after_recovery,
+            &bad_after_recovery,
         );
     }
 }

--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -47,7 +47,7 @@ const DEFAULT_HELPER_P2P_PORT: u16 = 9001;
 const DEFAULT_HELPER_API_PORT: u16 = 5052;
 const DEFAULT_HELPER_METADATA_PORT: u16 = 5053;
 const MESH_HELPER_GENESIS_BUFFER_PER_PEER_SECS: u64 = 10;
-const MESH_HELPER_SOURCE_STARTUP_CUSHION_SECS: u64 = 60;
+const MESH_HELPER_SOURCE_STARTUP_CUSHION_SECS: u64 = 20;
 const POST_GENESIS_TIMEOUT_SECS: u64 = 600;
 const MIN_FINALIZED_SLOT_FOR_CHECKPOINT_SYNC: u64 = 10;
 const LOCAL_HELPER_STARTUP_TIMEOUT_SECS: u64 = 120;
@@ -60,6 +60,12 @@ const CHECKPOINT_SYNC_CLIENT_READY_TIMEOUT_SECS: u64 = 30;
 const MESH_HELPER_READY_TIMEOUT_SECS: u64 = 120;
 const OPTIONAL_MESH_HELPER_READY_GRACE_SECS: u64 = 15;
 const LIVE_HELPER_FORK_CHOICE_RETRY_ATTEMPTS: u64 = 10;
+const BAD_CHECKPOINT_PEER_GENESIS_DELAY_SECS: u64 = 5;
+const BAD_CHECKPOINT_PEER_P2P_PORT: u16 = DEFAULT_HELPER_P2P_PORT + 50;
+const BAD_CHECKPOINT_PEER_API_PORT: u16 = DEFAULT_HELPER_API_PORT + 100;
+const BAD_CHECKPOINT_PEER_METADATA_PORT: u16 = DEFAULT_HELPER_METADATA_PORT + 100;
+const BAD_CHECKPOINT_PEER_IDENTITY_PRIVATE_KEY_HEX: &str =
+    "2222222222222222222222222222222222222222222222222222222222222222";
 const LOCAL_HELPER_ENTRYPOINT: &str = "/app/hive/leanspec-client.sh";
 const LOCAL_HELPER_KIND: &str = "lean-spec-local-helper";
 const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
@@ -107,6 +113,10 @@ pub(crate) struct PostGenesisSyncContext {
     pub client_checkpoint: Option<CheckpointResponse>,
 }
 
+pub(crate) struct RunningBadCheckpointPeer {
+    helper: RunningLocalLeanSpecHelper,
+}
+
 pub(crate) struct CheckpointSyncHelperMesh {
     helpers: RunningLocalLeanSpecHelperGroup,
     source_fork_choice: ForkChoiceSnapshot,
@@ -126,6 +136,25 @@ impl PostGenesisSyncContext {
         self.try_load_live_helper_fork_choice()
             .await
             .unwrap_or_else(|err| panic!("{err}"))
+    }
+
+    pub(crate) async fn try_load_agreed_helper_fork_choice(
+        &mut self,
+        minimum_finalized_slot: u64,
+    ) -> Result<ForkChoiceResponse, String> {
+        self._helpers
+            .load_agreed_fork_choice(minimum_finalized_slot)
+            .await
+    }
+}
+
+impl RunningBadCheckpointPeer {
+    pub(crate) fn bootnode_for_client(&self, client_type: &str) -> String {
+        self.helper.bootnode_for_client(client_type)
+    }
+
+    pub(crate) async fn try_load_fork_choice(&mut self) -> Result<ForkChoiceResponse, String> {
+        self.helper.try_load_fork_choice().await
     }
 }
 
@@ -230,6 +259,67 @@ impl RunningLocalLeanSpecHelperGroup {
                 last_errors.join(" | ")
             }
         ))
+    }
+
+    async fn load_agreed_fork_choice(
+        &mut self,
+        minimum_finalized_slot: u64,
+    ) -> Result<ForkChoiceResponse, String> {
+        let source = self.source.try_load_fork_choice().await?;
+        let source_finalized = source.finalized.clone();
+        let mut best_fork_choice = source.clone();
+        let mut observations = vec![format!(
+            "{} finalized {:#x} at slot {}",
+            self.source.node_id, source_finalized.root, source_finalized.slot
+        )];
+        let mut agreement_errors = Vec::new();
+
+        if source_finalized.slot < minimum_finalized_slot {
+            agreement_errors.push(format!(
+                "{} finalized slot {} is below required slot {}",
+                self.source.node_id, source_finalized.slot, minimum_finalized_slot
+            ));
+        }
+
+        for helper in &mut self.mesh_peers {
+            match helper.try_load_fork_choice().await {
+                Ok(fork_choice) => {
+                    observations.push(format!(
+                        "{} finalized {:#x} at slot {}",
+                        helper.node_id, fork_choice.finalized.root, fork_choice.finalized.slot
+                    ));
+
+                    if fork_choice.finalized.slot != source_finalized.slot
+                        || fork_choice.finalized.root != source_finalized.root
+                    {
+                        agreement_errors.push(format!(
+                            "{} finalized {:#x} at slot {}, expected source finalized {:#x} at slot {}",
+                            helper.node_id,
+                            fork_choice.finalized.root,
+                            fork_choice.finalized.slot,
+                            source_finalized.root,
+                            source_finalized.slot
+                        ));
+                    }
+
+                    if is_better_fork_choice(&fork_choice, &best_fork_choice) {
+                        best_fork_choice = fork_choice;
+                    }
+                }
+                Err(err) => agreement_errors.push(err),
+            }
+        }
+
+        if agreement_errors.is_empty() {
+            Ok(best_fork_choice)
+        } else {
+            Err(format!(
+                "honest LeanSpec helpers have not agreed on a finalized checkpoint at or above slot {} (observed: {}; issues: {})",
+                minimum_finalized_slot,
+                observations.join(", "),
+                agreement_errors.join(" | ")
+            ))
+        }
     }
 }
 
@@ -825,9 +915,77 @@ pub(crate) async fn start_checkpoint_sync_client_context(
     }
 }
 
+pub(crate) async fn start_bad_checkpoint_peer(
+    test_data: &PostGenesisSyncTestData,
+) -> RunningBadCheckpointPeer {
+    let helper_fork_digest = helper_gossip_fork_digest(test_data.helper_fork_digest_profile);
+    let genesis_validator_count = helper_genesis_validator_count(test_data);
+    let genesis_time = current_unix_time() + BAD_CHECKPOINT_PEER_GENESIS_DELAY_SECS;
+    let mut helper_config = LocalLeanSpecHelperConfig::source(
+        genesis_time,
+        helper_fork_digest,
+        test_data.source_helper_validator_indices.clone(),
+        genesis_validator_count,
+    );
+    helper_config.node_id = "lean_spec_bad_checkpoint_peer".to_string();
+    helper_config.p2p_port = BAD_CHECKPOINT_PEER_P2P_PORT;
+    helper_config.api_port = BAD_CHECKPOINT_PEER_API_PORT;
+    helper_config.metadata_port = BAD_CHECKPOINT_PEER_METADATA_PORT;
+    helper_config.identity_private_key_hex =
+        Some(BAD_CHECKPOINT_PEER_IDENTITY_PRIVATE_KEY_HEX.to_string());
+
+    let (mut helper, _genesis_validator_entries) =
+        start_local_lean_spec_helper_with_genesis_metadata(&helper_config)
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Unable to start adversarial {LOCAL_HELPER_KIND} for bad checkpoint sync test: {err}"
+                )
+            });
+
+    wait_for_checkpoint_slot_with_retry(
+        &mut helper,
+        MIN_FINALIZED_SLOT_FOR_CHECKPOINT_SYNC,
+        &helper_config,
+    )
+    .await
+    .unwrap_or_else(|err| {
+        panic!(
+            "Adversarial {LOCAL_HELPER_KIND} did not reach a non-genesis finalized checkpoint: {err}"
+        )
+    });
+
+    RunningBadCheckpointPeer { helper }
+}
+
 pub(crate) async fn start_post_genesis_sync_context(
     test: &Test,
     test_data: &PostGenesisSyncTestData,
+) -> PostGenesisSyncContext {
+    start_post_genesis_sync_context_with_extra_bootnodes(test, test_data, Vec::new()).await
+}
+
+pub(crate) async fn start_post_genesis_sync_context_with_extra_bootnodes(
+    test: &Test,
+    test_data: &PostGenesisSyncTestData,
+    extra_bootnodes: Vec<String>,
+) -> PostGenesisSyncContext {
+    start_post_genesis_sync_context_inner(test, test_data, extra_bootnodes, false).await
+}
+
+pub(crate) async fn start_post_genesis_sync_context_with_extra_bootnodes_after_helper_agreement(
+    test: &Test,
+    test_data: &PostGenesisSyncTestData,
+    extra_bootnodes: Vec<String>,
+) -> PostGenesisSyncContext {
+    start_post_genesis_sync_context_inner(test, test_data, extra_bootnodes, true).await
+}
+
+async fn start_post_genesis_sync_context_inner(
+    test: &Test,
+    test_data: &PostGenesisSyncTestData,
+    extra_bootnodes: Vec<String>,
+    wait_for_helper_agreement_before_client_start: bool,
 ) -> PostGenesisSyncContext {
     let helper_peer_count = test_data.helper_peer_count.max(1);
     let genesis_time = adjusted_genesis_time_for_helper_mesh(
@@ -885,8 +1043,9 @@ pub(crate) async fn start_post_genesis_sync_context(
         source: source_helper,
         mesh_peers,
     };
-    let should_start_client_early =
-        !test_data.use_checkpoint_sync && test_data.connect_client_to_lean_spec_mesh;
+    let should_start_client_early = !wait_for_helper_agreement_before_client_start
+        && !test_data.use_checkpoint_sync
+        && test_data.connect_client_to_lean_spec_mesh;
     let initial_client_under_test_environment = client_under_test_environment(
         &helpers,
         &test_data.client_under_test.name,
@@ -896,6 +1055,9 @@ pub(crate) async fn start_post_genesis_sync_context(
         test_data.connect_client_to_lean_spec_mesh,
         test_data.client_role,
     );
+    let initial_client_under_test_environment =
+        with_extra_bootnodes(initial_client_under_test_environment, &extra_bootnodes);
+    let mut delayed_client_under_test_environment = initial_client_under_test_environment.clone();
 
     let client_under_test = if should_start_client_early {
         Some(
@@ -1015,6 +1177,13 @@ pub(crate) async fn start_post_genesis_sync_context(
                 )
             }
             Err(error) => {
+                if wait_for_helper_agreement_before_client_start {
+                    panic!(
+                        "Unable to start client under test {} because not all honest auxiliary {LOCAL_HELPER_KIND} instances reached post-genesis forkchoice: {error}",
+                        test_data.client_under_test.name
+                    );
+                }
+
                 eprintln!(
                     "Continuing post-genesis sync test despite auxiliary helper lag: {error}"
                 );
@@ -1044,6 +1213,35 @@ pub(crate) async fn start_post_genesis_sync_context(
         }
     }
 
+    if wait_for_helper_agreement_before_client_start {
+        let agreed_fork_choice = wait_for_helper_group_agreed_fork_choice(
+            &mut helpers,
+            minimum_source_checkpoint_slot(test_data),
+        )
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Unable to start client under test {} because the honest {LOCAL_HELPER_KIND} helpers were not ready and in agreement: {err}",
+                    test_data.client_under_test.name
+                )
+            });
+        delayed_client_under_test_environment = client_under_test_environment(
+            &helpers,
+            &test_data.client_under_test.name,
+            genesis_time,
+            &source_genesis_validator_entries,
+            test_data.use_checkpoint_sync,
+            test_data.connect_client_to_lean_spec_mesh,
+            test_data.client_role,
+        );
+        delayed_client_under_test_environment =
+            with_extra_bootnodes(delayed_client_under_test_environment, &extra_bootnodes);
+        source_fork_choice = ForkChoiceSnapshot {
+            justified: agreed_fork_choice.justified,
+            finalized: agreed_fork_choice.finalized,
+        };
+    }
+
     let client_under_test = match client_under_test {
         Some(client_under_test) => client_under_test,
         None if test_data.use_checkpoint_sync => {
@@ -1056,6 +1254,8 @@ pub(crate) async fn start_post_genesis_sync_context(
                 test_data.connect_client_to_lean_spec_mesh,
                 test_data.client_role,
             );
+            let checkpoint_sync_client_environment =
+                with_extra_bootnodes(checkpoint_sync_client_environment, &extra_bootnodes);
             start_checkpoint_sync_client_under_test_with_retry(CheckpointSyncClientStart {
                 test,
                 helper: &mut helpers.source,
@@ -1071,7 +1271,7 @@ pub(crate) async fn start_post_genesis_sync_context(
             start_client_under_test_with_retry(
                 test,
                 test_data.client_under_test.name.clone(),
-                initial_client_under_test_environment,
+                delayed_client_under_test_environment,
             )
             .await
         }
@@ -1263,6 +1463,30 @@ fn client_under_test_environment(
     }
 
     client_role.apply_to_environment(&mut environment);
+
+    environment
+}
+
+fn with_extra_bootnodes(
+    mut environment: HashMap<String, String>,
+    extra_bootnodes: &[String],
+) -> HashMap<String, String> {
+    if extra_bootnodes.is_empty() {
+        return environment;
+    }
+
+    let extra_bootnodes = extra_bootnodes.join(",");
+    environment
+        .entry(BOOTNODES_ENVIRONMENT_VARIABLE.to_string())
+        .and_modify(|bootnodes| {
+            if bootnodes.is_empty() {
+                *bootnodes = extra_bootnodes.clone();
+            } else {
+                bootnodes.push(',');
+                bootnodes.push_str(&extra_bootnodes);
+            }
+        })
+        .or_insert(extra_bootnodes);
 
     environment
 }
@@ -1857,6 +2081,32 @@ async fn wait_for_all_mesh_helpers_to_reach_post_genesis(
         helpers.len(),
         MESH_HELPER_READY_TIMEOUT_SECS,
         last_errors.join(" | ")
+    ))
+}
+
+async fn wait_for_helper_group_agreed_fork_choice(
+    helpers: &mut RunningLocalLeanSpecHelperGroup,
+    minimum_finalized_slot: u64,
+) -> Result<ForkChoiceResponse, String> {
+    let mut last_error = None;
+
+    for _attempt in 0..MESH_HELPER_READY_TIMEOUT_SECS {
+        match helpers
+            .load_agreed_fork_choice(minimum_finalized_slot)
+            .await
+        {
+            Ok(fork_choice) => return Ok(fork_choice),
+            Err(err) => last_error = Some(err),
+        }
+
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    Err(format!(
+        "Honest {LOCAL_HELPER_KIND} group did not agree on a finalized checkpoint at or above slot {} within {} seconds: {}",
+        minimum_finalized_slot,
+        MESH_HELPER_READY_TIMEOUT_SECS,
+        last_error.unwrap_or_else(|| "no helper forkchoice responses were observed".to_string())
     ))
 }
 


### PR DESCRIPTION
Added a bad peer sync test to ensure that clients ignore an outlier peer and do not use it as a source to attempt to catch up to head