### PR TITLE
hivesim-rs: stability improvement

### DIFF
--- a/clients/besu/mapper.jq
+++ b/clients/besu/mapper.jq
@@ -102,5 +102,7 @@ def to_int:
     "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x00000000219ab540356cBB839Cbe05303d7705Fa"),
     "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
     "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
+    "builderDepositRequestContractAddress": "0x0000884d2aa32eaa155f59a2f24efa73d9008282",
+    "builderExitRequestContractAddress": "0x000014574a74c805590aff9499fc7a690f008282",
   }|remove_empty
 }

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -175,6 +175,7 @@ def clique_engine:
     "eip7934MaxRlpBlockSize": "0x800000",
 
     # Amsterdam
+    "eip2780TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip7708TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip7778TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip7843TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
@@ -182,8 +183,12 @@ def clique_engine:
     "eip7954TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip7976TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip7981TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
+    "eip7997TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip8024TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
     "eip8037TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
+    "eip8038TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
+    "eip8246TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
+    "eip8282TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
 
     # Other chain parameters
     "networkID": env.HIVE_NETWORK_ID|to_hex,

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -9,13 +9,11 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::net::IpAddr;
 use std::time::Duration;
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 
 use crate::utils::extract_test_results;
 
-const SHARED_CLIENT_STARTUP_ATTEMPTS: u64 = 3;
-const SHARED_CLIENT_STARTUP_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
-const SHARED_CLIENT_STARTUP_RETRY_DELAY: Duration = Duration::from_secs(1);
+const SHARED_CLIENT_STARTUP_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub type AsyncTestFunc = fn(
     &mut Test,
@@ -621,7 +619,7 @@ fn join_error_to_string(error: tokio::task::JoinError) -> String {
     }
 }
 
-async fn start_shared_client_with_retry(
+async fn start_shared_client(
     host: &Simulation,
     suite_id: SuiteID,
     owner_test_id: TestID,
@@ -629,64 +627,34 @@ async fn start_shared_client_with_retry(
     environment: Option<HashMap<String, String>>,
     files: Option<HashMap<String, Vec<u8>>>,
 ) -> Result<(String, IpAddr), String> {
-    let mut last_error = None;
+    let host = host.clone();
+    let client_name_for_start = client_name.to_string();
+    let mut handle = tokio::spawn(async move {
+        host.start_client_with_files(
+            suite_id,
+            owner_test_id,
+            client_name_for_start,
+            environment,
+            files,
+        )
+        .await
+    });
 
-    for attempt in 1..=SHARED_CLIENT_STARTUP_ATTEMPTS {
-        let host = host.clone();
-        let client_name_for_attempt = client_name.to_string();
-        let environment_for_attempt = environment.clone();
-        let files_for_attempt = files.clone();
-
-        let mut handle = tokio::spawn(async move {
-            host.start_client_with_files(
-                suite_id,
-                owner_test_id,
-                client_name_for_attempt,
-                environment_for_attempt,
-                files_for_attempt,
-            )
-            .await
-        });
-
-        let result: Result<(String, IpAddr), String> =
-            match timeout(SHARED_CLIENT_STARTUP_ATTEMPT_TIMEOUT, &mut handle).await {
-                Ok(Ok(client)) => return Ok(client),
-                Ok(Err(error)) => Err(join_error_to_string(error)),
-                Err(_) => {
-                    handle.abort();
-                    let _ = handle.await;
-                    Err(format!(
-                        "startup attempt exceeded {} seconds",
-                        SHARED_CLIENT_STARTUP_ATTEMPT_TIMEOUT.as_secs()
-                    ))
-                }
-            };
-
-        match result {
-            Err(error) if attempt < SHARED_CLIENT_STARTUP_ATTEMPTS => {
-                eprintln!(
-                    "Retrying shared-client startup for {client_name} after attempt {attempt} failed: {error}"
-                );
-                last_error = Some(error);
-                sleep(SHARED_CLIENT_STARTUP_RETRY_DELAY).await;
-            }
-            Err(error) => {
-                return Err(format!(
-                    "unable to start shared client {client_name} after {SHARED_CLIENT_STARTUP_ATTEMPTS} attempts: {error}"
-                ));
-            }
-            Ok(_) => unreachable!("successful shared-client startup returns above"),
+    match timeout(SHARED_CLIENT_STARTUP_TIMEOUT, &mut handle).await {
+        Ok(Ok(client)) => Ok(client),
+        Ok(Err(error)) => Err(format!(
+            "startup task failed: {}",
+            join_error_to_string(error)
+        )),
+        Err(_) => {
+            handle.abort();
+            let _ = handle.await;
+            Err(format!(
+                "startup exceeded {} seconds",
+                SHARED_CLIENT_STARTUP_TIMEOUT.as_secs()
+            ))
         }
     }
-
-    Err(format!(
-        "unable to start shared client {} after {} attempts{}",
-        client_name,
-        SHARED_CLIENT_STARTUP_ATTEMPTS,
-        last_error
-            .map(|error| format!(": {error}"))
-            .unwrap_or_default()
-    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -707,7 +675,7 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
     let mut guard = OwnerGuard::new(host.clone(), suite_id, owner_test_id);
     guard.arm();
 
-    let (container_id, ip) = match start_shared_client_with_retry(
+    let (container_id, ip) = match start_shared_client(
         &host,
         suite_id,
         owner_test_id,

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -9,8 +9,13 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::net::IpAddr;
 use std::time::Duration;
+use tokio::time::{sleep, timeout};
 
 use crate::utils::extract_test_results;
+
+const SHARED_CLIENT_STARTUP_ATTEMPTS: u64 = 3;
+const SHARED_CLIENT_STARTUP_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
+const SHARED_CLIENT_STARTUP_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub type AsyncTestFunc = fn(
     &mut Test,
@@ -601,6 +606,89 @@ impl Drop for OwnerGuard {
     }
 }
 
+fn join_error_to_string(error: tokio::task::JoinError) -> String {
+    if error.is_panic() {
+        let payload = error.into_panic();
+        if let Some(error) = payload.downcast_ref::<&'static str>() {
+            error.to_string()
+        } else if let Some(error) = payload.downcast_ref::<String>() {
+            error.clone()
+        } else {
+            format!("unknown panic payload: {payload:?}")
+        }
+    } else {
+        error.to_string()
+    }
+}
+
+async fn start_shared_client_with_retry(
+    host: &Simulation,
+    suite_id: SuiteID,
+    owner_test_id: TestID,
+    client_name: &str,
+    environment: Option<HashMap<String, String>>,
+    files: Option<HashMap<String, Vec<u8>>>,
+) -> Result<(String, IpAddr), String> {
+    let mut last_error = None;
+
+    for attempt in 1..=SHARED_CLIENT_STARTUP_ATTEMPTS {
+        let host = host.clone();
+        let client_name_for_attempt = client_name.to_string();
+        let environment_for_attempt = environment.clone();
+        let files_for_attempt = files.clone();
+
+        let mut handle = tokio::spawn(async move {
+            host.start_client_with_files(
+                suite_id,
+                owner_test_id,
+                client_name_for_attempt,
+                environment_for_attempt,
+                files_for_attempt,
+            )
+            .await
+        });
+
+        let result: Result<(String, IpAddr), String> =
+            match timeout(SHARED_CLIENT_STARTUP_ATTEMPT_TIMEOUT, &mut handle).await {
+                Ok(Ok(client)) => return Ok(client),
+                Ok(Err(error)) => Err(join_error_to_string(error)),
+                Err(_) => {
+                    handle.abort();
+                    let _ = handle.await;
+                    Err(format!(
+                        "startup attempt exceeded {} seconds",
+                        SHARED_CLIENT_STARTUP_ATTEMPT_TIMEOUT.as_secs()
+                    ))
+                }
+            };
+
+        match result {
+            Err(error) if attempt < SHARED_CLIENT_STARTUP_ATTEMPTS => {
+                eprintln!(
+                    "Retrying shared-client startup for {client_name} after attempt {attempt} failed: {error}"
+                );
+                last_error = Some(error);
+                sleep(SHARED_CLIENT_STARTUP_RETRY_DELAY).await;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "unable to start shared client {client_name} after {SHARED_CLIENT_STARTUP_ATTEMPTS} attempts: {error}"
+                ));
+            }
+            Ok(_) => unreachable!("successful shared-client startup returns above"),
+        }
+    }
+
+    Err(format!(
+        "unable to start shared client {} after {} attempts{}",
+        client_name,
+        SHARED_CLIENT_STARTUP_ATTEMPTS,
+        last_error
+            .map(|error| format!(": {error}"))
+            .unwrap_or_default()
+    ))
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
     host: Simulation,
@@ -619,15 +707,69 @@ async fn run_shared_client_test<T: Clone + Send + Sync + 'static>(
     let mut guard = OwnerGuard::new(host.clone(), suite_id, owner_test_id);
     guard.arm();
 
-    let (container_id, ip) = host
-        .start_client_with_files(
-            suite_id,
-            owner_test_id,
-            client_def.name.clone(),
-            environment,
-            files,
-        )
-        .await;
+    let (container_id, ip) = match start_shared_client_with_retry(
+        &host,
+        suite_id,
+        owner_test_id,
+        &client_def.name,
+        environment,
+        files,
+    )
+    .await
+    {
+        Ok(client) => client,
+        Err(err) => {
+            let mut scenarios_failed = 0;
+            let mut scenarios_filtered = 0;
+
+            for scenario in scenarios {
+                if let Some(test_match) = host.test_matcher.clone() {
+                    if !scenario.always_run && !test_match.match_test(&suite.name, &scenario.name) {
+                        scenarios_filtered += 1;
+                        continue;
+                    }
+                }
+
+                let scenario_test_id = host
+                    .start_test(
+                        suite_id,
+                        scenario.name.clone(),
+                        scenario.description.clone(),
+                    )
+                    .await;
+                host.end_test(
+                    suite_id,
+                    scenario_test_id,
+                    TestResult {
+                        pass: false,
+                        details: format!(
+                            "shared-client startup failed for {}; skipping scenario: {err}",
+                            client_def.name
+                        ),
+                    },
+                )
+                .await;
+                host.test_progress(&suite.name);
+                scenarios_failed += 1;
+            }
+
+            host.end_test(
+                suite_id,
+                owner_test_id,
+                TestResult {
+                    pass: false,
+                    details: format!(
+                        "shared-client startup failed for {}; {scenarios_failed} scenario(s) failed ({scenarios_filtered} filtered): {err}",
+                        client_def.name
+                    ),
+                },
+            )
+            .await;
+            host.test_progress(&suite.name);
+            guard.disarm();
+            return;
+        }
+    };
 
     let mut scenarios_run: usize = 0;
     let mut scenarios_passed: usize = 0;

--- a/simulators/ethereum/engine/config/genesis.go
+++ b/simulators/ethereum/engine/config/genesis.go
@@ -11,6 +11,7 @@ import (
 func (f *ForkConfig) ConfigGenesis(genesis *core.Genesis) error {
 	genesis.Config.TerminalTotalDifficulty = genesis.Difficulty
 	genesis.Config.MergeNetsplitBlock = big.NewInt(0)
+	genesis.Difficulty = big.NewInt(0)
 	if f.ShanghaiTimestamp != nil {
 		shanghaiTime := f.ShanghaiTimestamp.Uint64()
 		genesis.Config.ShanghaiTime = &shanghaiTime

--- a/simulators/lean/src/scenarios/reqresp.rs
+++ b/simulators/lean/src/scenarios/reqresp.rs
@@ -10,9 +10,9 @@ use crate::utils::libp2p_mock::{
 };
 use crate::utils::util::{
     default_genesis_time, fork_choice_head_slot, http_client, lean_api_url, lean_clients,
-    lean_environment, lean_single_client_runtime_setup, load_fork_choice_response,
-    prepare_client_runtime_files, run_data_test_with_timeout, selected_lean_devnet,
-    simulator_container_ip, ClientUnderTestRole, TimedDataTestSpec,
+    lean_environment, load_fork_choice_response, prepare_client_runtime_files,
+    run_data_test_with_timeout, selected_lean_devnet, simulator_container_ip, ClientUnderTestRole,
+    TimedDataTestSpec,
 };
 use alloy_primitives::B256;
 use hivesim::{dyn_async, Client, Test};
@@ -64,10 +64,23 @@ dyn_async! {
         if clients.is_empty() {
             panic!("No lean clients were selected for this run");
         }
+        let planning = test.plan_test("reqresp: client launch", true);
 
         for client in &clients {
-            let (_fresh_client_environments, _fresh_client_files) = lean_single_client_runtime_setup(
-                &client.name);
+            if !planning {
+                let environment = lean_environment();
+                let files = prepare_client_runtime_files(&client.name, &environment)
+                    .unwrap_or_else(|err| panic!("Unable to prepare runtime assets for {}: {err}", client.name));
+                let launch_client = test
+                    .start_client_with_files(client.name.clone(), Some(environment), Some(files))
+                    .await;
+                if let Err(err) = launch_client.stop().await {
+                    eprintln!(
+                        "Unable to stop reqresp launch-attribution client {}: {err}",
+                        client.name
+                    );
+                }
+            }
 
 
             let status_happy_genesis_time = default_genesis_time();
@@ -82,7 +95,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_happy_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -113,7 +125,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_genesis_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: false,
                         connect_client_to_lean_spec_mesh: false,
@@ -144,7 +155,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_advanced_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -178,7 +188,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_bad_root_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -209,7 +218,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_bad_fork_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -240,7 +248,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_malformed_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -271,7 +278,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_single_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -302,7 +308,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_multiple_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: false,
                         connect_client_to_lean_spec_mesh: false,
@@ -333,7 +338,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_unknown_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -364,7 +368,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_mixed_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -395,7 +398,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_max_limit_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -426,7 +428,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_too_many_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -457,7 +458,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_duplicate_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -488,7 +488,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_malformed_req_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -519,7 +518,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_single_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -550,7 +548,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_multiple_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -581,7 +578,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_zero_count_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -612,7 +608,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_too_many_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -643,7 +638,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: backfill_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -674,7 +668,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: catchup_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -705,7 +698,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: concurrency_genesis_time,
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,

--- a/simulators/lean/src/scenarios/reqresp.rs
+++ b/simulators/lean/src/scenarios/reqresp.rs
@@ -82,6 +82,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_happy_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -112,6 +113,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_genesis_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: false,
                         connect_client_to_lean_spec_mesh: false,
@@ -142,6 +144,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_advanced_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -175,6 +178,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_bad_root_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -205,6 +209,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_bad_fork_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -235,6 +240,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: status_malformed_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -265,6 +271,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_single_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -295,6 +302,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_multiple_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: false,
                         connect_client_to_lean_spec_mesh: false,
@@ -325,6 +333,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_unknown_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -355,6 +364,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_mixed_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -385,6 +395,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_max_limit_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -415,6 +426,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_too_many_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -445,6 +457,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_duplicate_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -475,6 +488,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: blocks_malformed_req_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -505,6 +519,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_single_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -535,6 +550,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_multiple_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -565,6 +581,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_zero_count_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -595,6 +612,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: range_too_many_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -625,6 +643,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: backfill_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -655,6 +674,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: catchup_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -685,6 +705,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: concurrency_genesis_time,
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,

--- a/simulators/lean/src/scenarios/rpc_compat.rs
+++ b/simulators/lean/src/scenarios/rpc_compat.rs
@@ -596,6 +596,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: checkpoint_genesis_time,
+                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: true,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -623,6 +624,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: finalized_filters_genesis_time,
+                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -650,6 +652,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: finalized_boundary_genesis_time,
+                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -677,6 +680,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: pre_finalized_only_genesis_time,
+                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -834,6 +838,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: state_finalized_genesis_time,
+                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -862,6 +867,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: finalized_block_pairing_genesis_time,
+                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,

--- a/simulators/lean/src/scenarios/rpc_compat.rs
+++ b/simulators/lean/src/scenarios/rpc_compat.rs
@@ -1,6 +1,6 @@
 use crate::utils::helper::{
-    start_post_genesis_sync_context, HelperGossipForkDigestProfile, PostGenesisSyncContext,
-    PostGenesisSyncTestData,
+    start_post_genesis_sync_context_without_client_startup_retry as start_rpc_compat_post_genesis_sync_context,
+    HelperGossipForkDigestProfile, PostGenesisSyncContext, PostGenesisSyncTestData,
 };
 use crate::utils::libp2p_mock::LeanSignature;
 use crate::utils::util::{
@@ -26,7 +26,7 @@ use tree_hash_derive::TreeHash as TreeHashDerive;
 
 const FORK_CHOICE_TIMEOUT_SECS: u64 = 600;
 const FINALIZED_STATE_ALIGNMENT_TIMEOUT_SECS: u64 = 60;
-const POST_GENESIS_TEST_TIMEOUT: Duration = Duration::from_secs(3 * 60);
+const POST_GENESIS_TEST_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
 
 #[derive(Debug, Clone, PartialEq, Eq, Decode, TreeHashDerive)]
@@ -276,7 +276,7 @@ async fn load_post_genesis_fork_choice_setup(
     test: &Test,
     test_data: PostGenesisSyncTestData,
 ) -> (PostGenesisSyncContext, ForkChoiceResponse) {
-    let context = start_post_genesis_sync_context(test, &test_data).await;
+    let context = start_rpc_compat_post_genesis_sync_context(test, &test_data).await;
     let fork_choice = wait_for_post_genesis_fork_choice_response(&context.client_under_test).await;
     (context, fork_choice)
 }
@@ -352,7 +352,7 @@ async fn load_post_genesis_state_setup(
     test: &Test,
     test_data: PostGenesisSyncTestData,
 ) -> (PostGenesisSyncContext, LeanState, ForkChoiceResponse) {
-    let context = start_post_genesis_sync_context(test, &test_data).await;
+    let context = start_rpc_compat_post_genesis_sync_context(test, &test_data).await;
     let state = load_finalized_state(&context.client_under_test).await;
     let fork_choice = load_fork_choice_response(&context.client_under_test).await;
     (context, state, fork_choice)
@@ -596,7 +596,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: checkpoint_genesis_time,
-                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: true,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -624,7 +623,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: finalized_filters_genesis_time,
-                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -652,7 +650,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: finalized_boundary_genesis_time,
-                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -680,7 +677,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: pre_finalized_only_genesis_time,
-                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -838,7 +834,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: state_finalized_genesis_time,
-                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -867,7 +862,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: finalized_block_pairing_genesis_time,
-                        retry_client_startup: false,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: false,
@@ -950,7 +944,7 @@ dyn_async! {
 
 dyn_async! {
     async fn test_checkpoints_justified<'a>(test: &'a mut Test, test_data: PostGenesisSyncTestData) {
-        let context = start_post_genesis_sync_context(test, &test_data).await;
+        let context = start_rpc_compat_post_genesis_sync_context(test, &test_data).await;
         assert!(
             context.source_fork_choice.justified.slot > 0,
             "helper source should reach a non-genesis justified checkpoint before syncing the client under test"
@@ -1322,7 +1316,7 @@ dyn_async! {
 // /lean/v0/blocks/finalized
 dyn_async! {
     async fn test_finalized_block_pairs_with_finalized_state<'a>(test: &'a mut Test, test_data: PostGenesisSyncTestData) {
-        let context = start_post_genesis_sync_context(test, &test_data).await;
+        let context = start_rpc_compat_post_genesis_sync_context(test, &test_data).await;
         let response = load_finalized_block_response(&context.client_under_test).await;
         assert_octet_stream_content_type(&response, "finalized block endpoint");
 

--- a/simulators/lean/src/scenarios/spec_assets.rs
+++ b/simulators/lean/src/scenarios/spec_assets.rs
@@ -15,9 +15,14 @@ use serde_json::{Map, Value};
 
 const SPEC_TEST_ROOT_DEVNET4: &str = "/app/hive/lean-spec-tests-devnet4";
 const SPEC_TEST_ROOT_DEVNET5: &str = "/app/hive/lean-spec-tests-devnet5";
-const FORK_CHOICE_FIXTURE_DIR: &str = "consensus/fork_choice/lstar/fc";
-const STATE_TRANSITION_FIXTURE_DIR: &str = "consensus/state_transition/lstar/state_transition";
-const VERIFY_SIGNATURES_FIXTURE_DIR: &str = "consensus/verify_signatures/lstar/verify_signatures";
+const FORK_CHOICE_FIXTURE_DIRS: &[&str] = &[
+    "consensus/fork_choice/lstar/fc",
+    "consensus/fork_choice/lstar/fork_choice",
+];
+const STATE_TRANSITION_FIXTURE_DIRS: &[&str] =
+    &["consensus/state_transition/lstar/state_transition"];
+const VERIFY_SIGNATURES_FIXTURE_DIRS: &[&str] =
+    &["consensus/verify_signatures/lstar/verify_signatures"];
 const SPEC_ASSET_TEST_TIMEOUT: Duration = Duration::from_secs(120);
 const SPEC_ASSET_FILTER_ENV: &str = "HIVE_LEAN_SPEC_ASSET_FILTER";
 const SPEC_ASSET_LIMIT_ENV: &str = "HIVE_LEAN_SPEC_ASSET_LIMIT";
@@ -30,11 +35,11 @@ enum SpecFixtureKind {
 }
 
 impl SpecFixtureKind {
-    fn fixture_dir(self) -> &'static str {
+    fn fixture_dirs(self) -> &'static [&'static str] {
         match self {
-            Self::ForkChoice => FORK_CHOICE_FIXTURE_DIR,
-            Self::StateTransition => STATE_TRANSITION_FIXTURE_DIR,
-            Self::VerifySignatures => VERIFY_SIGNATURES_FIXTURE_DIR,
+            Self::ForkChoice => FORK_CHOICE_FIXTURE_DIRS,
+            Self::StateTransition => STATE_TRANSITION_FIXTURE_DIRS,
+            Self::VerifySignatures => VERIFY_SIGNATURES_FIXTURE_DIRS,
         }
     }
 
@@ -190,7 +195,9 @@ fn spec_test_root() -> &'static str {
 
 fn discover_fixture_cases(root: &Path, kind: SpecFixtureKind) -> Vec<SpecFixtureCase> {
     let mut cases = Vec::new();
-    collect_fixture_cases(&root.join(kind.fixture_dir()), kind, &mut cases);
+    for fixture_dir in kind.fixture_dirs() {
+        collect_fixture_cases(&root.join(fixture_dir), kind, &mut cases);
+    }
     cases.sort_by(|a, b| a.path.cmp(&b.path).then(a.test_name.cmp(&b.test_name)));
     cases
 }
@@ -337,8 +344,12 @@ async fn run_fork_choice_fixture(client: &Client, fixture: &SpecFixtureCase) {
 }
 
 fn expects_fork_choice_init_failure(case: &Value, steps: &[Value]) -> bool {
-    steps.is_empty()
-        && case
+    if !steps.is_empty() {
+        return false;
+    }
+
+    expected_case_rejection(case).is_some()
+        || case
             .pointer("/_info/description")
             .and_then(Value::as_str)
             .is_some_and(|description| description.contains("anchor_valid=False"))
@@ -420,7 +431,7 @@ async fn run_state_transition_fixture(client: &Client, fixture: &SpecFixtureCase
         .await
         .unwrap_or_else(|err| panic!("failed to decode state-transition response: {err}"));
 
-    let expect_exception = fixture.case.get("expectException").and_then(Value::as_str);
+    let expect_exception = expected_case_rejection(&fixture.case);
     assert_eq!(
         response.succeeded,
         expect_exception.is_none(),
@@ -479,7 +490,7 @@ async fn run_verify_signatures_fixture(client: &Client, fixture: &SpecFixtureCas
         .json()
         .await
         .unwrap_or_else(|err| panic!("failed to decode verify-signatures response: {err}"));
-    let expect_exception = fixture.case.get("expectException").and_then(Value::as_str);
+    let expect_exception = expected_case_rejection(&fixture.case);
 
     assert_eq!(
         response.succeeded,
@@ -492,4 +503,132 @@ async fn run_verify_signatures_fixture(client: &Client, fixture: &SpecFixtureCas
 
 fn normalize_hex(value: &str) -> String {
     value.trim_start_matches("0x").to_ascii_lowercase()
+}
+
+fn expected_case_rejection(case: &Value) -> Option<&str> {
+    case.get("expectException")
+        .or_else(|| case.get("rejectionReason"))
+        .and_then(Value::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env, fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use serde_json::json;
+
+    use super::{
+        discover_fixture_cases, expected_case_rejection, expects_fork_choice_init_failure,
+        SpecFixtureKind,
+    };
+
+    fn unique_fixture_root(test_name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let root = env::temp_dir().join(format!("lean-spec-assets-{test_name}-{unique}"));
+        fs::create_dir_all(&root).expect("failed to create temporary fixture root");
+        root
+    }
+
+    fn write_fixture(root: &Path, relative_path: &str) {
+        let path = root.join(relative_path);
+        fs::create_dir_all(
+            path.parent()
+                .expect("fixture path should include a parent directory"),
+        )
+        .expect("failed to create fixture directory");
+        fs::write(path, r#"{"case_a": {"steps": []}}"#).expect("failed to write fixture");
+    }
+
+    #[test]
+    fn discovers_legacy_devnet4_fork_choice_fixtures() {
+        let root = unique_fixture_root("legacy-fork-choice");
+        write_fixture(
+            &root,
+            "consensus/fork_choice/lstar/fc/test_group/test_case.json",
+        );
+
+        let cases = discover_fixture_cases(&root, SpecFixtureKind::ForkChoice);
+
+        assert_eq!(cases.len(), 1);
+        assert_eq!(cases[0].test_name, "case_a");
+        fs::remove_dir_all(root).expect("failed to remove temporary fixture root");
+    }
+
+    #[test]
+    fn discovers_current_devnet5_fork_choice_fixtures() {
+        let root = unique_fixture_root("current-fork-choice");
+        write_fixture(
+            &root,
+            "consensus/fork_choice/lstar/fork_choice/test_group/test_case.json",
+        );
+
+        let cases = discover_fixture_cases(&root, SpecFixtureKind::ForkChoice);
+
+        assert_eq!(cases.len(), 1);
+        assert_eq!(cases[0].test_name, "case_a");
+        fs::remove_dir_all(root).expect("failed to remove temporary fixture root");
+    }
+
+    #[test]
+    fn discovers_current_devnet5_fixture_kinds() {
+        let root = unique_fixture_root("current-kinds");
+        write_fixture(
+            &root,
+            "consensus/fork_choice/lstar/fork_choice/test_group/test_case.json",
+        );
+        write_fixture(
+            &root,
+            "consensus/state_transition/lstar/state_transition/test_group/test_case.json",
+        );
+        write_fixture(
+            &root,
+            "consensus/verify_signatures/lstar/verify_signatures/test_group/test_case.json",
+        );
+
+        assert_eq!(
+            discover_fixture_cases(&root, SpecFixtureKind::ForkChoice).len(),
+            1
+        );
+        assert_eq!(
+            discover_fixture_cases(&root, SpecFixtureKind::StateTransition).len(),
+            1
+        );
+        assert_eq!(
+            discover_fixture_cases(&root, SpecFixtureKind::VerifySignatures).len(),
+            1
+        );
+        fs::remove_dir_all(root).expect("failed to remove temporary fixture root");
+    }
+
+    #[test]
+    fn detects_legacy_and_current_expected_rejections() {
+        assert_eq!(
+            expected_case_rejection(&json!({ "expectException": "AssertionError" })),
+            Some("AssertionError")
+        );
+        assert_eq!(
+            expected_case_rejection(&json!({ "rejectionReason": "INVALID_BLOCK" })),
+            Some("INVALID_BLOCK")
+        );
+        assert_eq!(expected_case_rejection(&json!({ "post": {} })), None);
+    }
+
+    #[test]
+    fn detects_current_fork_choice_init_rejection() {
+        assert!(expects_fork_choice_init_failure(
+            &json!({ "rejectionReason": "ANCHOR_STATE_ROOT_MISMATCH" }),
+            &[]
+        ));
+        assert!(!expects_fork_choice_init_failure(
+            &json!({ "rejectionReason": "LATER_STEP_FAILURE" }),
+            &[json!({ "valid": false })]
+        ));
+    }
 }

--- a/simulators/lean/src/scenarios/sync.rs
+++ b/simulators/lean/src/scenarios/sync.rs
@@ -613,6 +613,7 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: checkpoint_sync_genesis_time,
+                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: true,
                     connect_client_to_lean_spec_mesh: true,
@@ -639,6 +640,7 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: default_genesis_time(),
+                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -681,6 +683,7 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: head_behind_finalized_recovery_genesis_time,
+                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: false,
                     connect_client_to_lean_spec_mesh: true,
@@ -705,6 +708,7 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: bad_checkpoint_rejection_genesis_time,
+                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: false,
                     connect_client_to_lean_spec_mesh: true,
@@ -729,6 +733,7 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: head_recovery_genesis_time,
+                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: false,
                     connect_client_to_lean_spec_mesh: true,

--- a/simulators/lean/src/scenarios/sync.rs
+++ b/simulators/lean/src/scenarios/sync.rs
@@ -613,7 +613,6 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: checkpoint_sync_genesis_time,
-                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: true,
                     connect_client_to_lean_spec_mesh: true,
@@ -640,7 +639,6 @@ dyn_async! {
                     test_data: PostGenesisSyncTestData {
                         client_under_test: client.clone(),
                         genesis_time: default_genesis_time(),
-                        retry_client_startup: true,
                         wait_for_client_justified_checkpoint: false,
                         use_checkpoint_sync: true,
                         connect_client_to_lean_spec_mesh: true,
@@ -683,7 +681,6 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: head_behind_finalized_recovery_genesis_time,
-                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: false,
                     connect_client_to_lean_spec_mesh: true,
@@ -708,7 +705,6 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: bad_checkpoint_rejection_genesis_time,
-                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: false,
                     connect_client_to_lean_spec_mesh: true,
@@ -733,7 +729,6 @@ dyn_async! {
                 PostGenesisSyncTestData {
                     client_under_test: client.clone(),
                     genesis_time: head_recovery_genesis_time,
-                    retry_client_startup: true,
                     wait_for_client_justified_checkpoint: false,
                     use_checkpoint_sync: false,
                     connect_client_to_lean_spec_mesh: true,

--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -94,7 +94,6 @@ pub(crate) enum HelperGossipForkDigestProfile {
 pub(crate) struct PostGenesisSyncTestData {
     pub client_under_test: ClientDefinition,
     pub genesis_time: u64,
-    pub retry_client_startup: bool,
     pub wait_for_client_justified_checkpoint: bool,
     pub use_checkpoint_sync: bool,
     pub connect_client_to_lean_spec_mesh: bool,
@@ -1103,7 +1102,7 @@ pub(crate) async fn start_checkpoint_sync_client_context(
         client_type: test_data.client_under_test.name.clone(),
         environment: checkpoint_sync_client_environment.clone(),
         minimum_slot: minimum_source_checkpoint_slot(test_data),
-        startup_attempts: client_startup_attempts(test_data),
+        startup_attempts: CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
     })
     .await;
 
@@ -1121,7 +1120,7 @@ pub(crate) async fn start_checkpoint_sync_client_context(
         _helpers: helper_mesh.helpers,
         client_under_test,
         client_under_test_environment: checkpoint_sync_client_environment,
-        client_startup_attempts: client_startup_attempts(test_data),
+        client_startup_attempts: CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
         source_fork_choice: helper_mesh.source_fork_choice,
         client_checkpoint,
     }
@@ -1180,12 +1179,26 @@ pub(crate) async fn start_post_genesis_sync_context(
     start_post_genesis_sync_context_with_extra_bootnodes(test, test_data, Vec::new()).await
 }
 
+pub(crate) async fn start_post_genesis_sync_context_without_client_startup_retry(
+    test: &Test,
+    test_data: &PostGenesisSyncTestData,
+) -> PostGenesisSyncContext {
+    start_post_genesis_sync_context_inner(test, test_data, Vec::new(), false, 1).await
+}
+
 pub(crate) async fn start_post_genesis_sync_context_with_extra_bootnodes(
     test: &Test,
     test_data: &PostGenesisSyncTestData,
     extra_bootnodes: Vec<String>,
 ) -> PostGenesisSyncContext {
-    start_post_genesis_sync_context_inner(test, test_data, extra_bootnodes, false).await
+    start_post_genesis_sync_context_inner(
+        test,
+        test_data,
+        extra_bootnodes,
+        false,
+        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
+    )
+    .await
 }
 
 pub(crate) async fn start_post_genesis_sync_context_with_extra_bootnodes_after_helper_agreement(
@@ -1193,7 +1206,14 @@ pub(crate) async fn start_post_genesis_sync_context_with_extra_bootnodes_after_h
     test_data: &PostGenesisSyncTestData,
     extra_bootnodes: Vec<String>,
 ) -> PostGenesisSyncContext {
-    start_post_genesis_sync_context_inner(test, test_data, extra_bootnodes, true).await
+    start_post_genesis_sync_context_inner(
+        test,
+        test_data,
+        extra_bootnodes,
+        true,
+        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
+    )
+    .await
 }
 
 async fn start_post_genesis_sync_context_inner(
@@ -1201,7 +1221,9 @@ async fn start_post_genesis_sync_context_inner(
     test_data: &PostGenesisSyncTestData,
     extra_bootnodes: Vec<String>,
     wait_for_helper_agreement_before_client_start: bool,
+    client_startup_attempts: u64,
 ) -> PostGenesisSyncContext {
+    let client_startup_attempts = client_startup_attempts.max(1);
     let helper_peer_count = test_data.helper_peer_count.max(1);
     let passive_validator_mesh = should_start_passive_validator_mesh(test_data, helper_peer_count);
     let StartedLocalHelperMesh {
@@ -1234,7 +1256,7 @@ async fn start_post_genesis_sync_context_inner(
                 test,
                 test_data.client_under_test.name.clone(),
                 initial_client_under_test_environment.clone(),
-                client_startup_attempts(test_data),
+                client_startup_attempts,
             )
             .await,
         )
@@ -1269,7 +1291,7 @@ async fn start_post_genesis_sync_context_inner(
         {
             Ok(source_fork_choice) => source_fork_choice,
             Err(err) => {
-                if client_under_test.is_none() {
+                if client_under_test.is_none() && client_startup_attempts > 1 {
                     register_client_under_test_for_failed_setup(
                         test,
                         &test_data.client_under_test.name,
@@ -1430,7 +1452,7 @@ async fn start_post_genesis_sync_context_inner(
                     client_type: test_data.client_under_test.name.clone(),
                     environment: checkpoint_sync_client_environment.clone(),
                     minimum_slot: minimum_source_checkpoint_slot(test_data),
-                    startup_attempts: client_startup_attempts(test_data),
+                    startup_attempts: client_startup_attempts,
                 })
                 .await;
             (client_under_test, checkpoint_sync_client_environment)
@@ -1440,7 +1462,7 @@ async fn start_post_genesis_sync_context_inner(
                 test,
                 test_data.client_under_test.name.clone(),
                 delayed_client_under_test_environment.clone(),
-                client_startup_attempts(test_data),
+                client_startup_attempts,
             )
             .await;
             (client_under_test, delayed_client_under_test_environment)
@@ -1461,7 +1483,7 @@ async fn start_post_genesis_sync_context_inner(
         _helpers: helpers,
         client_under_test,
         client_under_test_environment,
-        client_startup_attempts: client_startup_attempts(test_data),
+        client_startup_attempts,
         source_fork_choice,
         client_checkpoint,
     }
@@ -1677,14 +1699,6 @@ fn with_extra_bootnodes(
 fn minimum_source_checkpoint_slot(test_data: &PostGenesisSyncTestData) -> u64 {
     if test_data.use_checkpoint_sync {
         MIN_FINALIZED_SLOT_FOR_CHECKPOINT_SYNC
-    } else {
-        1
-    }
-}
-
-fn client_startup_attempts(test_data: &PostGenesisSyncTestData) -> u64 {
-    if test_data.retry_client_startup {
-        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS
     } else {
         1
     }
@@ -2717,7 +2731,6 @@ mod tests {
                 meta: hivesim::types::ClientMetadata { roles: Vec::new() },
             },
             genesis_time: 1,
-            retry_client_startup: true,
             wait_for_client_justified_checkpoint: false,
             use_checkpoint_sync: false,
             connect_client_to_lean_spec_mesh: true,

--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -94,6 +94,7 @@ pub(crate) enum HelperGossipForkDigestProfile {
 pub(crate) struct PostGenesisSyncTestData {
     pub client_under_test: ClientDefinition,
     pub genesis_time: u64,
+    pub retry_client_startup: bool,
     pub wait_for_client_justified_checkpoint: bool,
     pub use_checkpoint_sync: bool,
     pub connect_client_to_lean_spec_mesh: bool,
@@ -108,6 +109,7 @@ pub(crate) struct PostGenesisSyncContext {
     _helpers: RunningLocalLeanSpecHelperGroup,
     pub client_under_test: Client,
     client_under_test_environment: HashMap<String, String>,
+    client_startup_attempts: u64,
     pub source_fork_choice: ForkChoiceSnapshot,
     pub client_checkpoint: Option<CheckpointResponse>,
 }
@@ -144,10 +146,11 @@ impl PostGenesisSyncContext {
             )
         })?;
 
-        self.client_under_test = start_client_under_test_with_retry(
+        self.client_under_test = start_client_under_test_with_attempts(
             test,
             client_type,
             self.client_under_test_environment.clone(),
+            self.client_startup_attempts,
         )
         .await;
         Ok(())
@@ -250,6 +253,7 @@ struct CheckpointSyncClientStart<'a> {
     client_type: String,
     environment: HashMap<String, String>,
     minimum_slot: u64,
+    startup_attempts: u64,
 }
 
 struct HelperForkChoiceObservation {
@@ -1091,17 +1095,17 @@ pub(crate) async fn start_checkpoint_sync_client_context(
         test_data.connect_client_to_lean_spec_mesh,
         test_data.client_role,
     );
-    let client_under_test =
-        start_checkpoint_sync_client_under_test_with_retry(CheckpointSyncClientStart {
-            test,
-            helper: &mut helper_mesh.helpers.source,
-            source_fork_choice: &mut helper_mesh.source_fork_choice,
-            helper_config: helper_mesh.source_helper_config.clone(),
-            client_type: test_data.client_under_test.name.clone(),
-            environment: checkpoint_sync_client_environment.clone(),
-            minimum_slot: minimum_source_checkpoint_slot(test_data),
-        })
-        .await;
+    let client_under_test = start_checkpoint_sync_client_under_test(CheckpointSyncClientStart {
+        test,
+        helper: &mut helper_mesh.helpers.source,
+        source_fork_choice: &mut helper_mesh.source_fork_choice,
+        helper_config: helper_mesh.source_helper_config.clone(),
+        client_type: test_data.client_under_test.name.clone(),
+        environment: checkpoint_sync_client_environment.clone(),
+        minimum_slot: minimum_source_checkpoint_slot(test_data),
+        startup_attempts: client_startup_attempts(test_data),
+    })
+    .await;
 
     let client_checkpoint = if test_data.wait_for_client_justified_checkpoint {
         Some(
@@ -1117,6 +1121,7 @@ pub(crate) async fn start_checkpoint_sync_client_context(
         _helpers: helper_mesh.helpers,
         client_under_test,
         client_under_test_environment: checkpoint_sync_client_environment,
+        client_startup_attempts: client_startup_attempts(test_data),
         source_fork_choice: helper_mesh.source_fork_choice,
         client_checkpoint,
     }
@@ -1225,10 +1230,11 @@ async fn start_post_genesis_sync_context_inner(
 
     let client_under_test = if should_start_client_early {
         Some(
-            start_client_under_test_with_retry(
+            start_client_under_test_with_attempts(
                 test,
                 test_data.client_under_test.name.clone(),
                 initial_client_under_test_environment.clone(),
+                client_startup_attempts(test_data),
             )
             .await,
         )
@@ -1416,7 +1422,7 @@ async fn start_post_genesis_sync_context_inner(
             let checkpoint_sync_client_environment =
                 with_extra_bootnodes(checkpoint_sync_client_environment, &extra_bootnodes);
             let client_under_test =
-                start_checkpoint_sync_client_under_test_with_retry(CheckpointSyncClientStart {
+                start_checkpoint_sync_client_under_test(CheckpointSyncClientStart {
                     test,
                     helper: &mut helpers.source,
                     source_fork_choice: &mut source_fork_choice,
@@ -1424,15 +1430,17 @@ async fn start_post_genesis_sync_context_inner(
                     client_type: test_data.client_under_test.name.clone(),
                     environment: checkpoint_sync_client_environment.clone(),
                     minimum_slot: minimum_source_checkpoint_slot(test_data),
+                    startup_attempts: client_startup_attempts(test_data),
                 })
                 .await;
             (client_under_test, checkpoint_sync_client_environment)
         }
         None => {
-            let client_under_test = start_client_under_test_with_retry(
+            let client_under_test = start_client_under_test_with_attempts(
                 test,
                 test_data.client_under_test.name.clone(),
                 delayed_client_under_test_environment.clone(),
+                client_startup_attempts(test_data),
             )
             .await;
             (client_under_test, delayed_client_under_test_environment)
@@ -1453,6 +1461,7 @@ async fn start_post_genesis_sync_context_inner(
         _helpers: helpers,
         client_under_test,
         client_under_test_environment,
+        client_startup_attempts: client_startup_attempts(test_data),
         source_fork_choice,
         client_checkpoint,
     }
@@ -1673,6 +1682,14 @@ fn minimum_source_checkpoint_slot(test_data: &PostGenesisSyncTestData) -> u64 {
     }
 }
 
+fn client_startup_attempts(test_data: &PostGenesisSyncTestData) -> u64 {
+    if test_data.retry_client_startup {
+        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS
+    } else {
+        1
+    }
+}
+
 fn checkpoint_sync_requires_finalized_block_endpoint(devnet: LeanDevnet) -> bool {
     !devnet.uses_merged_block_proof()
 }
@@ -1749,11 +1766,27 @@ pub(crate) async fn start_client_under_test_with_retry(
     client_type: String,
     environment: HashMap<String, String>,
 ) -> Client {
+    start_client_under_test_with_attempts(
+        test,
+        client_type,
+        environment,
+        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
+    )
+    .await
+}
+
+async fn start_client_under_test_with_attempts(
+    test: &Test,
+    client_type: String,
+    environment: HashMap<String, String>,
+    startup_attempts: u64,
+) -> Client {
     let files = prepare_client_runtime_files(&client_type, &environment)
         .unwrap_or_else(|err| panic!("Unable to prepare runtime assets for {client_type}: {err}"));
     let mut last_error = None;
+    let startup_attempts = startup_attempts.max(1);
 
-    for attempt in 1..=CLIENT_UNDER_TEST_STARTUP_ATTEMPTS {
+    for attempt in 1..=startup_attempts {
         let test = test.clone();
         let client_type_for_attempt = client_type.clone();
         let environment_for_attempt = environment.clone();
@@ -1768,7 +1801,7 @@ pub(crate) async fn start_client_under_test_with_retry(
         .await
         {
             Ok(client) => return client,
-            Err(message) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
+            Err(message) if attempt < startup_attempts => {
                 eprintln!(
                     "Retrying client-under-test startup for {client_type} after attempt {attempt} failed: {message}"
                 );
@@ -1777,7 +1810,7 @@ pub(crate) async fn start_client_under_test_with_retry(
             }
             Err(message) => {
                 panic!(
-                    "Unable to start client under test {client_type} after {CLIENT_UNDER_TEST_STARTUP_ATTEMPTS} attempts: {message}"
+                    "Unable to start client under test {client_type} after {startup_attempts} attempt(s): {message}"
                 );
             }
         }
@@ -1786,16 +1819,14 @@ pub(crate) async fn start_client_under_test_with_retry(
     panic!(
         "Unable to start client under test {} after {} attempts{}",
         client_type,
-        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
+        startup_attempts,
         last_error
             .map(|error| format!(": {error}"))
             .unwrap_or_default()
     );
 }
 
-async fn start_checkpoint_sync_client_under_test_with_retry(
-    params: CheckpointSyncClientStart<'_>,
-) -> Client {
+async fn start_checkpoint_sync_client_under_test(params: CheckpointSyncClientStart<'_>) -> Client {
     let files = prepare_client_runtime_files(&params.client_type, &params.environment)
         .unwrap_or_else(|err| {
             panic!(
@@ -1805,8 +1836,9 @@ async fn start_checkpoint_sync_client_under_test_with_retry(
         });
     let mut last_error = None;
     let mut client_was_started = false;
+    let startup_attempts = params.startup_attempts.max(1);
 
-    for attempt in 1..=CLIENT_UNDER_TEST_STARTUP_ATTEMPTS {
+    for attempt in 1..=startup_attempts {
         if client_was_started {
             wait_for_checkpoint_sync_state_ready(params.helper)
                 .await
@@ -1852,7 +1884,7 @@ async fn start_checkpoint_sync_client_under_test_with_retry(
         {
             Ok(client) => match wait_for_checkpoint_sync_client_post_genesis(&client).await {
                 Ok(()) => return client,
-                Err(error) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
+                Err(error) if attempt < startup_attempts => {
                     client_was_started = true;
                     eprintln!(
                         "Retrying checkpoint-sync client-under-test startup for {} after attempt {} never reached a post-genesis forkchoice state: {}",
@@ -1864,12 +1896,12 @@ async fn start_checkpoint_sync_client_under_test_with_retry(
                 }
                 Err(error) => {
                     panic!(
-                        "Unable to start checkpoint-sync client under test {} after {} attempts: {}",
-                        params.client_type, CLIENT_UNDER_TEST_STARTUP_ATTEMPTS, error
+                        "Unable to start checkpoint-sync client under test {} after {} attempt(s): {}",
+                        params.client_type, startup_attempts, error
                     );
                 }
             },
-            Err(message) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
+            Err(message) if attempt < startup_attempts => {
                 eprintln!(
                     "Retrying checkpoint-sync client-under-test startup for {} after attempt {} failed: {}",
                     params.client_type, attempt, message
@@ -1879,8 +1911,8 @@ async fn start_checkpoint_sync_client_under_test_with_retry(
             }
             Err(message) => {
                 panic!(
-                    "Unable to start checkpoint-sync client under test {} after {} attempts: {}",
-                    params.client_type, CLIENT_UNDER_TEST_STARTUP_ATTEMPTS, message
+                    "Unable to start checkpoint-sync client under test {} after {} attempt(s): {}",
+                    params.client_type, startup_attempts, message
                 );
             }
         }
@@ -1889,7 +1921,7 @@ async fn start_checkpoint_sync_client_under_test_with_retry(
     panic!(
         "Unable to start checkpoint-sync client under test {} after {} attempts{}",
         params.client_type,
-        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
+        startup_attempts,
         last_error
             .map(|error| format!(": {error}"))
             .unwrap_or_default()
@@ -2685,6 +2717,7 @@ mod tests {
                 meta: hivesim::types::ClientMetadata { roles: Vec::new() },
             },
             genesis_time: 1,
+            retry_client_startup: true,
             wait_for_client_justified_checkpoint: false,
             use_checkpoint_sync: false,
             connect_client_to_lean_spec_mesh: true,

--- a/simulators/lean/src/utils/util.rs
+++ b/simulators/lean/src/utils/util.rs
@@ -13,7 +13,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use alloy_primitives::B256;
 use hivesim::types::ClientDefinition;
-use hivesim::{types::TestResult, Client, Simulation, Test};
+use hivesim::{
+    types::{SuiteID, TestID, TestResult},
+    Client, Simulation, Test,
+};
 use reqwest::{header::ACCEPT, Client as HttpClient, Url};
 use serde::{de::DeserializeOwned, Deserialize};
 use tokio::time::{sleep, timeout};
@@ -37,6 +40,8 @@ pub(crate) const LEAN_HELPER_IDENTITY_PRIVATE_KEY_ENVIRONMENT_VARIABLE: &str =
 const LEAN_CLIENT_RUNTIME_ROLE_ENVIRONMENT_VARIABLE: &str = "HIVE_LEAN_CLIENT_RUNTIME_ROLE";
 const CLIENT_RUNTIME_ASSET_PREPARER: &str = "/app/hive/prepare_lean_client_assets.py";
 const LEAN_GENESIS_DELAY_SECS: u64 = 30;
+const TIMEOUT_ATTRIBUTION_CLIENT_START_TIMEOUT_SECS: u64 = 120;
+const TIMEOUT_ATTRIBUTION_CLIENT_STOP_TIMEOUT_SECS: u64 = 30;
 pub(crate) const DEVNET4_HELPER_GOSSIP_FORK_DIGEST: &str = "12345678";
 pub(crate) const HEALTHY_STATUS: &str = "healthy";
 pub(crate) const LEAN_RPC_SERVICE: &str = "lean-rpc-api";
@@ -608,6 +613,89 @@ fn annotate_failed_client(mut test_result: TestResult, client_name: &str) -> Tes
     test_result
 }
 
+async fn register_timeout_client_for_failed_setup(
+    simulation: Simulation,
+    suite_id: SuiteID,
+    test_id: TestID,
+    client_name: String,
+) {
+    let environment = lean_environment();
+    let files = match prepare_client_runtime_files(&client_name, &environment) {
+        Ok(files) => files,
+        Err(err) => {
+            eprintln!(
+                "Unable to prepare runtime assets for timeout attribution client {client_name}: {err}"
+            );
+            return;
+        }
+    };
+
+    let start_simulation = simulation.clone();
+    let start_client_name = client_name.clone();
+    let mut start_handle = tokio::spawn(async move {
+        start_simulation
+            .start_client_with_files(
+                suite_id,
+                test_id,
+                start_client_name,
+                Some(environment),
+                Some(files),
+            )
+            .await
+    });
+
+    let container = match timeout(
+        Duration::from_secs(TIMEOUT_ATTRIBUTION_CLIENT_START_TIMEOUT_SECS),
+        &mut start_handle,
+    )
+    .await
+    {
+        Ok(Ok((container, _ip))) => container,
+        Ok(Err(err)) => {
+            eprintln!("Timeout attribution client {client_name} startup failed: {err}");
+            return;
+        }
+        Err(_) => {
+            start_handle.abort();
+            start_handle.await.ok();
+            eprintln!(
+                "Timeout attribution client {client_name} startup exceeded {TIMEOUT_ATTRIBUTION_CLIENT_START_TIMEOUT_SECS} seconds"
+            );
+            return;
+        }
+    };
+
+    let stop_simulation = simulation.clone();
+    let stop_container = container.clone();
+    let mut stop_handle = tokio::spawn(async move {
+        stop_simulation
+            .stop_client(suite_id, test_id, &stop_container)
+            .await
+    });
+
+    match timeout(
+        Duration::from_secs(TIMEOUT_ATTRIBUTION_CLIENT_STOP_TIMEOUT_SECS),
+        &mut stop_handle,
+    )
+    .await
+    {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(err))) => {
+            eprintln!("Unable to stop timeout attribution client {client_name}: {err}");
+        }
+        Ok(Err(err)) => {
+            eprintln!("Timeout attribution client {client_name} stop task failed: {err}");
+        }
+        Err(_) => {
+            stop_handle.abort();
+            stop_handle.await.ok();
+            eprintln!(
+                "Timeout attribution client {client_name} stop exceeded {TIMEOUT_ATTRIBUTION_CLIENT_STOP_TIMEOUT_SECS} seconds"
+            );
+        }
+    }
+}
+
 pub(crate) async fn run_data_test<T: Send + 'static>(
     host_test: &Test,
     name: String,
@@ -706,6 +794,13 @@ pub(crate) async fn run_data_test_with_timeout<T: Send + 'static>(
         Err(_) => {
             join_handle.abort();
             join_handle.await.ok();
+            register_timeout_client_for_failed_setup(
+                host_test.sim.clone(),
+                suite_id,
+                test_id,
+                client_name.clone(),
+            )
+            .await;
             TestResult {
                 pass: false,
                 details: format!(


### PR DESCRIPTION
Fixes an issue where tests in the rpc-compat suite either fail and don't count or experience panics not accounted for. Added the standard retry mechanism found in the other suites for transient crashes from tested clients.