### PR TITLE
fix graphql on gas estimation

### DIFF
--- a/simulators/ethereum/graphql/testcases/04_eth_estimateGas_contractDeploy.json
+++ b/simulators/ethereum/graphql/testcases/04_eth_estimateGas_contractDeploy.json
@@ -3,7 +3,7 @@
   "responses":[{
     "data" : {
       "block" : {
-        "estimateGas" : "0x1b551"
+        "estimateGas" : "0x1b954"
       }
     }
   }],

--- a/simulators/ethereum/graphql/testcases/05_eth_estimateGas_noParams.json
+++ b/simulators/ethereum/graphql/testcases/05_eth_estimateGas_noParams.json
@@ -3,7 +3,7 @@
   "responses":[{
     "data" : {
       "block" : {
-        "estimateGas" : "0x5208"
+        "estimateGas" : "0x52ad"
       }
     }
   }],


### PR DESCRIPTION

Fix expected for gasEstimation: responses are set in accordance with Geth and Erigon clients.