### PR TITLE
.circleci: enforce gofmt and align Go version with go.mod

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -18,6 +18,15 @@ jobs:
     steps:
       # Build it.
       - checkout
+      - run:
+          name: "Check gofmt"
+          command: |
+            unformatted=$(gofmt -l .)
+            if [ -n "$unformatted" ]; then
+              echo "These files are not gofmt-formatted; run 'gofmt -w .':"
+              echo "$unformatted"
+              exit 1
+            fi
       - go/load-cache
       - go/mod-download
       - go/save-cache

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -14,7 +14,7 @@ jobs:
   # This job builds the hive executable and stores it in the workspace.
   build:
     docker:
-      - image: cimg/go:1.21
+      - image: cimg/go:1.24
     steps:
       # Build it.
       - checkout
@@ -66,7 +66,7 @@ jobs:
   # This job runs the go unit tests.
   go-test:
     docker:
-      - image: cimg/go:1.21
+      - image: cimg/go:1.24
     steps:
       # Get the source.
       - checkout

--- a/hive.go
+++ b/hive.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/ethereum/hive/internal/libdocker"
 	"github.com/ethereum/hive/internal/libhive"
-	"github.com/lmittmann/tint"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/lmittmann/tint"
 )
 
 type buildArgs map[string]string


### PR DESCRIPTION
Two small CI hygiene changes.

### Enforce gofmt

The Go CI jobs (`build`, `go-test`) run `go build` and `go test` but never check formatting, so non-gofmt'd code can land silently. Adds a `gofmt -l .` check to the `build` job that fails with the offending file list if anything isn't formatted.

Only one existing file was not gofmt-clean (`hive.go`, an import-ordering nit); it's reformatted here so the check passes on master.

### Align Go image with go.mod

The `build` and `go-test` jobs used `cimg/go:1.21` while `go.mod` declares `go 1.24.0`. Bumped both to `cimg/go:1.24` so CI matches the module's toolchain.

### Validation

Reproduced the `build`/`go-test` jobs locally on a Go ≥1.24 toolchain: `go build`, `go test ./...` (hive + hiveproxy modules), and `compile-simulators.sh` (all 14 Go simulators) pass; `gofmt -l .` is clean.
