### PR TITLE
clients/besu: update EIP-8282 builder request contract addresses

### DIFF
--- a/clients/besu/mapper.jq
+++ b/clients/besu/mapper.jq
@@ -102,7 +102,7 @@ def to_int:
     "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x00000000219ab540356cBB839Cbe05303d7705Fa"),
     "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
     "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
-    "builderDepositRequestContractAddress": "0x0000884d2aa32eaa155f59a2f24efa73d9008282",
-    "builderExitRequestContractAddress": "0x000014574a74c805590aff9499fc7a690f008282",
+    "builderDepositRequestContractAddress": "0x0000bff46984e3725691fa540a8c7589300d8282",
+    "builderExitRequestContractAddress": "0x000064d678505ad48f8ccb093bc65613800e8282",
   }|remove_empty
 }


### PR DESCRIPTION
## Summary

Updates the two hardcoded EIP-8282 builder request contract addresses in the Besu genesis config mapper from the glamsterdam devnet-6 values to the current [EIP-8282 spec](https://eips.ethereum.org/EIPS/eip-8282) addresses used by devnet-7.