### PR TITLE
clients/besu: remove incorrect EIP-8282 builder request contract addresses

### DIFF
--- a/clients/besu/mapper.jq
+++ b/clients/besu/mapper.jq
@@ -102,7 +102,5 @@ def to_int:
     "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x00000000219ab540356cBB839Cbe05303d7705Fa"),
     "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
     "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
-    "builderDepositRequestContractAddress": "0x0000884d2aa32eaa155f59a2f24efa73d9008282",
-    "builderExitRequestContractAddress": "0x000014574a74c805590aff9499fc7a690f008282",
   }|remove_empty
 }


### PR DESCRIPTION
### Problem

The EIP-8282 builder request contract addresses added for besu in #1550 are **not** the canonical addresses. EIP-8282 fixes the two new builder execution-request contracts at:

| Contract | Req type | Address |
|----------|----------|---------|
| deposit  | `0x03`   | `0x0000bff46984e3725691fa540a8c7589300d8282` |
| exit     | `0x04`   | `0x000064d678505ad48f8ccb093bc65613800e8282` |

The besu mapper instead set:

```jq
"builderDepositRequestContractAddress": "0x0000884d2aa32eaa155f59a2f24efa73d9008282",
"builderExitRequestContractAddress":    "0x000014574a74c805590aff9499fc7a690f008282",
```

Because besu resolves these via `getBuilder*RequestContractAddress().orElse(DEFAULT)`, the genesis config **overrides** besu's correct built-in defaults with the wrong addresses. Besu then runs its per-block builder-request system call against an address with no deployed contract and throws `SystemCallNoCodeAtAddressException`, so `engine_newPayload` returns `INVALID` for essentially every block — causing near-total failure of the Amsterdam `consume-engine` suite for besu.

### Fix

Remove the two besu address lines. With the keys omitted, besu falls back to its canonical hardcoded defaults, which match where the fixtures deploy the contracts — and is consistent with go-ethereum and nethermind, neither of which sets these addresses via the mapper.

The nethermind changes from #1550 (the `eip8282TransitionTimestamp` and other transition-timestamp flags) are correct and are left untouched; only the two besu address lines are reverted.
