### PR TITLE
Set genesis difficulty to zero in ConfigGenesis

### DIFF
--- a/simulators/ethereum/engine/config/genesis.go
+++ b/simulators/ethereum/engine/config/genesis.go
@@ -11,7 +11,7 @@ import (
 func (f *ForkConfig) ConfigGenesis(genesis *core.Genesis) error {
 	genesis.Config.TerminalTotalDifficulty = genesis.Difficulty
 	genesis.Config.MergeNetsplitBlock = big.NewInt(0)
-	genesis.Config.Difficulty = big.NewInt(0)
+	genesis.Difficulty = big.NewInt(0)
 	if f.ShanghaiTimestamp != nil {
 		shanghaiTime := f.ShanghaiTimestamp.Uint64()
 		genesis.Config.ShanghaiTime = &shanghaiTime

--- a/simulators/ethereum/engine/config/genesis.go
+++ b/simulators/ethereum/engine/config/genesis.go
@@ -11,6 +11,7 @@ import (
 func (f *ForkConfig) ConfigGenesis(genesis *core.Genesis) error {
 	genesis.Config.TerminalTotalDifficulty = genesis.Difficulty
 	genesis.Config.MergeNetsplitBlock = big.NewInt(0)
+	genesis.Config.Difficulty = big.NewInt(0)
 	if f.ShanghaiTimestamp != nil {
 		shanghaiTime := f.ShanghaiTimestamp.Uint64()
 		genesis.Config.ShanghaiTime = &shanghaiTime


### PR DESCRIPTION
Post-Merge all blocks are required to have difficulty == 0, otherwise they might not be recognized as post-merge blocks

fixes: https://hive.ethpandaops.io/#/test/generic/1782033755-a7cfa4948ef97d314a533ee790ec4181?testnumber=181