### PR TITLE
simulators/eels: optionally consume pre-staged local fixtures tar.gz

### DIFF
--- a/simulators/ethereum/eels/consume-engine/Dockerfile
+++ b/simulators/ethereum/eels/consume-engine/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -7,7 +7,7 @@ ENV FIXTURES=${fixtures}
 ARG branch=""
 
 ## Clone and install EELS
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git isal
 
 # Clone repo and use the default branch if none specified
 RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
@@ -20,29 +20,25 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
 WORKDIR /execution-specs/packages/testing
 RUN uv sync
 
-# Optionally bake pre-staged fixtures into the image so `consume` reads them
-# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
-# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
-# release/URL and consume downloads as before. Extraction runs in a throwaway
-# stage so the tarball never lands in the final image (no size doubling); the
+# Optionally keep pre-staged fixtures compressed in the image. A caller that
+# stages ./fixtures.tar.gz and passes fixtures=/fixtures gets the local fixtures;
+# otherwise FIXTURES stays a release/URL and consume downloads as before. The
 # `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
-FROM base AS fixtures-stage
 COPY Dockerfile fixtures.tar.gz* /staged/
-RUN mkdir -p /fixtures && \
-    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
-
-FROM base
-COPY --from=fixtures-stage /fixtures /fixtures
-
-# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
-# the container starts.
-# If newer version of the fixtures is needed, the image needs to be rebuilt.
-# Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$FIXTURES"
+RUN rm -f /staged/Dockerfile && \
+    if [ "$FIXTURES" != /fixtures ] || [ ! -f /staged/fixtures.tar.gz ]; then \
+        rm -rf /staged && uv run --no-sync consume cache --input "$FIXTURES"; \
+    fi
 
 
 ## Define `consume engine` entry point using the local fixtures
 # TODO: remove when fixed on nimbus-el side.
 ARG disable_strict_exception_matching=nimbus-el
 ENV DISABLE_STRICT_EXCEPTION_MATCHING=${disable_strict_exception_matching}
-ENTRYPOINT uv run consume engine -v --input "$FIXTURES" --disable-strict-exception-matching "$DISABLE_STRICT_EXCEPTION_MATCHING"
+ENTRYPOINT if [ "$FIXTURES" = /fixtures ] && [ -f /staged/fixtures.tar.gz ]; then \
+        mkdir -p /fixtures && \
+        igzip -d -c /staged/fixtures.tar.gz | \
+            tar -xf - -C /fixtures --strip-components=1 \
+                fixtures/.meta fixtures/blockchain_tests_engine; \
+    fi && \
+    exec uv run --no-sync consume engine -v --input "$FIXTURES" --disable-strict-exception-matching "$DISABLE_STRICT_EXCEPTION_MATCHING"

--- a/simulators/ethereum/eels/consume-engine/Dockerfile
+++ b/simulators/ethereum/eels/consume-engine/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,12 +18,26 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv sync
 RUN uv run consume cache --input "$FIXTURES"
 
 

--- a/simulators/ethereum/eels/consume-enginex/Dockerfile
+++ b/simulators/ethereum/eels/consume-enginex/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume enginex simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,12 +18,26 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv sync
 RUN uv run consume cache --input "$FIXTURES"
 
 

--- a/simulators/ethereum/eels/consume-enginex/Dockerfile
+++ b/simulators/ethereum/eels/consume-enginex/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume enginex simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -7,7 +7,7 @@ ENV FIXTURES=${fixtures}
 ARG branch=""
 
 ## Clone and install EELS
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git isal
 
 # Clone repo and use the default branch if none specified
 RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
@@ -20,29 +20,25 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
 WORKDIR /execution-specs/packages/testing
 RUN uv sync
 
-# Optionally bake pre-staged fixtures into the image so `consume` reads them
-# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
-# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
-# release/URL and consume downloads as before. Extraction runs in a throwaway
-# stage so the tarball never lands in the final image (no size doubling); the
+# Optionally keep pre-staged fixtures compressed in the image. A caller that
+# stages ./fixtures.tar.gz and passes fixtures=/fixtures gets the local fixtures;
+# otherwise FIXTURES stays a release/URL and consume downloads as before. The
 # `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
-FROM base AS fixtures-stage
 COPY Dockerfile fixtures.tar.gz* /staged/
-RUN mkdir -p /fixtures && \
-    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
-
-FROM base
-COPY --from=fixtures-stage /fixtures /fixtures
-
-# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
-# the container starts.
-# If newer version of the fixtures is needed, the image needs to be rebuilt.
-# Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$FIXTURES"
+RUN rm -f /staged/Dockerfile && \
+    if [ "$FIXTURES" != /fixtures ] || [ ! -f /staged/fixtures.tar.gz ]; then \
+        rm -rf /staged && uv run --no-sync consume cache --input "$FIXTURES"; \
+    fi
 
 
 ## Define `consume enginex` entry point using the local fixtures
 # TODO: remove when fixed on nimbus-el side.
 ARG disable_strict_exception_matching=nimbus-el
 ENV DISABLE_STRICT_EXCEPTION_MATCHING=${disable_strict_exception_matching}
-ENTRYPOINT uv run consume enginex -v --input "$FIXTURES" --disable-strict-exception-matching "$DISABLE_STRICT_EXCEPTION_MATCHING"
+ENTRYPOINT if [ "$FIXTURES" = /fixtures ] && [ -f /staged/fixtures.tar.gz ]; then \
+        mkdir -p /fixtures && \
+        igzip -d -c /staged/fixtures.tar.gz | \
+            tar -xf - -C /fixtures --strip-components=1 \
+                fixtures/.meta fixtures/blockchain_tests_engine_x; \
+    fi && \
+    exec uv run --no-sync consume enginex -v --input "$FIXTURES" --disable-strict-exception-matching "$DISABLE_STRICT_EXCEPTION_MATCHING"

--- a/simulators/ethereum/eels/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eels/consume-rlp/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume rlp simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,13 +18,27 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
 RUN uv run consume cache --input "$FIXTURES"
-RUN uv sync
 
 ## Define `consume rlp` entry point using the local fixtures
 ENTRYPOINT uv run consume rlp -v --input "$FIXTURES"

--- a/simulators/ethereum/eels/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eels/consume-rlp/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume rlp simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -7,7 +7,7 @@ ENV FIXTURES=${fixtures}
 ARG branch=""
 
 ## Clone and install EELS
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git isal
 
 # Clone repo and use the default branch if none specified
 RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
@@ -20,25 +20,21 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
 WORKDIR /execution-specs/packages/testing
 RUN uv sync
 
-# Optionally bake pre-staged fixtures into the image so `consume` reads them
-# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
-# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
-# release/URL and consume downloads as before. Extraction runs in a throwaway
-# stage so the tarball never lands in the final image (no size doubling); the
+# Optionally keep pre-staged fixtures compressed in the image. A caller that
+# stages ./fixtures.tar.gz and passes fixtures=/fixtures gets the local fixtures;
+# otherwise FIXTURES stays a release/URL and consume downloads as before. The
 # `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
-FROM base AS fixtures-stage
 COPY Dockerfile fixtures.tar.gz* /staged/
-RUN mkdir -p /fixtures && \
-    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
-
-FROM base
-COPY --from=fixtures-stage /fixtures /fixtures
-
-# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
-# the container starts.
-# If newer version of the fixtures is needed, the image needs to be rebuilt.
-# Use `--docker.nocache` flag to force rebuild.
-RUN uv run consume cache --input "$FIXTURES"
+RUN rm -f /staged/Dockerfile && \
+    if [ "$FIXTURES" != /fixtures ] || [ ! -f /staged/fixtures.tar.gz ]; then \
+        rm -rf /staged && uv run --no-sync consume cache --input "$FIXTURES"; \
+    fi
 
 ## Define `consume rlp` entry point using the local fixtures
-ENTRYPOINT uv run consume rlp -v --input "$FIXTURES"
+ENTRYPOINT if [ "$FIXTURES" = /fixtures ] && [ -f /staged/fixtures.tar.gz ]; then \
+        mkdir -p /fixtures && \
+        igzip -d -c /staged/fixtures.tar.gz | \
+            tar -xf - -C /fixtures --strip-components=1 \
+                fixtures/.meta fixtures/blockchain_tests; \
+    fi && \
+    exec uv run --no-sync consume rlp -v --input "$FIXTURES"


### PR DESCRIPTION
## Summary

[Hive PR #1566](https://github.com/ethereum/hive/pull/1566) adds an optional path for CI callers to stage a cached EEST tarball and pass `fixtures=/fixtures`, avoiding a fresh GitHub release download on every cache-disabled simulator build while preserving the existing URL/release fallback. This PR improves that approach by keeping the staged tarball compressed in the image and extracting only the fixtures needed by each simulator at container startup.

At startup, `igzip` (ISA-L) streams the archive into `tar`. `--strip-components=1` places the bundled index at `/fixtures/.meta/index.json`, while selective extraction limits the writable layer to `.meta` plus `blockchain_tests_engine`, `blockchain_tests_engine_x`, or `blockchain_tests`, depending on the simulator. `consume --input /fixtures` then reuses that index without regenerating it.

## Cold-build results

Local `consume-engine` comparison using the same fixture tarball, filter, and completed test collection as the endpoint, with the simulator Docker cache disabled:

| Approach | Cold build | Startup/extract/collection | Build to ready | Image size |
|---|---:|---:|---:|---:|
| Extract the full staged tar during build | 182.00s | 9.37s | 191.37s | ~8.66 GB |
| Keep compressed and selectively extract at runtime | 19.16s | 20.55s | 39.71s | ~0.94 GB |

This reduces build-to-ready time by 151.66 seconds (79%, or 4.82x) and avoids exporting an approximately 8 GB uncompressed fixture layer. Verification collected the same 50,564 tests and selected the same 64 tests in both runs; the extracted `index.json` also matched the archive copy byte-for-byte.

## CI validation

[Erigon Hive EEST run 29501762880](https://github.com/erigontech/erigon/actions/runs/29501762880) pinned `taratorio/hive` at `77d3e52c23009d38b26c7a5d3de44b157f594f74`, supplied fixture tarballs from the runner cache, and passed all 11 matrix jobs across `consume-enginex`, `consume-rlp`, and the Glamsterdam `consume-engine` shard.
