### PR TITLE
Balance Cancun blob-packing fixtures

### DIFF
--- a/simulators/ethereum/engine/suites/cancun/steps.go
+++ b/simulators/ethereum/engine/suites/cancun/steps.go
@@ -642,6 +642,8 @@ type SendBlobTransactions struct {
 	ReplaceTransactions bool
 	// Skip verification of retrieving the tx from node
 	SkipVerificationFromNode bool
+	// Recipient of the blob transactions
+	Recipient *common.Address
 	// Account index to send the blob transactions from
 	AccountIndex uint64
 	// Client index to send the blob transactions to
@@ -658,7 +660,10 @@ func (step SendBlobTransactions) GetBlobsPerTransaction() uint64 {
 
 func (step SendBlobTransactions) Execute(t *TestContext) error {
 	// Send a blob transaction
-	addr := common.BigToAddress(cancun.DATAHASH_START_ADDRESS)
+	recipient := common.BigToAddress(cancun.DATAHASH_START_ADDRESS)
+	if step.Recipient != nil {
+		recipient = *step.Recipient
+	}
 	blobCountPerTx := step.GetBlobsPerTransaction()
 	var engine client.EngineClient
 	if step.ClientIndex >= uint64(len(t.Engines)) {
@@ -668,7 +673,7 @@ func (step SendBlobTransactions) Execute(t *TestContext) error {
 	//  Send the blob transactions
 	for bTx := uint64(0); bTx < step.TransactionCount; bTx++ {
 		blobTxCreator := &helper.BlobTransactionCreator{
-			To:         &addr,
+			To:         &recipient,
 			GasLimit:   100000,
 			GasTip:     step.BlobTransactionGasTipCap,
 			GasFee:     step.BlobTransactionGasFeeCap,

--- a/simulators/ethereum/engine/suites/cancun/tests.go
+++ b/simulators/ethereum/engine/suites/cancun/tests.go
@@ -18,6 +18,7 @@ import (
 // Precalculate the first data gas cost increase
 var (
 	DATA_GAS_COST_INCREMENT_EXCEED_BLOBS = GetMinExcessBlobsForBlobGasPrice(2)
+	blobPackingRecipient                 = common.Address{}
 )
 
 func pUint64(v uint64) *uint64 {
@@ -258,13 +259,17 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "Blob Transaction Ordering, Multiple Accounts",
+			Name: "Blob Transaction Packing, Multiple Accounts",
 			About: `
-			Send N blob transactions with cancun.MAX_BLOBS_PER_BLOCK-1 blobs each,
-			using account A.
-			Send N blob transactions with 1 blob each from account B.
-			Verify that the payloads are created with the correct ordering:
-			 - All payloads must have full blobs.
+			Send cancun.MAX_BLOBS_PER_BLOCK-1 blob transactions with
+			cancun.MAX_BLOBS_PER_BLOCK-1 blobs each, using account A, to an EOA.
+			Each has cancun.MAX_BLOBS_PER_BLOCK-1 times the execution tip of a
+			single-blob transaction.
+			Send twice as many single-blob transactions from account B.
+			The multi-blob transaction plus a single-blob transaction have the same
+			execution cost and priority-fee revenue as
+			cancun.MAX_BLOBS_PER_BLOCK single-blob transactions, so every payload
+			must fill the blob capacity.
 			All transactions have sufficient data gas price to be included any
 			of the payloads.
 			`,
@@ -272,23 +277,30 @@ var Tests = []test.Spec{
 		},
 
 		TestSequence: TestSequence{
-			// First send the cancun.MAX_BLOBS_PER_BLOCK-1 blob transactions from
-			// account A.
+			// Send the multi-blob transactions from account A.
 			SendBlobTransactions{
-				TransactionCount:              5,
+				TransactionCount:              cancun.MAX_BLOBS_PER_BLOCK - 1,
 				BlobsPerTransaction:           cancun.MAX_BLOBS_PER_BLOCK - 1,
 				BlobTransactionMaxBlobGasCost: big.NewInt(120),
-				AccountIndex:                  0,
+				BlobTransactionGasFeeCap:      globals.GasPrice,
+				BlobTransactionGasTipCap: new(big.Int).Mul(
+					globals.GasTipPrice,
+					big.NewInt(int64(cancun.MAX_BLOBS_PER_BLOCK-1)),
+				),
+				Recipient:    &blobPackingRecipient,
+				AccountIndex: 0,
 			},
-			// Then send the single-blob transactions from account B
+			// Send enough single-blob transactions to fill every payload via either packing.
 			SendBlobTransactions{
-				TransactionCount:              5,
+				TransactionCount:              2 * (cancun.MAX_BLOBS_PER_BLOCK - 1),
 				BlobsPerTransaction:           1,
 				BlobTransactionMaxBlobGasCost: big.NewInt(100),
+				BlobTransactionGasFeeCap:      globals.GasPrice,
+				BlobTransactionGasTipCap:      globals.GasTipPrice,
+				Recipient:                     &blobPackingRecipient,
 				AccountIndex:                  1,
 			},
 
-			// All payloads have full blobs
 			NewPayloads{
 				PayloadCount:              5,
 				ExpectedIncludedBlobCount: cancun.MAX_BLOBS_PER_BLOCK,
@@ -299,14 +311,17 @@ var Tests = []test.Spec{
 	&CancunBaseSpec{
 
 		BaseSpec: test.BaseSpec{
-			Name: "Blob Transaction Ordering, Multiple Clients",
+			Name: "Blob Transaction Packing, Multiple Clients",
 			About: `
-			Send N blob transactions with cancun.MAX_BLOBS_PER_BLOCK-1 blobs each,
-			using account A, to client A.
-			Send N blob transactions with 1 blob each from account B, to client
-			B.
-			Verify that the payloads are created with the correct ordering:
-			 - All payloads must have full blobs.
+			Send cancun.MAX_BLOBS_PER_BLOCK-1 blob transactions with
+			cancun.MAX_BLOBS_PER_BLOCK-1 blobs each from account A to an EOA via
+			client A. Each has cancun.MAX_BLOBS_PER_BLOCK-1 times the execution tip
+			of a single-blob transaction.
+			Send twice as many single-blob transactions from account B to client B.
+			The multi-blob transaction plus a single-blob transaction have the same
+			execution cost and priority-fee revenue as
+			cancun.MAX_BLOBS_PER_BLOCK single-blob transactions, so every payload
+			must fill the blob capacity.
 			All transactions have sufficient data gas price to be included any
 			of the payloads.
 			`,
@@ -330,26 +345,33 @@ var Tests = []test.Spec{
 				ExpectedIncludedBlobCount: 0,
 			},
 
-			// First send the cancun.MAX_BLOBS_PER_BLOCK-1 blob transactions from
-			// account A, to client A.
+			// Send the multi-blob transactions from account A to client A.
 			SendBlobTransactions{
-				TransactionCount:              5,
+				TransactionCount:              cancun.MAX_BLOBS_PER_BLOCK - 1,
 				BlobsPerTransaction:           cancun.MAX_BLOBS_PER_BLOCK - 1,
 				BlobTransactionMaxBlobGasCost: big.NewInt(120),
-				AccountIndex:                  0,
-				ClientIndex:                   0,
+				BlobTransactionGasFeeCap:      globals.GasPrice,
+				BlobTransactionGasTipCap: new(big.Int).Mul(
+					globals.GasTipPrice,
+					big.NewInt(int64(cancun.MAX_BLOBS_PER_BLOCK-1)),
+				),
+				Recipient:    &blobPackingRecipient,
+				AccountIndex: 0,
+				ClientIndex:  0,
 			},
-			// Then send the single-blob transactions from account B, to client
-			// B.
+			// Send enough single-blob transactions from account B to client B to
+			// fill every payload via either packing.
 			SendBlobTransactions{
-				TransactionCount:              5,
+				TransactionCount:              2 * (cancun.MAX_BLOBS_PER_BLOCK - 1),
 				BlobsPerTransaction:           1,
 				BlobTransactionMaxBlobGasCost: big.NewInt(100),
+				BlobTransactionGasFeeCap:      globals.GasPrice,
+				BlobTransactionGasTipCap:      globals.GasTipPrice,
+				Recipient:                     &blobPackingRecipient,
 				AccountIndex:                  1,
 				ClientIndex:                   1,
 			},
 
-			// All payloads have full blobs
 			NewPayloads{
 				PayloadCount:              5,
 				ExpectedIncludedBlobCount: cancun.MAX_BLOBS_PER_BLOCK,


### PR DESCRIPTION
Nethermind does not pass a full blobs block test due to correct but untypical behavior, the pr is an attempt to make full blobs block optimally profitable

## Summary
- Balance the priority-fee economics in the two Cancun blob-packing fixtures.
- Send their transactions to a code-free EOA while preserving the default DATAHASH recipient for every other case.
- Retain strict full-blob-capacity assertions.

## Rationale
EIP-4844 caps blob gas but does not require a block to fill capacity. The earlier fixture could make a five-blob payload more profitable. The revised fixture gives a capacity-filling A+B package the same priority-fee revenue as six B transactions, so strict six-blob assertions test packing behavior without preferring a valid selection policy.

## Testing
- Focused packing cases: 3/3 passed.
- Complete `ethereum/engine` simulation against Nethermind master: 403/403 passed.