### PR TITLE
simulators/eels: optionally consume pre-staged local fixtures

### DIFF
--- a/simulators/ethereum/eels/consume-engine/Dockerfile
+++ b/simulators/ethereum/eels/consume-engine/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,12 +18,26 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv sync
 RUN uv run consume cache --input "$FIXTURES"
 
 

--- a/simulators/ethereum/eels/consume-enginex/Dockerfile
+++ b/simulators/ethereum/eels/consume-enginex/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume enginex simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,12 +18,26 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv sync
 RUN uv run consume cache --input "$FIXTURES"
 
 

--- a/simulators/ethereum/eels/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eels/consume-rlp/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume rlp simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,13 +18,27 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
 RUN uv run consume cache --input "$FIXTURES"
-RUN uv sync
 
 ## Define `consume rlp` entry point using the local fixtures
 ENTRYPOINT uv run consume rlp -v --input "$FIXTURES"


### PR DESCRIPTION
## Why

The `eels/consume-engine` and `eels/consume-rlp` simulators download the fixtures tarball at **image-build time** via `uv run consume cache --input "$FIXTURES"`. Because hive is typically invoked with `--docker.nocache`, that download repeats on **every run** — slow, and exposed to transient GitHub release-CDN failures (e.g. HTTP 504s).

## What

Let a caller provide the fixtures **locally** instead of by URL, with **no change to default behavior**:

- Stage a `fixtures.tar.gz` into the simulator build context and pass the build arg `fixtures=/fixtures`.
- The tarball is extracted in a **throwaway build stage** (`fixtures-stage`); only the extracted directory is `COPY --from`'d into the final image, so the tarball itself never lands in the final image (no size doubling).
- `consume` then reads `--input /fixtures` (a local directory), which it accepts and recursively indexes (`FixturesSource.validate_local_path` + `generate_fixtures_index` in `execution-specs`).

## Backward compatible

With **no** `fixtures.tar.gz` staged and `fixtures=<release/url>` (the default, and how it is invoked today):
- the optional `COPY Dockerfile fixtures.tar.gz*` matches only the `Dockerfile` anchor,
- `/fixtures` stays empty,
- `FIXTURES` remains the URL/release,
- and `consume` downloads exactly as before.

The new path activates **only** when both a tarball is staged **and** `fixtures=/fixtures` is passed.

## How to use it in CI (generic)

Warm the fixtures **once**, out of band, cache the tarball, and hand it to the simulator build. Only two simulators are touched — `consume-engine` and `consume-rlp` — so stage the tarball into whichever simulator dir(s) you run.

1. **Restore/produce** `fixtures.tar.gz` from your CI cache (keyed by fixtures release/version).
2. **Stage** it into the simulator build context:
   ```
   cp fixtures.tar.gz simulators/ethereum/eels/consume-engine/fixtures.tar.gz
   cp fixtures.tar.gz simulators/ethereum/eels/consume-rlp/fixtures.tar.gz
   ```
3. **Run hive** with the build arg pointing at the local dir:
   ```
   ./hive --sim ethereum/eels --client <client> \
          --sim.buildarg fixtures=/fixtures \
          --docker.nocache
   ```

### GitHub Actions

```yaml
- name: Cache EEST fixtures
  id: fixtures-cache
  uses: actions/cache@v4
  with:
    path: fixtures.tar.gz
    key: eest-fixtures-${{ env.FIXTURES_RELEASE }}

- name: Download fixtures on cache miss
  if: steps.fixtures-cache.outputs.cache-hit != 'true'
  run: curl -fSL "$FIXTURES_URL" -o fixtures.tar.gz

- name: Stage fixtures into simulators
  run: |
    for sim in consume-engine consume-rlp; do
      cp fixtures.tar.gz "hive/simulators/ethereum/eels/$sim/fixtures.tar.gz"
    done

- name: Run hive
  working-directory: hive
  run: |
    ./hive --sim ethereum/eels --client <client> \
           --sim.buildarg fixtures=/fixtures \
           --docker.nocache
```

### CircleCI

```yaml
steps:
  - restore_cache:
      keys:
        - eest-fixtures-{{ .Environment.FIXTURES_RELEASE }}
  - run:
      name: Ensure fixtures + stage into simulators
      command: |
        [ -f fixtures.tar.gz ] || curl -fSL "$FIXTURES_URL" -o fixtures.tar.gz
        for sim in consume-engine consume-rlp; do
          cp fixtures.tar.gz "hive/simulators/ethereum/eels/$sim/fixtures.tar.gz"
        done
  - save_cache:
      key: eest-fixtures-{{ .Environment.FIXTURES_RELEASE }}
      paths: [fixtures.tar.gz]
  - run:
      name: Run hive
      command: |
        cd hive
        ./hive --sim ethereum/eels --client <client> \
               --sim.buildarg fixtures=/fixtures \
               --docker.nocache
```

Net effect: the per-run CDN download is replaced by a cache restore that the CI provider serves, removing both the latency and the transient-failure surface. Callers that do nothing keep the current download-by-URL behavior.

---

This mirrors a change already running in the `erigontech/hive` fork (erigontech/hive#2).
