### PR TITLE
fix(sim/lean): scope reqresp "client launch" failure to the failing client

### DIFF
--- a/simulators/lean/src/scenarios/reqresp.rs
+++ b/simulators/lean/src/scenarios/reqresp.rs
@@ -1,5 +1,5 @@
 use crate::utils::helper::{
-    start_post_genesis_sync_context, try_start_client_under_test, HelperGossipForkDigestProfile,
+    start_client_under_test, start_post_genesis_sync_context, HelperGossipForkDigestProfile,
     PostGenesisSyncTestData, LEAN_SPEC_SOURCE_VALIDATORS_EXCLUDING_V0,
 };
 use crate::utils::libp2p_mock::{
@@ -15,7 +15,7 @@ use crate::utils::util::{
     TimedDataTestSpec,
 };
 use alloy_primitives::B256;
-use hivesim::{dyn_async, Client, Test};
+use hivesim::{dyn_async, utils::client_test_name, Client, Test};
 use ssz::Encode;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -24,6 +24,10 @@ const POST_GENESIS_TEST_TIMEOUT: Duration = Duration::from_secs(8 * 60);
 const REQRESP_SYNC_TIMEOUT_SECS: u64 = 180;
 const STATUS_EXCHANGE_TIMEOUT_SECS: u64 = 60;
 const REQRESP_LIBP2P_TIMEOUT_SECS: u64 = 30;
+// Headroom over `CLIENT_UNDER_TEST_STARTUP_ATTEMPT_TIMEOUT_SECS` (helper.rs), so
+// `run_data_test_with_timeout`'s outer timeout never races the inner per-attempt
+// timeout used by `start_client_under_test`.
+const CLIENT_LAUNCH_ATTRIBUTION_TIMEOUT: Duration = Duration::from_secs(150);
 
 /// Dial a lean client from a MockNode using its deterministic PeerId and multiaddr.
 async fn dial_client(mock: &mut MockNode, client: &Client) -> Result<(), String> {
@@ -64,28 +68,31 @@ dyn_async! {
         if clients.is_empty() {
             panic!("No lean clients were selected for this run");
         }
-        let planning = test.plan_test("reqresp: client launch", true);
-        let mut launch_failures = Vec::new();
-
         for client in &clients {
-            if !planning {
-                let environment = lean_environment();
-                match try_start_client_under_test(test, client.name.clone(), environment).await {
-                    Ok(launch_client) => {
-                        if let Err(err) = launch_client.stop().await {
-                            eprintln!(
-                                "Unable to stop reqresp launch-attribution client {}: {err}",
-                                client.name
-                            );
-                        }
-                    }
-                    Err(message) => {
-                        eprintln!("{message}");
-                        launch_failures.push(message);
-                    }
-                }
-            }
-
+            // Attribute a launch failure to exactly the client that failed to
+            // boot. Each client gets its own `run_data_test_with_timeout` call
+            // below, which registers a fresh hive test id per client; hive's
+            // clientInfo for a test comes from which container(s) were started
+            // under that test id, so a per-client id means a boot failure by
+            // one client can no longer paint every other selected client as
+            // having a "client launch" failure too. This does not gate the
+            // child req/resp tests scheduled below: they still run
+            // unconditionally regardless of this smoke test's outcome.
+            run_data_test_with_timeout(
+                test,
+                TimedDataTestSpec {
+                    name: client_test_name("reqresp: client launch".to_string(), client.name.clone()),
+                    description: "Launches the client under test as a boot smoke test, attributed only to this client.".to_string(),
+                    always_run: true,
+                    client_name: client.name.clone(),
+                    timeout_duration: CLIENT_LAUNCH_ATTRIBUTION_TIMEOUT,
+                    test_data: LaunchAttributionTestData {
+                        client_type: client.name.clone(),
+                    },
+                },
+                test_reqresp_client_launch_attribution,
+            )
+            .await;
 
             let status_happy_genesis_time = default_genesis_time();
             run_data_test_with_timeout(
@@ -722,11 +729,28 @@ dyn_async! {
 
 
         }
+    }
+}
 
-        if !launch_failures.is_empty() {
-            panic!(
-                "One or more reqresp launch-attribution clients failed; all reqresp child tests were still scheduled:\n{}",
-                launch_failures.join("\n")
+// === LAUNCH ATTRIBUTION ===
+
+/// Test data for the per-client "reqresp: client launch" boot smoke test.
+struct LaunchAttributionTestData {
+    client_type: String,
+}
+
+dyn_async! {
+    async fn test_reqresp_client_launch_attribution<'a>(test: &'a mut Test, test_data: LaunchAttributionTestData) {
+        let environment = lean_environment();
+        // `start_client_under_test` panics with a message identifying
+        // `test_data.client_type` on failure; `run_data_test_with_timeout`
+        // catches that panic and reports it as this (single-client) test's
+        // failure, so the attribution stays scoped to this client only.
+        let launch_client = start_client_under_test(test, test_data.client_type.clone(), environment).await;
+        if let Err(err) = launch_client.stop().await {
+            eprintln!(
+                "Unable to stop reqresp launch-attribution client {}: {err}",
+                test_data.client_type
             );
         }
     }


### PR DESCRIPTION
## Problem

The `reqresp` suite starts every selected client under a single shared `reqresp: client launch` test id. Because Hive attributes a test's `clientInfo` to whichever containers were started under that test id, a boot failure by one client (e.g. lantern or qlean) is attributed to **every** selected client, inflating the fail count / client score for healthy clients on the dashboard.

## Fix

Run each client's launch as its own smoke test via the existing `run_data_test_with_timeout` helper, which mints a fresh per-client Hive test id named `reqresp: client launch (<client>)`. A boot failure now scopes only to the client that actually failed.

The parent `reqresp: client launch` (registered as the suite's `PlannedTestSpec` in `main.rs`) stays as an always-passing scheduler with empty `clientInfo` — the same shape the `gossip`/`validation`/`rpc-compat` suites already produce. Child req/resp scenarios are still scheduled unconditionally.

Single file touched: `simulators/lean/src/scenarios/reqresp.rs`.

## Validation

Ran locally on macOS (`./hive --sim lean --sim.limit reqresp`):

- **ethlambda only**: 23/23 pass; the new `reqresp: client launch (ethlambda_devnet5)` row appears.
- **ethlambda + lantern**: 45 tests; lantern's single scenario failure (`blocks_by_root/max_request_limit`) is attributed to **lantern only**, ethlambda unaffected; per-client launch rows present for both clients, and the parent `reqresp: client launch` carries empty `clientInfo`.

Rendered both runs in a locally-built copy of the `lean-hiveview` frontend and headless-checked them (puppeteer + Chrome): **0 console errors, 0 uncaught page errors, 0 failed requests**; the per-client launch rows and client scoring render correctly.

## Caveat

These changes were **not** tried against the UI actually served at https://hive.leanroadmap.org/ — only against a locally-built copy of the `lean-hiveview` frontend. The live deployment may differ (commit, config, accumulated data), so the scoring/rendering there should be sanity-checked before merge.
