### PR TITLE
fix(lean): release helper p2p port before restart

### DIFF
--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -193,6 +193,8 @@ impl RunningBadCheckpointPeer {
         }
 
         eprintln!("Restarting adversarial {LOCAL_HELPER_KIND} after retryable exit: {error}");
+        // Free the previous helper's p2p port before spawning the replacement.
+        self.helper.stop();
         let (mut helper, _genesis_validator_entries) =
             start_local_lean_spec_helper_with_genesis_metadata(&self.helper_config).await?;
         wait_for_checkpoint_slot_with_retry(
@@ -553,6 +555,20 @@ impl RunningLocalLeanSpecHelper {
             )),
         }
     }
+
+    /// Terminate the helper process and wait for it to be reaped so the kernel
+    /// releases its QUIC/UDP listener port.
+    ///
+    /// Restarts reuse the same `p2p_port`, so a replacement helper must not be
+    /// spawned until the previous process has fully exited. The `Drop` impl
+    /// also kills the child, but it only runs once the old value is reassigned,
+    /// which happens *after* the replacement has already tried (and failed) to
+    /// bind the still-held port with `Address already in use`. Calling this
+    /// before starting the replacement closes that race.
+    fn stop(&mut self) {
+        self.child.kill().ok();
+        self.child.wait().ok();
+    }
 }
 
 impl Drop for RunningLocalLeanSpecHelper {
@@ -576,6 +592,8 @@ async fn restart_local_helper_after_retryable_exit(
         "Restarting {LOCAL_HELPER_KIND} `{}` after retryable exit: {error}",
         helper.node_id
     );
+    // Free the previous helper's p2p port before spawning the replacement.
+    helper.stop();
     let (restarted_helper, _genesis_validator_entries) =
         start_local_lean_spec_helper_with_genesis_metadata(helper_config).await?;
     *helper = restarted_helper;
@@ -1917,6 +1935,8 @@ async fn refresh_checkpoint_sync_source(
     helper_config: &LocalLeanSpecHelperConfig,
     minimum_slot: u64,
 ) -> Result<bool, String> {
+    // Free the previous helper's p2p port before spawning the replacement.
+    helper.stop();
     let (mut restarted_helper, _source_genesis_validator_entries) =
         start_local_lean_spec_helper_with_genesis_metadata(helper_config).await?;
     let refreshed_source_fork_choice =
@@ -2004,6 +2024,8 @@ async fn wait_for_checkpoint_slot_with_retry(
                 eprintln!(
                     "Restarting {LOCAL_HELPER_KIND} after finalized checkpoint wait failure on attempt {attempt}: {error}"
                 );
+                // Free the previous helper's p2p port before spawning the replacement.
+                helper.stop();
                 let (restarted_helper, _source_genesis_validator_entries) =
                     start_local_lean_spec_helper_with_genesis_metadata(helper_config).await?;
                 *helper = restarted_helper;


### PR DESCRIPTION
## Error description

The reqresp/checkpoint-sync simulator restarts the lean-spec local helper when it fails to reach the required finalized slot. Each restart path spawned the replacement helper (binding the same p2p_port) before the previous RunningLocalLeanSpecHelper was dropped, so the old process still held the QUIC/UDP port. The replacement then failed to bind with `OSError: [Errno 98] Address already in use`, every restart attempt re-hit the conflict, and the helper never came up — leaving every positive-path reqresp scenario to time out at 480s (only the negative, disconnect-only tests passed).

## Fix

Kill and reap the old helper child before starting its replacement so the kernel releases the port first. Applied to all four restart-in-place sites (adversarial restart, retryable-exit restart, checkpoint-sync source refresh, and the finalized-slot wait retry loop).