### PR TITLE
simulators: remove retries

### DIFF
--- a/simulators/lean/src/scenarios/client_interop.rs
+++ b/simulators/lean/src/scenarios/client_interop.rs
@@ -525,29 +525,25 @@ async fn start_interop_client(
             Ok(client) => return client,
             Err(message) if attempt < CLIENT_STARTUP_ATTEMPTS => {
                 eprintln!(
-                    "Retrying client-interop startup for node {} ({}) after attempt {} failed: {}",
-                    node.node_id, node.client.name, attempt, message
+                    "Retrying client-interop startup for node {} ({}) after startup failure: {}",
+                    node.node_id, node.client.name, message
                 );
                 last_error = Some(message);
                 sleep(Duration::from_secs(1)).await;
             }
             Err(message) => {
                 panic!(
-                    "Client-interop node {} ({}) crashed or failed during startup after {} attempts; no retries remain. Last startup failure: {}",
-                    node.node_id, node.client.name, CLIENT_STARTUP_ATTEMPTS, message
+                    "Client-interop node {} ({}) failed during startup: {}",
+                    node.node_id, node.client.name, message
                 );
             }
         };
     }
 
+    let cause = last_error.unwrap_or_else(|| "no startup failure cause was reported".to_string());
     panic!(
-        "Client-interop node {} ({}) crashed or failed during startup after {} attempts; no retries remain{}",
-        node.node_id,
-        node.client.name,
-        CLIENT_STARTUP_ATTEMPTS,
-        last_error
-            .map(|error| format!(". Last startup failure: {error}"))
-            .unwrap_or_default()
+        "Client-interop node {} ({}) failed during startup: {}",
+        node.node_id, node.client.name, cause
     );
 }
 

--- a/simulators/lean/src/scenarios/client_interop.rs
+++ b/simulators/lean/src/scenarios/client_interop.rs
@@ -533,7 +533,7 @@ async fn start_interop_client(
             }
             Err(message) => {
                 panic!(
-                    "Unable to start client-interop node {} ({}) after {} attempts: {}",
+                    "Client-interop node {} ({}) crashed or failed during startup after {} attempts; no retries remain. Last startup failure: {}",
                     node.node_id, node.client.name, CLIENT_STARTUP_ATTEMPTS, message
                 );
             }
@@ -541,12 +541,12 @@ async fn start_interop_client(
     }
 
     panic!(
-        "Unable to start client-interop node {} ({}) after {} attempts{}",
+        "Client-interop node {} ({}) crashed or failed during startup after {} attempts; no retries remain{}",
         node.node_id,
         node.client.name,
         CLIENT_STARTUP_ATTEMPTS,
         last_error
-            .map(|error| format!(": {error}"))
+            .map(|error| format!(". Last startup failure: {error}"))
             .unwrap_or_default()
     );
 }

--- a/simulators/lean/src/scenarios/reqresp.rs
+++ b/simulators/lean/src/scenarios/reqresp.rs
@@ -1,6 +1,6 @@
 use crate::utils::helper::{
-    start_post_genesis_sync_context, HelperGossipForkDigestProfile, PostGenesisSyncTestData,
-    LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
+    start_client_under_test, start_post_genesis_sync_context, HelperGossipForkDigestProfile,
+    PostGenesisSyncTestData, LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
 };
 use crate::utils::libp2p_mock::{
     client_multiaddr, compute_client_peer_id, decode_request, encode_request, encode_request_raw,
@@ -69,11 +69,8 @@ dyn_async! {
         for client in &clients {
             if !planning {
                 let environment = lean_environment();
-                let files = prepare_client_runtime_files(&client.name, &environment)
-                    .unwrap_or_else(|err| panic!("Unable to prepare runtime assets for {}: {err}", client.name));
-                let launch_client = test
-                    .start_client_with_files(client.name.clone(), Some(environment), Some(files))
-                    .await;
+                let launch_client =
+                    start_client_under_test(test, client.name.clone(), environment).await;
                 if let Err(err) = launch_client.stop().await {
                     eprintln!(
                         "Unable to stop reqresp launch-attribution client {}: {err}",

--- a/simulators/lean/src/scenarios/sync.rs
+++ b/simulators/lean/src/scenarios/sync.rs
@@ -1,7 +1,6 @@
 use crate::utils::helper::{
     start_bad_checkpoint_peer, start_checkpoint_sync_client_context,
-    start_checkpoint_sync_helper_mesh, start_client_under_test_with_retry,
-    start_post_genesis_sync_context,
+    start_checkpoint_sync_helper_mesh, start_client_under_test, start_post_genesis_sync_context,
     start_post_genesis_sync_context_with_extra_bootnodes_after_helper_agreement,
     HelperGossipForkDigestProfile, PostGenesisSyncContext, PostGenesisSyncTestData,
     RunningBadCheckpointPeer, LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
@@ -129,14 +128,14 @@ fn helper_failed_after_test_start_message(client_name: &str, phase: &str, error:
 }
 
 enum HeadSyncWaitError {
-    RetryableClient(String),
+    ClientFailure(String),
     NonRetryable(String),
 }
 
 impl HeadSyncWaitError {
     fn into_message(self) -> String {
         match self {
-            Self::RetryableClient(message) | Self::NonRetryable(message) => message,
+            Self::ClientFailure(message) | Self::NonRetryable(message) => message,
         }
     }
 }
@@ -236,19 +235,19 @@ async fn try_wait_for_client_to_reach_source_head(
         }
 
         if let Some(err) = last_client_error {
-            return Err(HeadSyncWaitError::RetryableClient(format!(
-                "Client under test fork_choice endpoint never became readable within {} seconds while comparing against the local LeanSpec helper head: {}",
+            return Err(HeadSyncWaitError::ClientFailure(format!(
+                "Client under test {client_name} crashed or became unreachable: fork_choice endpoint never became readable within {} seconds while comparing against the local LeanSpec helper head: {}",
                 HEAD_SYNC_TIMEOUT_SECS, err
             )));
         }
 
-        return Err(HeadSyncWaitError::RetryableClient(format!(
-            "Client under test could not be compared with the local LeanSpec helper head within {} seconds",
+        return Err(HeadSyncWaitError::ClientFailure(format!(
+            "Client under test {client_name} could not be compared with the local LeanSpec helper head within {} seconds",
             HEAD_SYNC_TIMEOUT_SECS
         )));
     };
-    Err(HeadSyncWaitError::RetryableClient(format!(
-        "Client under test never reached required head slot {} and caught up to the local LeanSpec helper head slot within {} seconds (allowed lag: {} slots, helper-before head: {:#x} at slot {} [justified={}, finalized={}], client head: {:#x} at slot {} [justified={}, finalized={}], helper-after head: {:#x} at slot {} [justified={}, finalized={}])",
+    Err(HeadSyncWaitError::ClientFailure(format!(
+        "Client under test {client_name} never reached required head slot {} and caught up to the local LeanSpec helper head slot within {} seconds (allowed lag: {} slots, helper-before head: {:#x} at slot {} [justified={}, finalized={}], client head: {:#x} at slot {} [justified={}, finalized={}], helper-after head: {:#x} at slot {} [justified={}, finalized={}])",
         minimum_client_head_slot,
         HEAD_SYNC_TIMEOUT_SECS,
         HEAD_SYNC_MAX_SLOT_LAG,
@@ -283,8 +282,7 @@ async fn wait_for_client_to_reach_source_head(
     .unwrap_or_else(|err| panic!("{}", err.into_message()))
 }
 
-async fn wait_for_client_to_reach_source_head_with_client_restart(
-    test: &Test,
+async fn wait_for_client_to_reach_source_head_for_phase(
     context: &mut PostGenesisSyncContext,
     minimum_source_head_slot: u64,
     minimum_source_finalized_slot: u64,
@@ -301,33 +299,11 @@ async fn wait_for_client_to_reach_source_head_with_client_restart(
     {
         Ok(result) => result,
         Err(HeadSyncWaitError::NonRetryable(message)) => panic!("{message}"),
-        Err(HeadSyncWaitError::RetryableClient(first_error)) => {
+        Err(HeadSyncWaitError::ClientFailure(message)) => {
             let client_name = context.client_under_test.kind.clone();
-            eprintln!(
-                "Restarting client under test {client_name} after it failed to catch up during {phase}: {first_error}"
-            );
-            context
-                .restart_client_under_test(test)
-                .await
-                .unwrap_or_else(|restart_err| {
-                    panic!(
-                        "Unable to restart client under test {client_name} after failed {phase}: {restart_err}. Initial catch-up failure: {first_error}"
-                    )
-                });
-
-            try_wait_for_client_to_reach_source_head(
-                context,
-                minimum_source_head_slot,
-                minimum_source_finalized_slot,
-                minimum_client_head_slot,
+            panic!(
+                "Client under test {client_name} failed during {phase}; not retrying or restarting the client. {message}"
             )
-            .await
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Client under test {client_name} still failed to catch up during {phase} after one restart: {}. Initial catch-up failure before restart: {first_error}",
-                    err.into_message()
-                )
-            })
         }
     }
 }
@@ -780,8 +756,7 @@ dyn_async! {
 
         let checkpoint_sync_boundary = context.source_fork_choice.finalized.slot;
 
-        wait_for_client_to_reach_source_head_with_client_restart(
-            test,
+        wait_for_client_to_reach_source_head_for_phase(
             &mut context,
             checkpoint_sync_boundary,
             checkpoint_sync_boundary,
@@ -873,12 +848,8 @@ async fn start_same_client_genesis_node(
         node_index,
         &bootnodes,
     );
-    let client = start_client_under_test_with_retry(
-        test,
-        test_data.client_under_test.name.clone(),
-        environment,
-    )
-    .await;
+    let client =
+        start_client_under_test(test, test_data.client_under_test.name.clone(), environment).await;
     let metadata = bootnode_metadata_for_client(&private_key, client.ip, LEAN_CLIENT_P2P_PORT);
     let bootnode = lean_bootnodes_for_client(client_kind, &[metadata]);
 
@@ -1207,8 +1178,7 @@ dyn_async! {
         });
 
         let (source_before_pause, client_before_pause) =
-            wait_for_client_to_reach_source_head_with_client_restart(
-                test,
+            wait_for_client_to_reach_source_head_for_phase(
                 &mut context,
                 0,
                 1,
@@ -1293,8 +1263,7 @@ dyn_async! {
         });
 
         let (source_before_pause, client_before_pause) =
-            wait_for_client_to_reach_source_head_with_client_restart(
-                test,
+            wait_for_client_to_reach_source_head_for_phase(
                 &mut context,
                 0,
                 1,
@@ -1398,8 +1367,7 @@ dyn_async! {
         .await;
         let minimum_source_head_slot = fork_choice_head_slot(&honest_helper_agreement_before_pause);
         let (source_before_pause, client_before_pause) =
-            wait_for_client_to_reach_source_head_with_client_restart(
-                test,
+            wait_for_client_to_reach_source_head_for_phase(
                 &mut context,
                 minimum_source_head_slot,
                 1,

--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -52,7 +52,6 @@ const LOCAL_HELPER_STARTUP_TIMEOUT_SECS: u64 = 120;
 const LOCAL_HELPER_METADATA_TIMEOUT_SECS: u64 = 60;
 const LOCAL_HELPER_STARTUP_ATTEMPTS: u64 = 10;
 const LOCAL_HELPER_RETRY_DELAY_SECS: u64 = 2;
-const CLIENT_UNDER_TEST_STARTUP_ATTEMPTS: u64 = 3;
 const CLIENT_UNDER_TEST_STARTUP_ATTEMPT_TIMEOUT_SECS: u64 = 120;
 const CHECKPOINT_SYNC_CLIENT_READY_TIMEOUT_SECS: u64 = 30;
 const MESH_HELPER_READY_TIMEOUT_SECS: u64 = 120;
@@ -107,7 +106,6 @@ pub(crate) struct PostGenesisSyncTestData {
 pub(crate) struct PostGenesisSyncContext {
     _helpers: RunningLocalLeanSpecHelperGroup,
     pub client_under_test: Client,
-    client_under_test_environment: HashMap<String, String>,
     pub source_fork_choice: ForkChoiceSnapshot,
     pub client_checkpoint: Option<CheckpointResponse>,
 }
@@ -135,24 +133,6 @@ struct StartedLocalHelperMesh {
 }
 
 impl PostGenesisSyncContext {
-    pub(crate) async fn restart_client_under_test(&mut self, test: &Test) -> Result<(), String> {
-        let client_type = self.client_under_test.kind.clone();
-        let old_container = self.client_under_test.container.clone();
-        self.client_under_test.stop().await.map_err(|err| {
-            format!(
-                "unable to stop client under test {client_type} container {old_container} before restart: {err}"
-            )
-        })?;
-
-        self.client_under_test = start_client_under_test_with_retry(
-            test,
-            client_type,
-            self.client_under_test_environment.clone(),
-        )
-        .await;
-        Ok(())
-    }
-
     pub(crate) async fn try_load_live_helper_fork_choice(
         &mut self,
     ) -> Result<ForkChoiceResponse, String> {
@@ -1091,17 +1071,16 @@ pub(crate) async fn start_checkpoint_sync_client_context(
         test_data.connect_client_to_lean_spec_mesh,
         test_data.client_role,
     );
-    let client_under_test =
-        start_checkpoint_sync_client_under_test_with_retry(CheckpointSyncClientStart {
-            test,
-            helper: &mut helper_mesh.helpers.source,
-            source_fork_choice: &mut helper_mesh.source_fork_choice,
-            helper_config: helper_mesh.source_helper_config.clone(),
-            client_type: test_data.client_under_test.name.clone(),
-            environment: checkpoint_sync_client_environment.clone(),
-            minimum_slot: minimum_source_checkpoint_slot(test_data),
-        })
-        .await;
+    let client_under_test = start_checkpoint_sync_client_under_test(CheckpointSyncClientStart {
+        test,
+        helper: &mut helper_mesh.helpers.source,
+        source_fork_choice: &mut helper_mesh.source_fork_choice,
+        helper_config: helper_mesh.source_helper_config.clone(),
+        client_type: test_data.client_under_test.name.clone(),
+        environment: checkpoint_sync_client_environment,
+        minimum_slot: minimum_source_checkpoint_slot(test_data),
+    })
+    .await;
 
     let client_checkpoint = if test_data.wait_for_client_justified_checkpoint {
         Some(
@@ -1116,7 +1095,6 @@ pub(crate) async fn start_checkpoint_sync_client_context(
     PostGenesisSyncContext {
         _helpers: helper_mesh.helpers,
         client_under_test,
-        client_under_test_environment: checkpoint_sync_client_environment,
         source_fork_choice: helper_mesh.source_fork_choice,
         client_checkpoint,
     }
@@ -1225,7 +1203,7 @@ async fn start_post_genesis_sync_context_inner(
 
     let client_under_test = if should_start_client_early {
         Some(
-            start_client_under_test_with_retry(
+            start_client_under_test(
                 test,
                 test_data.client_under_test.name.clone(),
                 initial_client_under_test_environment.clone(),
@@ -1401,8 +1379,8 @@ async fn start_post_genesis_sync_context_inner(
         };
     }
 
-    let (client_under_test, client_under_test_environment) = match client_under_test {
-        Some(client_under_test) => (client_under_test, initial_client_under_test_environment),
+    let client_under_test = match client_under_test {
+        Some(client_under_test) => client_under_test,
         None if test_data.use_checkpoint_sync => {
             let checkpoint_sync_client_environment = client_under_test_environment(
                 &helpers,
@@ -1415,27 +1393,24 @@ async fn start_post_genesis_sync_context_inner(
             );
             let checkpoint_sync_client_environment =
                 with_extra_bootnodes(checkpoint_sync_client_environment, &extra_bootnodes);
-            let client_under_test =
-                start_checkpoint_sync_client_under_test_with_retry(CheckpointSyncClientStart {
-                    test,
-                    helper: &mut helpers.source,
-                    source_fork_choice: &mut source_fork_choice,
-                    helper_config: source_helper_config.clone(),
-                    client_type: test_data.client_under_test.name.clone(),
-                    environment: checkpoint_sync_client_environment.clone(),
-                    minimum_slot: minimum_source_checkpoint_slot(test_data),
-                })
-                .await;
-            (client_under_test, checkpoint_sync_client_environment)
+            start_checkpoint_sync_client_under_test(CheckpointSyncClientStart {
+                test,
+                helper: &mut helpers.source,
+                source_fork_choice: &mut source_fork_choice,
+                helper_config: source_helper_config.clone(),
+                client_type: test_data.client_under_test.name.clone(),
+                environment: checkpoint_sync_client_environment,
+                minimum_slot: minimum_source_checkpoint_slot(test_data),
+            })
+            .await
         }
         None => {
-            let client_under_test = start_client_under_test_with_retry(
+            start_client_under_test(
                 test,
                 test_data.client_under_test.name.clone(),
-                delayed_client_under_test_environment.clone(),
+                delayed_client_under_test_environment,
             )
-            .await;
-            (client_under_test, delayed_client_under_test_environment)
+            .await
         }
     };
 
@@ -1452,7 +1427,6 @@ async fn start_post_genesis_sync_context_inner(
     PostGenesisSyncContext {
         _helpers: helpers,
         client_under_test,
-        client_under_test_environment,
         source_fork_choice,
         client_checkpoint,
     }
@@ -1744,58 +1718,31 @@ async fn register_client_under_test_for_failed_setup(
     }
 }
 
-pub(crate) async fn start_client_under_test_with_retry(
+fn client_under_test_crash_message(client_type: &str, error: &str) -> String {
+    format!(
+        "Test failed because the client under test {client_type} crashed or failed during startup; not retrying client startup. Startup failure: {error}"
+    )
+}
+
+pub(crate) async fn start_client_under_test(
     test: &Test,
     client_type: String,
     environment: HashMap<String, String>,
 ) -> Client {
     let files = prepare_client_runtime_files(&client_type, &environment)
         .unwrap_or_else(|err| panic!("Unable to prepare runtime assets for {client_type}: {err}"));
-    let mut last_error = None;
 
-    for attempt in 1..=CLIENT_UNDER_TEST_STARTUP_ATTEMPTS {
-        let test = test.clone();
-        let client_type_for_attempt = client_type.clone();
-        let environment_for_attempt = environment.clone();
-        let files_for_attempt = files.clone();
-
-        match start_client_under_test_attempt(
-            test,
-            client_type_for_attempt,
-            environment_for_attempt,
-            files_for_attempt,
-        )
+    start_client_under_test_attempt(test.clone(), client_type.clone(), environment, files)
         .await
-        {
-            Ok(client) => return client,
-            Err(message) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
-                eprintln!(
-                    "Retrying client-under-test startup for {client_type} after attempt {attempt} failed: {message}"
-                );
-                last_error = Some(message);
-                sleep(Duration::from_secs(1)).await;
-            }
-            Err(message) => {
-                panic!(
-                    "Unable to start client under test {client_type} after {CLIENT_UNDER_TEST_STARTUP_ATTEMPTS} attempts: {message}"
-                );
-            }
-        }
-    }
-
-    panic!(
-        "Unable to start client under test {} after {} attempts{}",
-        client_type,
-        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
-        last_error
-            .map(|error| format!(": {error}"))
-            .unwrap_or_default()
-    );
+        .unwrap_or_else(|message| {
+            panic!(
+                "{}",
+                client_under_test_crash_message(&client_type, &message)
+            )
+        })
 }
 
-async fn start_checkpoint_sync_client_under_test_with_retry(
-    params: CheckpointSyncClientStart<'_>,
-) -> Client {
+async fn start_checkpoint_sync_client_under_test(params: CheckpointSyncClientStart<'_>) -> Client {
     let files = prepare_client_runtime_files(&params.client_type, &params.environment)
         .unwrap_or_else(|err| {
             panic!(
@@ -1803,97 +1750,46 @@ async fn start_checkpoint_sync_client_under_test_with_retry(
                 params.client_type
             )
         });
-    let mut last_error = None;
-    let mut client_was_started = false;
 
-    for attempt in 1..=CLIENT_UNDER_TEST_STARTUP_ATTEMPTS {
-        if client_was_started {
-            wait_for_checkpoint_sync_state_ready(params.helper)
-                .await
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "{}",
-                        helper_failed_after_client_started_message(
-                            &params.client_type,
-                            "checking checkpoint-sync source readiness before a retry",
-                            &err,
-                        )
-                    )
-                });
-        } else {
-            ensure_checkpoint_sync_source_ready(
-                params.helper,
-                params.source_fork_choice,
-                &params.helper_config,
-                params.minimum_slot,
-            )
-            .await
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Checkpoint-sync source state endpoint was not ready for {} before initial client startup attempt {}: {}",
-                    params.client_type, attempt, err
-                )
-            });
-        }
-        sleep(Duration::from_secs(1)).await;
-
-        let test = params.test.clone();
-        let client_type_for_attempt = params.client_type.clone();
-        let environment_for_attempt = params.environment.clone();
-        let files_for_attempt = files.clone();
-
-        match start_client_under_test_attempt(
-            test,
-            client_type_for_attempt,
-            environment_for_attempt,
-            files_for_attempt,
+    ensure_checkpoint_sync_source_ready(
+        params.helper,
+        params.source_fork_choice,
+        &params.helper_config,
+        params.minimum_slot,
+    )
+    .await
+    .unwrap_or_else(|err| {
+        panic!(
+            "Checkpoint-sync source state endpoint was not ready for {} before client startup: {}",
+            params.client_type, err
         )
-        .await
-        {
-            Ok(client) => match wait_for_checkpoint_sync_client_post_genesis(&client).await {
-                Ok(()) => return client,
-                Err(error) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
-                    client_was_started = true;
-                    eprintln!(
-                        "Retrying checkpoint-sync client-under-test startup for {} after attempt {} never reached a post-genesis forkchoice state: {}",
-                        params.client_type, attempt, error
-                    );
-                    last_error = Some(error);
-                    drop(client);
-                    sleep(Duration::from_secs(1)).await;
-                }
-                Err(error) => {
-                    panic!(
-                        "Unable to start checkpoint-sync client under test {} after {} attempts: {}",
-                        params.client_type, CLIENT_UNDER_TEST_STARTUP_ATTEMPTS, error
-                    );
-                }
-            },
-            Err(message) if attempt < CLIENT_UNDER_TEST_STARTUP_ATTEMPTS => {
-                eprintln!(
-                    "Retrying checkpoint-sync client-under-test startup for {} after attempt {} failed: {}",
-                    params.client_type, attempt, message
-                );
-                last_error = Some(message);
-                sleep(Duration::from_secs(1)).await;
-            }
-            Err(message) => {
-                panic!(
-                    "Unable to start checkpoint-sync client under test {} after {} attempts: {}",
-                    params.client_type, CLIENT_UNDER_TEST_STARTUP_ATTEMPTS, message
-                );
-            }
-        }
-    }
+    });
+    sleep(Duration::from_secs(1)).await;
 
-    panic!(
-        "Unable to start checkpoint-sync client under test {} after {} attempts{}",
-        params.client_type,
-        CLIENT_UNDER_TEST_STARTUP_ATTEMPTS,
-        last_error
-            .map(|error| format!(": {error}"))
-            .unwrap_or_default()
-    );
+    let client = start_client_under_test_attempt(
+        params.test.clone(),
+        params.client_type.clone(),
+        params.environment.clone(),
+        files,
+    )
+    .await
+    .unwrap_or_else(|message| {
+        panic!(
+            "{}",
+            client_under_test_crash_message(&params.client_type, &message)
+        )
+    });
+
+    wait_for_checkpoint_sync_client_post_genesis(&client)
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "Checkpoint-sync client under test {} started but crashed, became unreachable, or failed before exposing a post-genesis forkchoice state; not retrying client startup. Client failure: {}",
+                params.client_type, error
+            )
+        });
+
+    client
 }
 
 async fn ensure_checkpoint_sync_source_ready(


### PR DESCRIPTION
removes client retries and logs client failure reason. Tests now fail if a client crashes on start or during the test.