### PR TITLE
cmd/hivechain: add osaka/bpo forkenv output, bpo fork support, -disable-txmods flag

### DIFF
--- a/cmd/hivechain/generate.go
+++ b/cmd/hivechain/generate.go
@@ -28,11 +28,12 @@ type generatorConfig struct {
 	merged       bool   // create a proof-of-stake chain
 
 	// chain options
-	txInterval        int    // frequency of blocks containing transactions
-	txCount           int    // number of txs in block
-	chainLength       int    // number of generated blocks
-	gasLimit          uint64 // block gas limit
-	finalizedDistance int    // distance of finalized block from head
+	txInterval        int      // frequency of blocks containing transactions
+	txCount           int      // number of txs in block
+	chainLength       int      // number of generated blocks
+	gasLimit          uint64   // block gas limit
+	finalizedDistance int      // distance of finalized block from head
+	disabledMods      []string // tx modifiers to skip
 
 	// output options
 	outputs   []string // enabled outputs
@@ -99,6 +100,9 @@ func newGenerator(cfg generatorConfig) *generator {
 
 func (cfg *generatorConfig) createBlockModifiers() (list []*modifierInstance) {
 	for name, new := range modRegistry {
+		if slices.Contains(cfg.disabledMods, name) {
+			continue
+		}
 		list = append(list, &modifierInstance{
 			name:          name,
 			blockModifier: new(),

--- a/cmd/hivechain/genesis.go
+++ b/cmd/hivechain/genesis.go
@@ -48,6 +48,8 @@ var (
 		"cancun",
 		"prague",
 		"osaka",
+		"bpo1",
+		"bpo2",
 	}
 )
 
@@ -110,6 +112,12 @@ func (cfg *generatorConfig) createChainConfig() *params.ChainConfig {
 		case "osaka":
 			chaincfg.OsakaTime = &timestamp
 			chaincfg.BlobScheduleConfig.Osaka = params.DefaultOsakaBlobConfig
+		case "bpo1":
+			chaincfg.BPO1Time = &timestamp
+			chaincfg.BlobScheduleConfig.BPO1 = params.DefaultBPO1BlobConfig
+		case "bpo2":
+			chaincfg.BPO2Time = &timestamp
+			chaincfg.BlobScheduleConfig.BPO2 = params.DefaultBPO2BlobConfig
 		default:
 			panic(fmt.Sprintf("unknown fork name %q", fork))
 		}

--- a/cmd/hivechain/main.go
+++ b/cmd/hivechain/main.go
@@ -58,8 +58,9 @@ func main() {
 // generateCommand generates a test chain.
 func generateCommand(args []string) {
 	var (
-		cfg     generatorConfig
-		outlist = flag.String("outputs", "", "Enabled output modules")
+		cfg      generatorConfig
+		outlist  = flag.String("outputs", "", "Enabled output modules")
+		disabled = flag.String("disable-txmods", "", "Comma-separated list of tx modifiers to disable")
 	)
 	flag.IntVar(&cfg.chainLength, "length", 2, "The length of the pow chain to generate")
 	flag.Uint64Var(&cfg.gasLimit, "gaslimit", defaultGasLimit, "Block gas limit of the chain")
@@ -77,6 +78,12 @@ func generateCommand(args []string) {
 			cfg.outputs = outputFunctionNames()
 		}
 		cfg.outputs = splitAndTrim(*outlist)
+	}
+	for _, name := range splitAndTrim(*disabled) {
+		if _, ok := modRegistry[name]; !ok {
+			fatal(fmt.Errorf("unknown tx modifier %q", name))
+		}
+		cfg.disabledMods = append(cfg.disabledMods, name)
 	}
 
 	cfg, err := cfg.withDefaults()

--- a/cmd/hivechain/output_forkenv.go
+++ b/cmd/hivechain/output_forkenv.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // writeForkEnv writes chain fork configuration in the form that hive expects.
@@ -50,19 +52,24 @@ func (g *generator) writeForkEnv() error {
 	setTime("HIVE_SHANGHAI_TIMESTAMP", cfg.ShanghaiTime)
 	setTime("HIVE_CANCUN_TIMESTAMP", cfg.CancunTime)
 	setTime("HIVE_PRAGUE_TIMESTAMP", cfg.PragueTime)
+	setTime("HIVE_OSAKA_TIMESTAMP", cfg.OsakaTime)
+	setTime("HIVE_BPO1_TIMESTAMP", cfg.BPO1Time)
+	setTime("HIVE_BPO2_TIMESTAMP", cfg.BPO2Time)
 
 	// blob schedule
+	setBlobConfig := func(fork string, bc *params.BlobConfig) {
+		if bc != nil {
+			env["HIVE_"+fork+"_BLOB_TARGET"] = fmt.Sprint(bc.Target)
+			env["HIVE_"+fork+"_BLOB_MAX"] = fmt.Sprint(bc.Max)
+			env["HIVE_"+fork+"_BLOB_BASE_FEE_UPDATE_FRACTION"] = fmt.Sprint(bc.UpdateFraction)
+		}
+	}
 	if cfg.BlobScheduleConfig != nil {
-		if cfg.BlobScheduleConfig.Cancun != nil {
-			env["HIVE_CANCUN_BLOB_TARGET"] = fmt.Sprint(cfg.BlobScheduleConfig.Cancun.Target)
-			env["HIVE_CANCUN_BLOB_MAX"] = fmt.Sprint(cfg.BlobScheduleConfig.Cancun.Max)
-			env["HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION"] = fmt.Sprint(cfg.BlobScheduleConfig.Cancun.UpdateFraction)
-		}
-		if cfg.BlobScheduleConfig.Prague != nil {
-			env["HIVE_PRAGUE_BLOB_TARGET"] = fmt.Sprint(cfg.BlobScheduleConfig.Prague.Target)
-			env["HIVE_PRAGUE_BLOB_MAX"] = fmt.Sprint(cfg.BlobScheduleConfig.Prague.Max)
-			env["HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION"] = fmt.Sprint(cfg.BlobScheduleConfig.Prague.UpdateFraction)
-		}
+		setBlobConfig("CANCUN", cfg.BlobScheduleConfig.Cancun)
+		setBlobConfig("PRAGUE", cfg.BlobScheduleConfig.Prague)
+		setBlobConfig("OSAKA", cfg.BlobScheduleConfig.Osaka)
+		setBlobConfig("BPO1", cfg.BlobScheduleConfig.BPO1)
+		setBlobConfig("BPO2", cfg.BlobScheduleConfig.BPO2)
 	}
 
 	return g.writeJSON("forkenv.json", env)


### PR DESCRIPTION
- `output_forkenv.go`: emit `HIVE_{OSAKA,BPO1,BPO2}_TIMESTAMP` and the per-fork blob schedule vars. Client mappers already read these; hivechain never wrote them.
- `genesis.go`: add `bpo1`/`bpo2` forks (geth's default BPO blob configs), so `-lastfork bpo2` matches mainnet's fork set.
- New `-disable-txmods` flag to skip block modifiers. `tx-largereceipt`'s >10MB-receipts block turns the `eth_getLogs/no-topics` fixture into a 21MB file, overflowing the rpc-compat loader's 1MiB line buffer.

Companion to ethereum/execution-apis#846, the test-chain bump to Osaka+BPO (needed since ethereum/go-ethereum#35191 dropped v0 blob sidecars, breaking `send-blob-tx` in daily rpc-compat runs); that regeneration depends on this PR.
