### PR TITLE
clients/go-ethereum: raise engine API max reorg depth for enginex runs

### DIFF
--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -49,6 +49,12 @@ set -e
 geth=/usr/local/bin/geth
 FLAGS="--state.scheme=path"
 
+# Raise geth's engine API reorg depth limit (default 32) for simulators that
+# rewind deeply, e.g. consume-enginex; geth without the flag ignores the var.
+if [ "$HIVE_EXPECT_DEEP_REORGS" != "" ]; then
+    export GETH_ENGINE_MAXREORGDEPTH=512
+fi
+
 if [ "$HIVE_LOGLEVEL" != "" ]; then
     FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"
 fi


### PR DESCRIPTION
Since ethereum/go-ethereum#34767, geth refuses canonical-ancestor rewinds deeper than 32 blocks (`-38006 Too deep reorg`), so consume-enginex's reset-to-genesis between a shared client's tests fails permanently once any test's chain reaches height 32. Raise the limit via `GETH_ENGINE_MAXREORGDEPTH=512` when the simulator sets `HIVE_EXPECT_DEEP_REORGS` (mirroring #1568 for erigon); geth builds without `--engine.maxreorgdepth` (added in ethereum/go-ethereum#35335) ignore the variable with a warning.

Requires ethereum/execution-specs#3145, which sets `HIVE_EXPECT_DEEP_REORGS=1` in the enginex multi-test client environment, and ethereum/go-ethereum#35335 for the flag to exist.