### PR TITLE
clients/besu: remove discv5 experimental flag

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -166,11 +166,6 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     RPCFLAGS="$RPCFLAGS --engine-host-allowlist=* --engine-jwt-secret /jwtsecret"
 fi
 
-# Enable discv5 if requested by the test suite.
-if [ "$HIVE_DISCV5" != "" ]; then
-    FLAGS="$FLAGS --Xv5-discovery-enabled"
-fi
-
 # Disable parallel transaction processing
 if [ "$HIVE_PARALLEL_TX_PROCESSING_DISABLED" = "true" ]; then
     FLAGS="$FLAGS --bonsai-parallel-tx-processing-enabled=false"


### PR DESCRIPTION
Besu will start supporting both discovery v5 and v4 simultaneously with PR https://github.com/besu-eth/besu/pull/10624 