### PR TITLE
simulators/lean: reqresp stability fix

### DIFF
--- a/simulators/lean/src/scenarios/reqresp.rs
+++ b/simulators/lean/src/scenarios/reqresp.rs
@@ -1,5 +1,5 @@
 use crate::utils::helper::{
-    start_client_under_test, start_post_genesis_sync_context, HelperGossipForkDigestProfile,
+    start_post_genesis_sync_context, try_start_client_under_test, HelperGossipForkDigestProfile,
     PostGenesisSyncTestData, LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
 };
 use crate::utils::libp2p_mock::{
@@ -65,17 +65,24 @@ dyn_async! {
             panic!("No lean clients were selected for this run");
         }
         let planning = test.plan_test("reqresp: client launch", true);
+        let mut launch_failures = Vec::new();
 
         for client in &clients {
             if !planning {
                 let environment = lean_environment();
-                let launch_client =
-                    start_client_under_test(test, client.name.clone(), environment).await;
-                if let Err(err) = launch_client.stop().await {
-                    eprintln!(
-                        "Unable to stop reqresp launch-attribution client {}: {err}",
-                        client.name
-                    );
+                match try_start_client_under_test(test, client.name.clone(), environment).await {
+                    Ok(launch_client) => {
+                        if let Err(err) = launch_client.stop().await {
+                            eprintln!(
+                                "Unable to stop reqresp launch-attribution client {}: {err}",
+                                client.name
+                            );
+                        }
+                    }
+                    Err(message) => {
+                        eprintln!("{message}");
+                        launch_failures.push(message);
+                    }
                 }
             }
 
@@ -714,6 +721,13 @@ dyn_async! {
 
 
 
+        }
+
+        if !launch_failures.is_empty() {
+            panic!(
+                "One or more reqresp launch-attribution clients failed; all reqresp child tests were still scheduled:\n{}",
+                launch_failures.join("\n")
+            );
         }
     }
 }

--- a/simulators/lean/src/utils/helper.rs
+++ b/simulators/lean/src/utils/helper.rs
@@ -1747,17 +1747,22 @@ pub(crate) async fn start_client_under_test(
     client_type: String,
     environment: HashMap<String, String>,
 ) -> Client {
+    try_start_client_under_test(test, client_type, environment)
+        .await
+        .unwrap_or_else(|message| panic!("{message}"))
+}
+
+pub(crate) async fn try_start_client_under_test(
+    test: &Test,
+    client_type: String,
+    environment: HashMap<String, String>,
+) -> Result<Client, String> {
     let files = prepare_client_runtime_files(&client_type, &environment)
-        .unwrap_or_else(|err| panic!("Unable to prepare runtime assets for {client_type}: {err}"));
+        .map_err(|err| format!("Unable to prepare runtime assets for {client_type}: {err}"))?;
 
     start_client_under_test_attempt(test.clone(), client_type.clone(), environment, files)
         .await
-        .unwrap_or_else(|message| {
-            panic!(
-                "{}",
-                client_under_test_crash_message(&client_type, &message)
-            )
-        })
+        .map_err(|message| client_under_test_crash_message(&client_type, &message))
 }
 
 async fn start_checkpoint_sync_client_under_test(params: CheckpointSyncClientStart<'_>) -> Client {


### PR DESCRIPTION
Currently if a client fails to start in the reqresp suite the entire suite will exit instead of just moving on to the next test, causing the suite to end early not run any tests for any client after the failure. Handling the failure properly now allows for the suite to continue.