### PR TITLE
clients/gean: startup diagnosability — require devnet label, verify binary, echo checkpoint url

### DIFF
--- a/clients/gean/gean.sh
+++ b/clients/gean/gean.sh
@@ -9,7 +9,16 @@
 
 set -euo pipefail
 
-DEVNET_LABEL="${HIVE_LEAN_DEVNET_LABEL:-devnet4}"
+# Require the devnet label explicitly. A silent default once let the devnet4
+# binary run against a devnet5 network: the node starts, peers, and only
+# diverges at consensus, which is slow to trace back to a wrapper default. The
+# lean simulator always sets this, so demanding it costs nothing and closes the
+# footgun.
+if [ -z "${HIVE_LEAN_DEVNET_LABEL:-}" ]; then
+    echo "HIVE_LEAN_DEVNET_LABEL is not set; expected 'devnet4' or 'devnet5'" >&2
+    exit 1
+fi
+DEVNET_LABEL="$HIVE_LEAN_DEVNET_LABEL"
 NODE_ID="${HIVE_NODE_ID:-gean_0}"
 BOOTNODES="${HIVE_BOOTNODES:-none}"
 ASSET_ROOT="/tmp/gean-runtime"
@@ -54,6 +63,13 @@ case "$DEVNET_LABEL" in
 esac
 
 GEAN_BIN="${GEAN_BIN:-$DEFAULT_GEAN_BIN}"
+
+# A mispackaged image (label resolved to a binary the build never produced)
+# should fail here with a clear message rather than at exec with an opaque one.
+if [ ! -x "$GEAN_BIN" ]; then
+    echo "gean binary for '$DEVNET_LABEL' missing or not executable at $GEAN_BIN" >&2
+    exit 1
+fi
 
 cleanup() {
     if [ -n "$KEY_FILE" ] && [ -f "$KEY_FILE" ]; then


### PR DESCRIPTION
Two small startup-diagnosability fixes to the gean client wrapper.

### 1. Require `HIVE_LEAN_DEVNET_LABEL`, verify the selected binary

The wrapper defaulted an unset `HIVE_LEAN_DEVNET_LABEL` to `devnet4`, which would silently run the devnet4 binary against a devnet5 network — the node starts, peers, and only diverges at consensus, slow to trace back to a wrapper default. Now the label is required (the lean simulator always sets it), and a missing/incorrect resolved binary fails at startup with a clear message instead of at `exec` with an opaque one.

### 2. Echo the checkpoint-sync url at startup

A node expected to checkpoint-sync that silently starts from genesis looks identical to a normal genesis start in the logs. Echoing whether the harness delivered `HIVE_CHECKPOINT_SYNC_URL` makes a missing url visible in one line, alongside the client's own startup log. (Paired with a matching client-side log so it's clear whether the url reached the wrapper vs the binary.)

Both only surface configuration; no behavior change for correctly-configured runs. `bash -n` clean.