### PR TITLE
fix(sim/lean): install libcurl/libevent/libyaml in lantern devnet5 runtime

### DIFF
--- a/clients/lantern/Dockerfile
+++ b/clients/lantern/Dockerfile
@@ -5,6 +5,13 @@ ARG devnet5_tag=devnet-5
 FROM ${baseimage}:${devnet5_tag} AS devnet5
 FROM ${baseimage}:${devnet4_tag}
 
+# The devnet5 binary copied in below is dynamically linked against libcurl,
+# libevent and libyaml (lantern's HTTP/storage/YAML refactor, d3751267), but
+# this v0.0.4 devnet4 base image predates that refactor and doesn't ship
+# them, so the binary aborts at startup with "libcurl.so.4: cannot open
+# shared object file". Install the missing runtime libs here.
+RUN apt-get update && apt-get install -y --no-install-recommends libcurl4 libevent-2.1-7 libevent-extra-2.1-7 libevent-pthreads-2.1-7 libyaml-0-2 && rm -rf /var/lib/apt/lists/*
+
 COPY --from=devnet5 /opt/lantern/bin/lantern /usr/local/bin/lantern-devnet5
 ADD lantern.sh /lantern.sh
 


### PR DESCRIPTION
## Symptom

Every `client-interop` test involving **lantern** on the devnet5 profile fails at startup, and lantern regressed from 26 passing tests to 0. The container aborts immediately with:

```
/usr/local/bin/lantern-devnet5: error while loading shared libraries: libcurl.so.4: cannot open shared object file: No such file or directory
```

## Root cause

`clients/lantern/Dockerfile` builds a dual-binary image: the final image is `FROM ${baseimage}:${devnet4_tag}` (`bitminemavan/lantern:v0.0.4`, the **devnet4** base), and the devnet5 binary is copied into it from a separate build stage as `/usr/local/bin/lantern-devnet5`, which `lantern.sh` execs for the devnet5 nametag.

lantern's 2026-07-17 commit `d3751267` ("Refactor HTTP, storage, and YAML subsystems with libevent") switched the devnet5 binary to dynamically link against **libcurl, libevent and libyaml**. The `v0.0.4` devnet4 base image predates that refactor and doesn't ship those shared libraries, so `lantern-devnet5` can't load `libcurl.so.4` and aborts before any consensus code runs.

## Fix

Install the devnet5 binary's runtime shared libraries (`libcurl4`, `libevent-2.1-7`, `libevent-extra-2.1-7`, `libevent-pthreads-2.1-7`, `libyaml-0-2` — matching lantern's own `devnet-5` branch Dockerfile runtime dep list) in the final image stage, before the devnet5 binary is copied in.

Runtime-only change: the dual-binary build pattern is untouched; the diff is a single `RUN apt-get install` line plus an explanatory comment.
