### PR TITLE
all: stabilize execution sync interoperability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.jq text eol=lf

--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -126,7 +126,8 @@ FLAGS="$FLAGS --min-gas-price=1 --tx-pool-price-bump=0 --rpc-gas-cap=50000000"
 
 # Configure peer-to-peer networking.
 if [ "$HIVE_BOOTNODE" != "" ]; then
-    FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
+    printf '["%s"]\n' "$HIVE_BOOTNODE" > /static-nodes.json
+    FLAGS="$FLAGS --discovery-enabled=false --static-nodes-file=/static-nodes.json"
 fi
 if [ "$HIVE_NETWORK_ID" != "" ]; then
     FLAGS="$FLAGS --network-id=$HIVE_NETWORK_ID"
@@ -134,7 +135,7 @@ else
     FLAGS="$FLAGS --network-id=1337"
 fi
 
-# Configure sync mode
+# Configure sync mode for Hive's single-peer topology.
 case "$HIVE_NODETYPE" in
     "" | "full" | "archive")
         syncmode=FULL ;;
@@ -145,6 +146,9 @@ case "$HIVE_NODETYPE" in
         exit 1 ;;
 esac
 FLAGS="$FLAGS --sync-mode=$syncmode"
+if [ "$syncmode" = "SNAP" ]; then
+    FLAGS="$FLAGS --sync-min-peers=1"
+fi
 
 # Enable Snap Server.
 FLAGS="$FLAGS --snapsync-server-enabled"

--- a/clients/nimbus-el/nimbus.sh
+++ b/clients/nimbus-el/nimbus.sh
@@ -60,9 +60,9 @@ case "$HIVE_LOGLEVEL" in
 esac
 FLAGS="$FLAGS --log-level:$loglevel"
 
-# It doesn't make sense to dial out, use only a pre-set bootnode.
+# Hive provides a directly reachable peer, not a discovery network.
 if [ "$HIVE_BOOTNODE" != "" ]; then
-  FLAGS="$FLAGS --bootstrap-node:$HIVE_BOOTNODE"
+  FLAGS="$FLAGS --static-peers:$HIVE_BOOTNODE"
 fi
 
 if [ "$HIVE_NETWORK_ID" != "" ]; then

--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -54,13 +54,6 @@ DATADIR="/reth-hive-datadir"
 mkdir $DATADIR
 FLAGS="$FLAGS --datadir $DATADIR"
 
-# TODO If a specific network ID is requested, use that
-#if [ "$HIVE_NETWORK_ID" != "" ]; then
-#    FLAGS="$FLAGS --networkid $HIVE_NETWORK_ID"
-#else
-#    FLAGS="$FLAGS --networkid 1337"
-#fi
-
 # Configure the chain.
 mv /genesis.json /genesis-input.json
 jq -f /mapper.jq /genesis-input.json > /genesis.json
@@ -116,10 +109,15 @@ else
     $reth import $FLAGS "${BLOCKS[-1]}"
 fi
 
-# Only set boot nodes in online steps
-# It doesn't make sense to dial out, use only a pre-set bootnode.
+# Hive provides a direct peer for the online sync tests.
 if [ "$HIVE_BOOTNODE" != "" ]; then
-    FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE --trusted-peers=$HIVE_BOOTNODE"
+    FLAGS="$FLAGS --trusted-peers=$HIVE_BOOTNODE --trusted-only --disable-discovery"
+fi
+
+if [ "$HIVE_NETWORK_ID" != "" ]; then
+    FLAGS="$FLAGS --network-id=$HIVE_NETWORK_ID"
+else
+    FLAGS="$FLAGS --network-id=1337"
 fi
 
 # Configure any mining operation
@@ -172,4 +170,4 @@ fi
 
 # Launch the main client.
 echo "Running reth with flags: $FLAGS"
-RUST_LOG=info $reth node $FLAGS
+$reth node $FLAGS

--- a/simulators/ethereum/sync/sync.go
+++ b/simulators/ethereum/sync/sync.go
@@ -32,6 +32,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	snapParams := params.Set("HIVE_NODETYPE", "snap")
+	fullParams := params.Set("HIVE_NODETYPE", "full")
 
 	// Run snap sync tests.
 	var snapSuite = hivesim.Suite{
@@ -46,8 +48,7 @@ Each client runs as a source for all other clients (including itself).`,
 		Parameters:  params,
 		Files:       sourceFiles,
 		Run: func(t *hivesim.T, c *hivesim.Client) {
-			params = params.Set("HIVE_NODETYPE", "snap")
-			runSourceTest(t, c, "eth1_snap", params)
+			runSourceTest(t, c, "eth1_snap", snapParams)
 		},
 	})
 	sim := hivesim.New()
@@ -66,11 +67,10 @@ Each client runs as a source for all other clients (including itself).`,
 		Role:        "eth1",
 		Name:        "CLIENT as sync server",
 		Description: "This loads the test chain into the client and verifies whether it was imported correctly.",
-		Parameters:  params,
+		Parameters:  fullParams,
 		Files:       sourceFiles,
 		Run: func(t *hivesim.T, c *hivesim.Client) {
-			params = params.Set("HIVE_NODETYPE", "full")
-			runSourceTest(t, c, "eth1", params)
+			runSourceTest(t, c, "eth1", fullParams)
 		},
 	})
 	hivesim.MustRunSuite(hivesim.New(), fullSuite)
@@ -94,7 +94,7 @@ func runSourceTest(t *hivesim.T, c *hivesim.Client, role string, params hivesim.
 	if err != nil {
 		t.Fatal("can't get node peer-to-peer endpoint:", enode)
 	}
-	sinkParams := params.Set("HIVE_BOOTNODE", enode)
+	sinkParams := params.Set("HIVE_BOOTNODE", enode).Set("HIVE_CHECK_LIVE_PORT", "8551")
 
 	// Sync all sink nodes against the source.
 	t.RunAllClients(hivesim.ClientTestSpec{

--- a/simulators/ethereum/sync/sync.go
+++ b/simulators/ethereum/sync/sync.go
@@ -45,7 +45,7 @@ Each client runs as a source for all other clients (including itself).`,
 		Role:        "eth1_snap",
 		Name:        "CLIENT as snap-sync server",
 		Description: "This loads the test chain into the client and verifies whether it was imported correctly.",
-		Parameters:  params,
+		Parameters:  snapParams,
 		Files:       sourceFiles,
 		Run: func(t *hivesim.T, c *hivesim.Client) {
 			runSourceTest(t, c, "eth1_snap", snapParams)


### PR DESCRIPTION
## Summary

- Bind SNAP and full-sync sources to their own immutable launch parameters, including the source test specification itself, and wait for the Engine endpoint before starting sink checks.
- Configure direct static/trusted peers for Besu, Nimbus EL, and Reth, including Reth's Hive network ID and discovery isolation.
- Enforce LF endings for shell and jq launch helpers used in Linux containers.

## Validation

- Corrected seven-client Ethereum sync matrix: 76/76 passed (20 SNAP + 56 full-sync).
- The run logs confirm SNAP sources launch as snap and full-sync sources launch as full.
- Shell syntax checks, the affected simulator Go build, and diff checks passed.