### PR TITLE
clients, simulators: late joiner tests

### DIFF
--- a/clients/lean-spec-client/Dockerfile
+++ b/clients/lean-spec-client/Dockerfile
@@ -16,6 +16,7 @@ RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
+    RUST_MIN_STACK=134217728 \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/clients/lean-spec-client/lean_spec_client_runner.py
+++ b/clients/lean-spec-client/lean_spec_client_runner.py
@@ -14,7 +14,7 @@ from lean_spec_runtime import (
     ATTESTATION_SECRET_FIELD,
     PROPOSAL_SECRET_FIELD,
     ValidatorIndex,
-    api_server_supports_signed_block_getter,
+    build_api_server,
     build_helper_bootnode_enr,
     build_node_config,
     cache_signed_block,
@@ -43,13 +43,24 @@ from lean_spec_runtime import (
     uses_latest_leanspec_format,
 )
 
-from lean_spec.subspecs.api import ApiServer, ApiServerConfig
-from lean_spec.subspecs.metrics import registry as metrics
-from lean_spec.subspecs.networking.client import LiveNetworkEventSource
-from lean_spec.subspecs.networking.transport.quic.connection import QuicConnectionManager
-from lean_spec.subspecs.node import Node, NodeConfig
-from lean_spec.subspecs.validator import ValidatorRegistry
-from lean_spec.types import Bytes32
+try:
+    from lean_spec.node.api import ApiServer, ApiServerConfig
+    from lean_spec.node.metrics import registry as metrics
+    from lean_spec.node.networking.client import LiveNetworkEventSource
+    from lean_spec.node.networking.transport.quic.connection import QuicConnectionManager
+    from lean_spec.node.node import Node, NodeConfig
+    from lean_spec.node.validator import ValidatorRegistry
+    from lean_spec.spec.ssz import Bytes32
+except (ImportError, ModuleNotFoundError):
+    from lean_spec.subspecs.api import ApiServer, ApiServerConfig
+    from lean_spec.subspecs.metrics import registry as metrics
+    from lean_spec.subspecs.networking.client import LiveNetworkEventSource
+    from lean_spec.subspecs.networking.transport.quic.connection import (
+        QuicConnectionManager,
+    )
+    from lean_spec.subspecs.node import Node, NodeConfig
+    from lean_spec.subspecs.validator import ValidatorRegistry
+    from lean_spec.types import Bytes32
 
 GOSSIP_FORK_DIGEST: Final = "devnet0"
 LISTEN_ADDR: Final = "/ip4/0.0.0.0/udp/9001/quic-v1"
@@ -210,9 +221,11 @@ async def run() -> None:
         store = node.sync_service.store
         return store.blocks[store.head].slot
 
-    if api_server_supports_signed_block_getter(ApiServer):
-        api_server_kwargs["signed_block_getter"] = lambda root: published_blocks.get(root)
-    api_server = ApiServer(**api_server_kwargs)
+    api_server = build_api_server(
+        ApiServer,
+        api_server_kwargs,
+        lookup_published_block,
+    )
 
     event_source.set_block_lookup(lookup_published_block)
     event_source.set_block_by_slot_lookup(lookup_published_block_by_slot_async)

--- a/clients/lean-spec-client/lean_spec_runtime.py
+++ b/clients/lean-spec-client/lean_spec_runtime.py
@@ -178,6 +178,125 @@ def api_server_supports_signed_block_getter(api_server_type: type[Any]) -> bool:
     return "signed_block_getter" in inspect.signature(api_server_type).parameters
 
 
+async def finalized_block_response(
+    store: Any | None,
+    signed_block_getter: Any,
+) -> web.Response:
+    if store is None:
+        raise web.HTTPServiceUnavailable(reason="Store not initialized")
+
+    signed_block = signed_block_getter(store.latest_finalized.root)
+    if inspect.isawaitable(signed_block):
+        signed_block = await signed_block
+    if signed_block is None:
+        raise web.HTTPNotFound(reason="Finalized block not available")
+
+    ssz_bytes = await asyncio.to_thread(signed_block.encode_bytes)
+    return web.Response(body=ssz_bytes, content_type="application/octet-stream")
+
+
+class FinalizedBlockApiServer:
+    """API-server adapter for leanSpec versions without finalized-block support."""
+
+    def __init__(self, base_api_server: Any, signed_block_getter: Any) -> None:
+        self._base_api_server = base_api_server
+        self._signed_block_getter = signed_block_getter
+        self._runner: web.AppRunner | None = None
+        self._site: web.TCPSite | None = None
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        api_context_module = import_first_module(
+            "lean_spec.node.api.context",
+            "lean_spec.subspecs.api.context",
+        )
+        api_handlers_module = import_first_module(
+            "lean_spec.node.api.handlers",
+            "lean_spec.subspecs.api.handlers",
+        )
+        ApiContext = api_context_module.ApiContext
+        ApiHandlers = api_handlers_module.ApiHandlers
+
+        app = web.Application()
+        context = ApiContext(
+            spec=self._base_api_server.spec,
+            store_getter=self._base_api_server.store_getter,
+            aggregator_role_control=getattr(
+                self._base_api_server,
+                "aggregator_role_control",
+                None,
+            ),
+        )
+        handlers = ApiHandlers(context)
+
+        async def handle_finalized_block(_request: web.Request) -> web.Response:
+            store_getter = self._base_api_server.store_getter
+            store = store_getter() if store_getter else None
+            return await finalized_block_response(store, self._signed_block_getter)
+
+        routes = [
+            web.get("/lean/v0/health", handlers.health),
+            web.get("/lean/v0/states/finalized", handlers.finalized_state),
+            web.get("/lean/v0/blocks/finalized", handle_finalized_block),
+            web.get("/lean/v0/checkpoints/justified", handlers.justified_checkpoint),
+            web.get("/lean/v0/fork_choice", handlers.fork_choice),
+            web.get("/metrics", handlers.metrics),
+        ]
+        if hasattr(handlers, "aggregator_status"):
+            routes.extend(
+                [
+                    web.get("/lean/v0/admin/aggregator", handlers.aggregator_status),
+                    web.post("/lean/v0/admin/aggregator", handlers.aggregator_toggle),
+                ]
+            )
+        app.add_routes(routes)
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+
+        config = self._base_api_server.config
+        self._site = web.TCPSite(self._runner, config.host, config.port)
+        await self._site.start()
+
+        logger.info("API server listening on %s:%d", config.host, config.port)
+
+    async def run(self) -> None:
+        await self.start()
+        await self._stop_event.wait()
+
+    def stop(self) -> None:
+        if self._runner is not None:
+            asyncio.create_task(self.aclose())
+        else:
+            self._stop_event.set()
+
+    async def aclose(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+            self._site = None
+            logger.info("API server stopped")
+        self._stop_event.set()
+
+
+def build_api_server(
+    api_server_type: Any,
+    api_server_kwargs: dict[str, Any],
+    signed_block_getter: Any,
+) -> Any:
+    if api_server_supports_signed_block_getter(api_server_type):
+        return api_server_type(
+            **api_server_kwargs,
+            signed_block_getter=signed_block_getter,
+        )
+
+    logger.info("Using Hive helper API adapter with finalized block route")
+    return FinalizedBlockApiServer(
+        api_server_type(**api_server_kwargs),
+        signed_block_getter,
+    )
+
+
 def canonicalize_der_secp256k1_signature(der_signature: bytes) -> bytes:
     signature_r, signature_s = decode_dss_signature(der_signature)
     if signature_s > SECP256K1_ORDER // 2:

--- a/simulators/lean/Dockerfile
+++ b/simulators/lean/Dockerfile
@@ -32,6 +32,7 @@ RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
+    RUST_MIN_STACK=134217728 \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/simulators/lean/helper/lean_spec_client_runner.py
+++ b/simulators/lean/helper/lean_spec_client_runner.py
@@ -27,7 +27,7 @@ from lean_spec_runtime import (
     HELPER_ADVERTISE_IP_ENVIRONMENT_VARIABLE,
     PROPOSAL_SECRET_FIELD,
     ValidatorIndex,
-    api_server_supports_signed_block_getter,
+    build_api_server,
     build_helper_bootnode_enr,
     build_node_config,
     cache_signed_block,
@@ -296,52 +296,6 @@ def build_identify_response(identity_key: IdentityKeypair) -> bytes:
     response.extend(protobuf_string_field(5, "ipfs/0.1.0"))
     response.extend(protobuf_string_field(6, "hive-lean-spec-helper/0.1.0"))
     return bytes(response)
-
-
-def install_finalized_block_api_route(signed_block_getter: Any) -> None:
-    try:
-        routes_module = import_first_module(
-            "lean_spec.node.api.routes",
-            "lean_spec.subspecs.api.routes",
-        )
-    except (ImportError, ModuleNotFoundError):
-        return
-    routes = getattr(routes_module, "ROUTES", None)
-    route_type = getattr(routes_module, "Route", None)
-    if routes is None or route_type is None:
-        return
-
-    if any(
-        getattr(route, "method", None) == "GET"
-        and getattr(route, "path", None) == "/lean/v0/blocks/finalized"
-        for route in routes
-    ):
-        return
-
-    async def handle_finalized_block(request: web.Request) -> web.Response:
-        store_getter = request.app.get("store_getter")
-        store = store_getter() if store_getter else None
-        if store is None:
-            raise web.HTTPServiceUnavailable(reason="Store not initialized")
-
-        signed_block = signed_block_getter(store.latest_finalized.root)
-        if inspect.isawaitable(signed_block):
-            signed_block = await signed_block
-        if signed_block is None:
-            raise web.HTTPNotFound(reason="Finalized block not available")
-
-        ssz_bytes = await asyncio.to_thread(signed_block.encode_bytes)
-        return web.Response(body=ssz_bytes, content_type="application/octet-stream")
-
-    routes.append(
-        route_type(
-            "GET",
-            "/lean/v0/blocks/finalized",
-            handle_finalized_block,
-            is_admin=False,
-        )
-    )
-    logger.info("Installed helper finalized block API route")
 
 
 def decode_der_length(payload: bytes, offset: int) -> tuple[int, int]:
@@ -1320,11 +1274,11 @@ async def run() -> None:
         "config": ApiServerConfig(port=helper_api_port()),
         "store_getter": lambda: node.sync_service.store,
     }
-    if api_server_supports_signed_block_getter(ApiServer):
-        api_server_kwargs["signed_block_getter"] = lookup_published_block
-    else:
-        install_finalized_block_api_route(lookup_published_block)
-    api_server = ApiServer(**api_server_kwargs)
+    api_server = build_api_server(
+        ApiServer,
+        api_server_kwargs,
+        lookup_published_block,
+    )
     metadata_runner = await start_metadata_server(metadata, helper_metadata_port())
     refresh_status(event_source, node)
 

--- a/simulators/lean/src/scenarios/client_interop.rs
+++ b/simulators/lean/src/scenarios/client_interop.rs
@@ -942,13 +942,15 @@ mod tests {
 
     #[test]
     fn two_subnet_node_builder_accepts_all_devnet4_lean_clients() {
+        let clients = devnet4_lean_clients();
+        let expected_topology_count = clients.len() + clients.len() * (clients.len() - 1);
         assert_eq!(
-            two_subnet_interop_topology_matrix(&devnet4_lean_clients()).len(),
-            64
+            two_subnet_interop_topology_matrix(&clients).len(),
+            expected_topology_count
         );
         assert_eq!(aggregator_placements().len(), 2);
 
-        for topology_spec in two_subnet_interop_topology_matrix(&devnet4_lean_clients()) {
+        for topology_spec in two_subnet_interop_topology_matrix(&clients) {
             for placement in aggregator_placements() {
                 let mut nodes = build_two_subnet_interop_nodes(&topology_spec);
                 assign_two_subnet_aggregators(&mut nodes, placement);

--- a/simulators/lean/src/scenarios/sync.rs
+++ b/simulators/lean/src/scenarios/sync.rs
@@ -1,18 +1,35 @@
 use crate::utils::helper::{
     start_bad_checkpoint_peer, start_checkpoint_sync_client_context,
-    start_checkpoint_sync_helper_mesh, start_post_genesis_sync_context,
+    start_checkpoint_sync_helper_mesh, start_client_under_test_with_retry,
+    start_post_genesis_sync_context,
     start_post_genesis_sync_context_with_extra_bootnodes_after_helper_agreement,
     HelperGossipForkDigestProfile, PostGenesisSyncContext, PostGenesisSyncTestData,
     RunningBadCheckpointPeer, LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
 };
 use crate::utils::util::{
-    default_genesis_time, fork_choice_head_slot, lean_clients, run_data_test, selected_lean_devnet,
-    try_load_fork_choice_response, ClientUnderTestRole, ForkChoiceResponse,
+    bootnode_metadata_for_client, current_unix_time, default_genesis_time, fork_choice_head_slot,
+    lean_bootnodes_for_client, lean_client_kind, lean_clients, lean_environment, run_data_test,
+    run_data_test_with_timeout, selected_lean_devnet, try_load_fork_choice_response,
+    ClientUnderTestRole, ForkChoiceResponse, TimedDataTestSpec,
 };
 use alloy_primitives::B256;
+use hivesim::types::ClientDefinition;
 use hivesim::{dyn_async, Client, Test};
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::{sleep, timeout, Instant};
+
+const BOOTNODES_ENVIRONMENT_VARIABLE: &str = "HIVE_BOOTNODES";
+const CLIENT_PRIVATE_KEY_ENVIRONMENT_VARIABLE: &str = "HIVE_CLIENT_PRIVATE_KEY";
+const IS_AGGREGATOR_ENVIRONMENT_VARIABLE: &str = "HIVE_IS_AGGREGATOR";
+const LEAN_CLIENT_RUNTIME_ROLE_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_CLIENT_RUNTIME_ROLE";
+const LEAN_ATTESTATION_COMMITTEE_COUNT_ENVIRONMENT_VARIABLE: &str =
+    "HIVE_ATTESTATION_COMMITTEE_COUNT";
+const LEAN_GENESIS_TIME_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_GENESIS_TIME";
+const LEAN_GENESIS_VALIDATOR_COUNT_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_VALIDATOR_COUNT";
+const LEAN_VALIDATOR_INDEX_ENVIRONMENT_VARIABLE: &str = "HIVE_VALIDATOR_INDEX";
+const LEAN_VALIDATOR_INDICES_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_VALIDATOR_INDICES";
+const NODE_ID_ENVIRONMENT_VARIABLE: &str = "HIVE_NODE_ID";
 
 const CHECKPOINT_SYNC_HELPER_MESH_TIMEOUT_SECS: u64 = 420;
 const CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS: u64 = 180;
@@ -22,8 +39,39 @@ const HEAD_BEHIND_FINALIZED_HELPER_PROGRESS_TIMEOUT_SECS: u64 = 420;
 const BAD_CHECKPOINT_PEER_AHEAD_TIMEOUT_SECS: u64 = 120;
 const BAD_CHECKPOINT_PEER_MIN_SLOT_LEAD: u64 = 4;
 const SYNC_HELPER_PEER_COUNT: usize = 2;
+const SAME_CLIENT_GENESIS_BOOTSTRAP_PEER_COUNT: usize = 2;
+const SAME_CLIENT_GENESIS_NODE_COUNT: usize = 3;
+const SAME_CLIENT_GENESIS_VALIDATOR_COUNT: usize = 3;
+const SAME_CLIENT_GENESIS_VALIDATOR_NODE_INDEX: usize = 0;
+const SAME_CLIENT_GENESIS_LATE_JOINER_INDEX: usize = 2;
+const SAME_CLIENT_GENESIS_LATE_START_AFTER_GENESIS_SECS: u64 = 20;
+const SAME_CLIENT_GENESIS_ATTESTATION_COMMITTEE_COUNT: usize = 1;
+const LEAN_CLIENT_P2P_PORT: u16 = 9000;
 const HEAD_SYNC_MAX_SLOT_LAG: u64 = 2;
 const PRE_PAUSE_MIN_CLIENT_HEAD_SLOT: u64 = 4;
+const LATE_JOINER_FINALIZATION_TIMEOUT_SECS: u64 = 300;
+const LATE_JOINER_OUTER_TIMEOUT_SECS: u64 = 15 * 60;
+const LATE_JOINER_MAX_FINALIZED_SLOT_LAG: u64 = 4;
+const LATE_JOINER_POLL_INTERVAL_SECS: u64 = 2;
+
+struct LateJoinerObservation {
+    source: Option<ForkChoiceResponse>,
+    client: Option<ForkChoiceResponse>,
+    source_error: Option<String>,
+    client_error: Option<String>,
+}
+
+#[derive(Clone)]
+struct SameClientLateJoinerTestData {
+    client_under_test: ClientDefinition,
+    genesis_time: u64,
+}
+
+struct RunningSameClientGenesisNode {
+    node_id: String,
+    client: Client,
+    bootnode: String,
+}
 
 struct HeadSyncObservation {
     source_before_head: B256,
@@ -580,6 +628,50 @@ dyn_async! {
             )
             .await;
 
+            run_data_test_with_timeout(
+                test,
+                TimedDataTestSpec {
+                    name: "sync: late joiner syncs and finalizes via LeanSpec helper mesh".to_string(),
+                    description: "Starts a local LeanSpec helper mesh, waits for the helpers to finalize, starts the validator client under test late from the helper checkpoint, and checks that it catches up and finalizes close to the helper source.".to_string(),
+                    always_run: false,
+                    client_name: client.name.clone(),
+                    timeout_duration: Duration::from_secs(LATE_JOINER_OUTER_TIMEOUT_SECS),
+                    test_data: PostGenesisSyncTestData {
+                        client_under_test: client.clone(),
+                        genesis_time: default_genesis_time(),
+                        wait_for_client_justified_checkpoint: false,
+                        use_checkpoint_sync: true,
+                        connect_client_to_lean_spec_mesh: true,
+                        client_role: ClientUnderTestRole::Validator,
+                        source_helper_validator_indices: Some(
+                            LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0.to_string(),
+                        ),
+                        split_helper_validators_across_mesh: false,
+                        helper_peer_count: SYNC_HELPER_PEER_COUNT,
+                        helper_fork_digest_profile,
+                    },
+                },
+                test_sync_late_joiner_syncs_and_finalizes,
+            )
+            .await;
+
+            run_data_test_with_timeout(
+                test,
+                TimedDataTestSpec {
+                    name: "sync: late joiner syncs and finalizes".to_string(),
+                    description: "Starts two validator instances of the selected client from genesis, starts a third same-client observer instance late using the first two instances as bootnodes, and checks that the late joiner catches up and finalizes close to the bootstrap mesh.".to_string(),
+                    always_run: false,
+                    client_name: client.name.clone(),
+                    timeout_duration: Duration::from_secs(LATE_JOINER_OUTER_TIMEOUT_SECS),
+                    test_data: SameClientLateJoinerTestData {
+                        client_under_test: client.clone(),
+                        genesis_time: default_genesis_time(),
+                    },
+                },
+                test_sync_late_joiner_syncs_and_finalizes_via_same_client_mesh,
+            )
+            .await;
+
             let head_behind_finalized_recovery_genesis_time = default_genesis_time();
             run_data_test(
                 test,
@@ -653,6 +745,376 @@ dyn_async! {
             .await;
         }
     }
+}
+
+dyn_async! {
+    async fn test_sync_late_joiner_syncs_and_finalizes<'a>(test: &'a mut Test, test_data: PostGenesisSyncTestData) {
+        let client_name = test_data.client_under_test.name.clone();
+
+        let helper_mesh = timeout(
+            Duration::from_secs(CHECKPOINT_SYNC_HELPER_MESH_TIMEOUT_SECS),
+            start_checkpoint_sync_helper_mesh(&test_data),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "late-joiner checkpoint helper mesh setup for {client_name} exceeded {CHECKPOINT_SYNC_HELPER_MESH_TIMEOUT_SECS} seconds before client startup"
+            )
+        });
+
+        let mut context = timeout(
+            Duration::from_secs(CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS),
+            start_checkpoint_sync_client_context(test, &test_data, helper_mesh),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "late-joiner checkpoint client {client_name} did not start within {CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS} seconds after helper checkpoint readiness"
+            )
+        });
+
+        assert!(
+            context.source_fork_choice.finalized.slot > 0,
+            "helper source should expose a non-genesis finalized checkpoint before starting late-joiner client {client_name}"
+        );
+
+        let checkpoint_sync_boundary = context.source_fork_choice.finalized.slot;
+
+        wait_for_client_to_reach_source_head_with_client_restart(
+            test,
+            &mut context,
+            checkpoint_sync_boundary,
+            checkpoint_sync_boundary,
+            0,
+            "late-joiner checkpoint catch-up",
+        )
+        .await;
+
+        wait_for_late_joiner_client_to_finalize_near_source(&mut context).await;
+    }
+}
+
+dyn_async! {
+    async fn test_sync_late_joiner_syncs_and_finalizes_via_same_client_mesh<'a>(test: &'a mut Test, test_data: SameClientLateJoinerTestData) {
+        let client_name = test_data.client_under_test.name.clone();
+
+        let mut running_clients = Vec::with_capacity(SAME_CLIENT_GENESIS_NODE_COUNT);
+        for node_index in 0..SAME_CLIENT_GENESIS_BOOTSTRAP_PEER_COUNT {
+            let bootnodes = running_clients
+                .iter()
+                .map(|node: &RunningSameClientGenesisNode| node.bootnode.clone())
+                .collect::<Vec<_>>();
+            let running_client = timeout(
+                Duration::from_secs(CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS),
+                start_same_client_genesis_node(test, &test_data, node_index, bootnodes),
+            )
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "same-client genesis bootstrap node {node_index} for {client_name} did not start within {CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS} seconds"
+                )
+            });
+            running_clients.push(running_client);
+        }
+
+        sleep_until_unix_time(
+            test_data.genesis_time + SAME_CLIENT_GENESIS_LATE_START_AFTER_GENESIS_SECS,
+        )
+        .await;
+
+        let late_joiner_bootnodes = running_clients
+            .iter()
+            .map(|node| node.bootnode.clone())
+            .collect::<Vec<_>>();
+        let late_joiner = timeout(
+            Duration::from_secs(CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS),
+            start_same_client_genesis_node(
+                test,
+                &test_data,
+                SAME_CLIENT_GENESIS_LATE_JOINER_INDEX,
+                late_joiner_bootnodes,
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "same-client genesis late joiner for {client_name} did not start within {CHECKPOINT_SYNC_CLIENT_TO_HEAD_TIMEOUT_SECS} seconds"
+            )
+        });
+        running_clients.push(late_joiner);
+
+        wait_for_same_client_late_joiner_to_finalize(
+            &running_clients[SAME_CLIENT_GENESIS_VALIDATOR_NODE_INDEX],
+            &running_clients[SAME_CLIENT_GENESIS_LATE_JOINER_INDEX],
+        )
+        .await;
+    }
+}
+
+async fn start_same_client_genesis_node(
+    test: &Test,
+    test_data: &SameClientLateJoinerTestData,
+    node_index: usize,
+    bootnodes: Vec<String>,
+) -> RunningSameClientGenesisNode {
+    let client_name = &test_data.client_under_test.name;
+    let client_kind = lean_client_kind(client_name)
+        .unwrap_or_else(|err| panic!("Unable to build same-client genesis node: {err}"));
+    let node_id = format!("{client_kind}_{node_index}");
+    let private_key = crate::utils::libp2p_mock::deterministic_client_private_key_hex_for_node(
+        client_name,
+        &node_id,
+    );
+    let environment = same_client_genesis_environment(
+        &node_id,
+        &private_key,
+        test_data.genesis_time,
+        SAME_CLIENT_GENESIS_VALIDATOR_COUNT,
+        node_index,
+        &bootnodes,
+    );
+    let client = start_client_under_test_with_retry(
+        test,
+        test_data.client_under_test.name.clone(),
+        environment,
+    )
+    .await;
+    let metadata = bootnode_metadata_for_client(&private_key, client.ip, LEAN_CLIENT_P2P_PORT);
+    let bootnode = lean_bootnodes_for_client(client_kind, &[metadata]);
+
+    RunningSameClientGenesisNode {
+        node_id,
+        client,
+        bootnode,
+    }
+}
+
+fn same_client_genesis_environment(
+    node_id: &str,
+    private_key: &str,
+    genesis_time: u64,
+    genesis_validator_count: usize,
+    node_index: usize,
+    bootnodes: &[String],
+) -> HashMap<String, String> {
+    let mut environment = lean_environment();
+    let validator_indices = same_client_genesis_validator_indices(node_index);
+    environment.insert(
+        BOOTNODES_ENVIRONMENT_VARIABLE.to_string(),
+        if bootnodes.is_empty() {
+            "none".to_string()
+        } else {
+            bootnodes.join(",")
+        },
+    );
+    environment.insert(
+        CLIENT_PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(),
+        private_key.to_string(),
+    );
+    environment.insert(
+        LEAN_ATTESTATION_COMMITTEE_COUNT_ENVIRONMENT_VARIABLE.to_string(),
+        SAME_CLIENT_GENESIS_ATTESTATION_COMMITTEE_COUNT.to_string(),
+    );
+    environment.insert(
+        LEAN_GENESIS_VALIDATOR_COUNT_ENVIRONMENT_VARIABLE.to_string(),
+        genesis_validator_count.to_string(),
+    );
+    environment.insert(
+        LEAN_GENESIS_TIME_ENVIRONMENT_VARIABLE.to_string(),
+        genesis_time.to_string(),
+    );
+    environment.insert(
+        NODE_ID_ENVIRONMENT_VARIABLE.to_string(),
+        node_id.to_string(),
+    );
+
+    if let Some(validator_indices) = validator_indices {
+        let first_validator_index = validator_indices
+            .split(',')
+            .next()
+            .expect("validator index set must not be empty");
+        environment.insert(
+            LEAN_VALIDATOR_INDEX_ENVIRONMENT_VARIABLE.to_string(),
+            first_validator_index.to_string(),
+        );
+        environment.insert(
+            LEAN_VALIDATOR_INDICES_ENVIRONMENT_VARIABLE.to_string(),
+            validator_indices,
+        );
+        environment.insert(
+            IS_AGGREGATOR_ENVIRONMENT_VARIABLE.to_string(),
+            "1".to_string(),
+        );
+    } else {
+        environment.insert(
+            LEAN_CLIENT_RUNTIME_ROLE_ENVIRONMENT_VARIABLE.to_string(),
+            "observer".to_string(),
+        );
+    }
+
+    environment
+}
+
+fn same_client_genesis_validator_indices(node_index: usize) -> Option<String> {
+    match node_index {
+        0 => Some("0,1".to_string()),
+        1 => Some("2".to_string()),
+        _ => None,
+    }
+}
+
+async fn sleep_until_unix_time(target_unix_time: u64) {
+    loop {
+        let now = current_unix_time();
+        if now >= target_unix_time {
+            return;
+        }
+        sleep(Duration::from_secs((target_unix_time - now).min(1))).await;
+    }
+}
+
+async fn wait_for_same_client_late_joiner_to_finalize(
+    source: &RunningSameClientGenesisNode,
+    late_joiner: &RunningSameClientGenesisNode,
+) {
+    let client_name = late_joiner.client.kind.clone();
+    let deadline = Instant::now() + Duration::from_secs(LATE_JOINER_FINALIZATION_TIMEOUT_SECS);
+    let mut last_observation = None;
+
+    while Instant::now() < deadline {
+        let source_result = try_load_fork_choice_response(&source.client).await;
+        let client_result = try_load_fork_choice_response(&late_joiner.client).await;
+
+        let observation = LateJoinerObservation {
+            source: source_result.as_ref().ok().cloned(),
+            client: client_result.as_ref().ok().cloned(),
+            source_error: source_result.as_ref().err().cloned(),
+            client_error: client_result.as_ref().err().cloned(),
+        };
+
+        if let (Ok(source_fork_choice), Ok(client_fork_choice)) = (&source_result, &client_result) {
+            let head_slot_delta = fork_choice_head_slot(source_fork_choice)
+                .abs_diff(fork_choice_head_slot(client_fork_choice));
+            let finalized_slot_lag = source_fork_choice
+                .finalized
+                .slot
+                .saturating_sub(client_fork_choice.finalized.slot);
+
+            if client_fork_choice.finalized.slot > 0
+                && source_fork_choice.finalized.slot > 0
+                && head_slot_delta <= HEAD_SYNC_MAX_SLOT_LAG
+                && finalized_slot_lag <= LATE_JOINER_MAX_FINALIZED_SLOT_LAG
+            {
+                return;
+            }
+        }
+
+        last_observation = Some(observation);
+        sleep(Duration::from_secs(LATE_JOINER_POLL_INTERVAL_SECS)).await;
+    }
+
+    panic!(
+        "same-client genesis late joiner {} ({}) did not finalize close to bootstrap node {} within {} seconds. Required: both finalized slot > 0, head delta <= {} slots, finalized slot lag <= {}. Last observation: {}",
+        late_joiner.node_id,
+        client_name,
+        source.node_id,
+        LATE_JOINER_FINALIZATION_TIMEOUT_SECS,
+        HEAD_SYNC_MAX_SLOT_LAG,
+        LATE_JOINER_MAX_FINALIZED_SLOT_LAG,
+        last_observation
+            .as_ref()
+            .map(format_late_joiner_observation)
+            .unwrap_or_else(|| "no forkchoice observations collected".to_string()),
+    );
+}
+
+async fn wait_for_late_joiner_client_to_finalize_near_source(context: &mut PostGenesisSyncContext) {
+    let client_name = context.client_under_test.kind.clone();
+    let deadline = Instant::now() + Duration::from_secs(LATE_JOINER_FINALIZATION_TIMEOUT_SECS);
+    let mut last_observation = None;
+
+    while Instant::now() < deadline {
+        let source_result = context.try_load_live_helper_fork_choice().await;
+        let client_result = try_load_fork_choice_response(&context.client_under_test).await;
+
+        let observation = LateJoinerObservation {
+            source: source_result.as_ref().ok().cloned(),
+            client: client_result.as_ref().ok().cloned(),
+            source_error: source_result.as_ref().err().cloned(),
+            client_error: client_result.as_ref().err().cloned(),
+        };
+
+        if let (Ok(source_fork_choice), Ok(client_fork_choice)) = (&source_result, &client_result) {
+            let finalized_slot_lag = source_fork_choice
+                .finalized
+                .slot
+                .saturating_sub(client_fork_choice.finalized.slot);
+
+            if client_fork_choice.finalized.slot > 0
+                && client_caught_up_to_source(source_fork_choice, client_fork_choice)
+                && finalized_slot_lag <= LATE_JOINER_MAX_FINALIZED_SLOT_LAG
+            {
+                return;
+            }
+        }
+
+        last_observation = Some(observation);
+        sleep(Duration::from_secs(LATE_JOINER_POLL_INTERVAL_SECS)).await;
+    }
+
+    panic!(
+        "sync late-joiner client {client_name} did not finalize close to the local LeanSpec helper source within {} seconds after catching up. Required: client finalized slot > 0, client head within {} slots of helper source, finalized slot lag <= {}. Last observation: {}",
+        LATE_JOINER_FINALIZATION_TIMEOUT_SECS,
+        HEAD_SYNC_MAX_SLOT_LAG,
+        LATE_JOINER_MAX_FINALIZED_SLOT_LAG,
+        last_observation
+            .as_ref()
+            .map(format_late_joiner_observation)
+            .unwrap_or_else(|| "no forkchoice observations collected".to_string()),
+    );
+}
+
+fn format_late_joiner_observation(observation: &LateJoinerObservation) -> String {
+    let source = observation
+        .source
+        .as_ref()
+        .map(format_late_joiner_fork_choice)
+        .unwrap_or_else(|| {
+            format!(
+                "error={}",
+                observation
+                    .source_error
+                    .as_deref()
+                    .unwrap_or("unknown source forkchoice error")
+            )
+        });
+    let client = observation
+        .client
+        .as_ref()
+        .map(format_late_joiner_fork_choice)
+        .unwrap_or_else(|| {
+            format!(
+                "error={}",
+                observation
+                    .client_error
+                    .as_deref()
+                    .unwrap_or("unknown client forkchoice error")
+            )
+        });
+
+    format!("source {{{source}}}; client {{{client}}}")
+}
+
+fn format_late_joiner_fork_choice(fork_choice: &ForkChoiceResponse) -> String {
+    format!(
+        "head={:#x} head_slot={} justified={:#x}:{} finalized={:#x}:{}",
+        fork_choice.head,
+        fork_choice_head_slot(fork_choice),
+        fork_choice.justified.root,
+        fork_choice.justified.slot,
+        fork_choice.finalized.root,
+        fork_choice.finalized.slot,
+    )
 }
 
 dyn_async! {

--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -1740,7 +1740,7 @@ async fn register_client_under_test_for_failed_setup(
     }
 }
 
-async fn start_client_under_test_with_retry(
+pub(crate) async fn start_client_under_test_with_retry(
     test: &Test,
     client_type: String,
     environment: HashMap<String, String>,

--- a/simulators/lean/src/utils/libp2p_mock.rs
+++ b/simulators/lean/src/utils/libp2p_mock.rs
@@ -308,7 +308,17 @@ fn client_kind_label(client_name: &str) -> String {
 /// libp2p peer id matches what `compute_client_peer_id` expects.
 pub fn deterministic_client_private_key_hex(client_name: &str) -> String {
     let kind = client_kind_label(client_name);
-    let label = format!("{kind}:{kind}_0:node");
+    deterministic_client_private_key_hex_for_kind(&kind, &format!("{kind}_0"))
+}
+
+/// Hex-encoded deterministic secp256k1 secret for a specific lean client node id.
+pub fn deterministic_client_private_key_hex_for_node(client_name: &str, node_id: &str) -> String {
+    let kind = client_kind_label(client_name);
+    deterministic_client_private_key_hex_for_kind(&kind, node_id)
+}
+
+fn deterministic_client_private_key_hex_for_kind(kind: &str, node_id: &str) -> String {
+    let label = format!("{kind}:{node_id}:node");
     let hash = Sha256::digest(label.as_bytes());
     alloy_primitives::hex::encode(hash)
 }


### PR DESCRIPTION
Added two late joiner tests to the sync suite, one uses the leanspec helper to create the mesh that the tested client will join, the other uses the tested client to create the mesh.