### PR TITLE
fix(rpc-compat): support large fixture messages

### DIFF
--- a/simulators/ethereum/rpc-compat/testload.go
+++ b/simulators/ethereum/rpc-compat/testload.go
@@ -13,6 +13,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const maxTestLineSize = 32 * 1024 * 1024 // Large-receipt fixtures can contain JSON lines larger than 20 MiB.
+
 type rpcTest struct {
 	name     string
 	comment  string
@@ -34,7 +36,7 @@ func loadTestFile(name string, r io.Reader) (rpcTest, error) {
 		inHeader = true
 		test     = rpcTest{name: name}
 	)
-	scan.Buffer(buf, 1024*1024)
+	scan.Buffer(buf, maxTestLineSize)
 	for scan.Scan() {
 		line := strings.TrimSpace(scan.Text())
 		switch {

--- a/simulators/ethereum/rpc-compat/testload_test.go
+++ b/simulators/ethereum/rpc-compat/testload_test.go
@@ -6,6 +6,22 @@ import (
 	"testing"
 )
 
+func TestLoadLargeMessage(t *testing.T) {
+	const messageSize = 24 * 1024 * 1024
+	data := ">> {\"payload\":\"" + strings.Repeat("a", messageSize) + "\"}\n"
+
+	result, err := loadTestFile("large-message", strings.NewReader(data))
+	if err != nil {
+		t.Fatal("error:", err)
+	}
+	if len(result.messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(result.messages))
+	}
+	if !result.messages[0].send {
+		t.Fatal("large message was not parsed as a request")
+	}
+}
+
 func TestLoad(t *testing.T) {
 	data := `// this is a test comment
 // this is the second line


### PR DESCRIPTION
In #1567 it was noted that `rpc-compact` only supports 1MB line size and that means large receipt tests fail. This increases the line limit. I think we would ideally want to keep the large receipt tests for the official test suite. 

Is there reason to not do this? @MysticRyuujin wdyt?