### PR TITLE
erigon: raise MAX_REORG_DEPTH for enginex runs

### DIFF
--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -35,6 +35,11 @@ set -e
 
 erigon=/usr/local/bin/erigon
 
+# consume-enginex reuses one client across tests in same groupings and requires longer reorgs than the default of 96 blocks for some tests
+# TODO can be removed once work is done to support unlimited reorgs based on finalised hash (tracked by https://github.com/erigontech/erigon/issues/17070)
+# will need EELS to also send FCUs with finalised=genesis_hash,justified=genesis_hash too
+export MAX_REORG_DEPTH=512
+
 if [ "$HIVE_LOGLEVEL" != "" ]; then
     FLAGS="$FLAGS --log.console.verbosity=$HIVE_LOGLEVEL"
 fi


### PR DESCRIPTION
## Why
`consume-enginex` reuses one erigon client across all tests in a pre-alloc group and
resets it to genesis between tests via `forkchoiceUpdated(head=genesis)`. That reset must
unwind the whole test chain back to block 0. Erigon retains unwind changesets only for the
last `MAX_REORG_DEPTH` blocks behind the tip (default **96**), so a test that builds a
chain deeper than 96 — notably `test_genesis_hash_available` (256 empty blocks) — can no
longer unwind to genesis and the reset fails with `"Too deep reorg"`. The sim then retries
the FCU forever and the client's whole test group fails.

## What
`export MAX_REORG_DEPTH=512` in `clients/erigon/erigon.sh`. The deepest chain across the
osaka/BPO shard is `genesis_hash`'s 256 blocks, so 512 gives ~2x margin (it also matches
erigon's own `engine_x_test_runner.go`, which uses `config.MaxReorgDepth=512`).

## Follow-up (this bump can be removed later)
This is a workaround for the fixed 96-block reorg window. It can be dropped once **both**:
1. erigon supports unlimited reorgs based on the finalised hash — erigontech/erigon#17070
   (a reorg down to the finalised block is always allowed, regardless of depth); and
2. EELS also sends the engine-API FCUs with `finalized=genesis_hash` and
   `safe/justified=genesis_hash` (today the enginex flow leaves them at the zero hash), so
   erigon can treat genesis as finalised and unwind back to it at any depth.

With both in place, the reused-client genesis reset needs no depth override.

## Evidence
osaka `consume-enginex` shard against erigon (with the corresponding erigon-side fixes),
16675 tests:
- default depth 96: one worker wedges on the `genesis_hash` group
  (`reorg target below minimum unwindable block … "Too deep reorg"`; tip 257, 257 − 96 − 1 = 160).
- `MAX_REORG_DEPTH=512`: **0 failed / 16675**, `genesis_hash` passes, no wedge.
