### PR TITLE
clients/ethrex: raise max reorg depth for enginex runs

### DIFF
--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -6,6 +6,12 @@ set -ex
 # no ansi colors
 export RUST_LOG_STYLE=never
 
+# EEST consume-enginex reuses one client across tests in the same pre-allocation
+# group and resets it to genesis between tests; allow rewinds deeper than the
+# 128-block default. Ethrex builds without --max-reorg-depth support ignore this
+# variable.
+export ETHREX_MAX_REORG_DEPTH=512
+
 ethrex=./ethrex
 
 # Configure the chain.

--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -6,11 +6,11 @@ set -ex
 # no ansi colors
 export RUST_LOG_STYLE=never
 
-# EEST consume-enginex reuses one client across tests in the same pre-allocation
-# group and resets it to genesis between tests; allow rewinds deeper than the
-# 128-block default. Ethrex builds without --max-reorg-depth support ignore this
-# variable.
-export ETHREX_MAX_REORG_DEPTH=512
+# Raise ethrex's reorg depth limit (default 128) for simulators that rewind
+# deeply, e.g. consume-enginex; ethrex without the flag ignores the var.
+if [ "$HIVE_EXPECT_DEEP_REORGS" != "" ]; then
+    export ETHREX_MAX_REORG_DEPTH=512
+fi
 
 ethrex=./ethrex
 


### PR DESCRIPTION
EEST's consume-enginex simulator reuses one client per pre-allocation group and resets it to genesis between tests, so any test chain deeper than ethrex's 128-block reorg limit fails every remaining test in the group with `-38006 Too deep reorg`. Raise the limit to 512 via `ETHREX_MAX_REORG_DEPTH` when the simulator sets `HIVE_EXPECT_DEEP_REORGS`, mirroring the erigon fix (#1568); ethrex builds without `--max-reorg-depth` support ignore the variable.

Requires ethereum/execution-specs#3145, which sets `HIVE_EXPECT_DEEP_REORGS=1` in the enginex multi-test client environment.