### PR TITLE
simulators/ethereum/rpc-compat: tracer-aware schema selection for speconly tests

### DIFF
--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -94,6 +94,7 @@ func runTest(t *hivesim.T, c *hivesim.Client, test *rpcTest) error {
 		err       error
 		respBytes []byte
 		method    string
+		request   string
 	)
 
 	for _, msg := range test.messages {
@@ -101,6 +102,7 @@ func runTest(t *hivesim.T, c *hivesim.Client, test *rpcTest) error {
 			// Send request.
 			t.Log(">> ", msg.data)
 			method = gjson.Get(msg.data, "method").String()
+			request = msg.data
 			respBytes, err = postHttp(client, url, strings.NewReader(msg.data))
 			if err != nil {
 				return err
@@ -124,7 +126,10 @@ func runTest(t *hivesim.T, c *hivesim.Client, test *rpcTest) error {
 			// the client includes.
 			hasError := gjson.Get(resp, "error").Exists()
 			if !hasError && test.speconly {
-				schema := specMethods[method]
+				schema, err := specMethods.forRequest(method, request)
+				if err != nil {
+					return err
+				}
 				if schema == nil {
 					return fmt.Errorf("no result schema for speconly method %s in spec", method)
 				}

--- a/simulators/ethereum/rpc-compat/schema.go
+++ b/simulators/ethereum/rpc-compat/schema.go
@@ -4,32 +4,76 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	openrpc "github.com/open-rpc/meta-schema"
 	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/tidwall/gjson"
 )
 
-// methodSchemas maps a JSON-RPC method name to its compiled result schema,
-// parsed from an OpenRPC document.
-type methodSchemas map[string]*jsonschema.Schema
+// tracerConfigParamIndex maps debug tracing methods to the position of their
+// TraceConfig parameter.
+var tracerConfigParamIndex = map[string]int{
+	"debug_traceTransaction":   1,
+	"debug_traceBlockByNumber": 1,
+	"debug_traceBlockByHash":   1,
+	"debug_traceCall":          2,
+}
+
+// tracerBranchTitles maps a requested tracer name to the title prefix of the
+// result-schema anyOf branch that defines its output. The empty name is the
+// opcode (struct) logger.
+var tracerBranchTitles = map[string]string{
+	"":           "Opcode tracer",
+	"callTracer": "Call tracer",
+}
+
+// methodSchemas holds the compiled result schema for each method, plus
+// tracer-narrowed variants for the debug tracing methods.
+type methodSchemas struct {
+	full   map[string]*jsonschema.Schema
+	tracer map[string]map[string]*jsonschema.Schema
+}
+
+// forRequest returns the result schema for a speconly response. For debug
+// tracing methods, the anyOf branch matching the requested tracer is
+// selected — validating against the whole anyOf is vacuous because the
+// unconstrained named-tracer branch accepts anything. A known tracer with no
+// matching branch is an error, not a fallback, so a spec title reword cannot
+// silently disable validation.
+func (s methodSchemas) forRequest(method, request string) (*jsonschema.Schema, error) {
+	if idx, ok := tracerConfigParamIndex[method]; ok {
+		tracer := gjson.Get(request, fmt.Sprintf("params.%d.tracer", idx)).String()
+		if title, known := tracerBranchTitles[tracer]; known {
+			if schema := s.tracer[method][tracer]; schema != nil {
+				return schema, nil
+			}
+			return nil, fmt.Errorf("no %q branch in %s result schema for tracer %q", title, method, tracer)
+		}
+	}
+	return s.full[method], nil
+}
 
 // parseSpec reads a (dereferenced) OpenRPC document and returns the compiled
 // result schema for each method. Each schema is compiled once here and reused
 // for every test.
 func parseSpec(filename string) (methodSchemas, error) {
+	schemas := methodSchemas{
+		full:   make(map[string]*jsonschema.Schema),
+		tracer: make(map[string]map[string]*jsonschema.Schema),
+	}
 	spec, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, err
+		return schemas, err
 	}
 	var doc openrpc.OpenrpcDocument
 	if err := json.Unmarshal(spec, &doc); err != nil {
-		return nil, fmt.Errorf("unable to parse OpenRPC document: %w", err)
+		return schemas, fmt.Errorf("unable to parse OpenRPC document: %w", err)
 	}
 	if doc.Methods == nil {
-		return nil, fmt.Errorf("OpenRPC document has no methods")
+		return schemas, fmt.Errorf("OpenRPC document has no methods")
 	}
 
-	schemas := make(methodSchemas)
 	for _, m := range *doc.Methods {
 		if m.MethodObject == nil || m.MethodObject.Name == nil {
 			continue
@@ -45,11 +89,107 @@ func parseSpec(filename string) (methodSchemas, error) {
 		name := string(*method.Name)
 		schema, err := compileSchema(method.Result.ContentDescriptorObject.Schema.JSONSchemaObject)
 		if err != nil {
-			return nil, fmt.Errorf("unable to compile result schema for %s: %w", name, err)
+			return schemas, fmt.Errorf("unable to compile result schema for %s: %w", name, err)
 		}
-		schemas[name] = schema
+		schemas.full[name] = schema
+	}
+	if err := parseTracerSchemas(spec, schemas.tracer); err != nil {
+		return schemas, err
 	}
 	return schemas, nil
+}
+
+// parseTracerSchemas extracts and compiles the tracer-specific anyOf branches
+// of the debug tracing methods' result schemas. It works on the raw document,
+// not the typed one: the generated union types do not round-trip
+// (re-marshaling a normalized "type" array double-wraps it into invalid
+// schema JSON). Absent branches are not stored; forRequest errors when a
+// test needs one.
+func parseTracerSchemas(spec []byte, out map[string]map[string]*jsonschema.Schema) error {
+	var rawDoc struct {
+		Methods []struct {
+			Name   string `json:"name"`
+			Result struct {
+				Schema map[string]interface{} `json:"schema"`
+			} `json:"result"`
+		} `json:"methods"`
+	}
+	if err := json.Unmarshal(spec, &rawDoc); err != nil {
+		return fmt.Errorf("unable to parse OpenRPC document: %w", err)
+	}
+	for _, m := range rawDoc.Methods {
+		if _, ok := tracerConfigParamIndex[m.Name]; !ok || m.Result.Schema == nil {
+			continue
+		}
+		for tracer, title := range tracerBranchTitles {
+			narrowed := narrowResultSchema(m.Result.Schema, title)
+			if narrowed == nil {
+				continue
+			}
+			schema, err := compileRawSchema(narrowed)
+			if err != nil {
+				return fmt.Errorf("unable to compile %q branch of %s result schema: %w", title, m.Name, err)
+			}
+			if out[m.Name] == nil {
+				out[m.Name] = make(map[string]*jsonschema.Schema)
+			}
+			out[m.Name][tracer] = schema
+		}
+	}
+	return nil
+}
+
+// narrowResultSchema returns the anyOf branch of a result schema whose title
+// starts with wantTitle, either at the top level or (for the block trace
+// methods) under items, re-wrapped as an array schema.
+func narrowResultSchema(schema map[string]interface{}, wantTitle string) map[string]interface{} {
+	if branch := pickBranch(schema, wantTitle); branch != nil {
+		return branch
+	}
+	if items, ok := schema["items"].(map[string]interface{}); ok {
+		if branch := pickBranch(items, wantTitle); branch != nil {
+			narrowed := map[string]interface{}{"type": "array", "items": branch}
+			if title, ok := schema["title"]; ok {
+				narrowed["title"] = title
+			}
+			return narrowed
+		}
+	}
+	return nil
+}
+
+// pickBranch returns the anyOf branch of node whose title starts with wantTitle.
+func pickBranch(node map[string]interface{}, wantTitle string) map[string]interface{} {
+	branches, ok := node["anyOf"].([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, b := range branches {
+		branch, ok := b.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		title, _ := branch["title"].(string)
+		if strings.HasPrefix(title, wantTitle) {
+			return branch
+		}
+	}
+	return nil
+}
+
+// compileRawSchema compiles a schema given as a raw map, forcing draft
+// 2019-09 like compileSchema.
+func compileRawSchema(schema map[string]interface{}) (*jsonschema.Schema, error) {
+	withDraft := make(map[string]interface{}, len(schema)+1)
+	for k, v := range schema {
+		withDraft[k] = v
+	}
+	withDraft["$schema"] = "https://json-schema.org/draft/2019-09/schema"
+	b, err := json.Marshal(withDraft)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal schema to json: %w", err)
+	}
+	return jsonschema.CompileString("result", string(b))
 }
 
 // compileSchema compiles an OpenRPC result schema into a reusable validator.

--- a/simulators/ethereum/rpc-compat/schema_capabilities_test.go
+++ b/simulators/ethereum/rpc-compat/schema_capabilities_test.go
@@ -14,7 +14,7 @@ func TestCapabilitiesSchemaValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseSpec: %v", err)
 	}
-	schema := schemas["eth_capabilities"]
+	schema := schemas.full["eth_capabilities"]
 	if schema == nil {
 		t.Fatal("no schema for eth_capabilities")
 	}

--- a/simulators/ethereum/rpc-compat/schema_tracer_test.go
+++ b/simulators/ethereum/rpc-compat/schema_tracer_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTracerSchemaSelection verifies that speconly validation of debug_trace*
+// responses uses the anyOf branch matching the tracer requested by the test,
+// instead of the whole result schema, whose unconstrained named-tracer branch
+// accepts any value.
+func TestTracerSchemaSelection(t *testing.T) {
+	schemas, err := parseSpec("testdata/openrpc-tracer.json")
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+
+	txCallTracer := `{"method":"debug_traceTransaction","params":["0xabc",{"tracer":"callTracer"}]}`
+	txOpcode := `{"method":"debug_traceTransaction","params":["0xabc"]}`
+	txPrestate := `{"method":"debug_traceTransaction","params":["0xabc",{"tracer":"prestateTracer"}]}`
+	blockCallTracer := `{"method":"debug_traceBlockByNumber","params":["0x1",{"tracer":"callTracer"}]}`
+	callTracerCall := `{"method":"debug_traceCall","params":[{},"latest",{"tracer":"callTracer"}]}`
+
+	// A frame missing required fields must fail the callTracer branch, at the
+	// top level and nested.
+	schema, err := schemas.forRequest("debug_traceTransaction", txCallTracer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateResult(schema, []byte(`{"type":"CALL","from":"0xaa"}`)); err != nil {
+		t.Errorf("valid frame rejected: %v", err)
+	}
+	if err := validateResult(schema, []byte(`{"structLogs":[]}`)); err == nil {
+		t.Error("opcode-shaped response passed the callTracer branch")
+	}
+	if err := validateResult(schema, []byte(`{"type":"CALL","from":"0xaa","calls":[{"from":"0xbb"}]}`)); err == nil {
+		t.Error("nested frame missing required 'type' was accepted")
+	}
+
+	// No tracer selects the opcode branch.
+	schema, err = schemas.forRequest("debug_traceTransaction", txOpcode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateResult(schema, []byte(`{"type":"CALL","from":"0xaa"}`)); err == nil {
+		t.Error("callTracer-shaped response passed the opcode branch")
+	}
+
+	// Unknown tracers keep the whole-schema escape hatch.
+	schema, err = schemas.forRequest("debug_traceTransaction", txPrestate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateResult(schema, []byte(`{"anything":true}`)); err != nil {
+		t.Errorf("named-tracer escape hatch rejected a response: %v", err)
+	}
+
+	// Block methods narrow under items and enforce the entry shape.
+	schema, err = schemas.forRequest("debug_traceBlockByNumber", blockCallTracer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateResult(schema, []byte(`[{"txHash":"0xaa","result":{}}]`)); err != nil {
+		t.Errorf("valid block entry rejected: %v", err)
+	}
+	if err := validateResult(schema, []byte(`[{"txHash":"0xaa"}]`)); err == nil {
+		t.Error("entry with neither result nor error was accepted")
+	}
+
+	// debug_traceCall reads the tracer from its third parameter; the fixture
+	// spec has no such method, which must be an error, not a silent fallback.
+	if _, err := schemas.forRequest("debug_traceCall", callTracerCall); err == nil {
+		t.Error("expected error for a known tracer with no branch in the spec")
+	} else if !strings.Contains(err.Error(), "Call tracer") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Non-trace methods use the full schema.
+	schema, err = schemas.forRequest("eth_call", `{"method":"eth_call","params":[{},"latest"]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if schema == nil {
+		t.Error("expected the full schema for a non-trace method")
+	}
+}

--- a/simulators/ethereum/rpc-compat/testdata/openrpc-tracer.json
+++ b/simulators/ethereum/rpc-compat/testdata/openrpc-tracer.json
@@ -1,0 +1,77 @@
+{
+  "openrpc": "1.2.4",
+  "info": {"title": "tracer schema test fixture", "version": "1.0.0"},
+  "methods": [
+    {
+      "name": "debug_traceTransaction",
+      "params": [],
+      "result": {
+        "name": "Transaction trace",
+        "schema": {
+          "anyOf": [
+            {
+              "title": "Opcode tracer result",
+              "type": "object",
+              "required": ["structLogs"],
+              "properties": {"structLogs": {"type": "array"}}
+            },
+            {
+              "title": "Call tracer result",
+              "$id": "https://example.org/callframe",
+              "type": "object",
+              "required": ["type", "from"],
+              "properties": {
+                "type": {"type": "string"},
+                "from": {"type": "string"},
+                "calls": {"type": "array", "items": {"$ref": "https://example.org/callframe"}}
+              }
+            },
+            {
+              "title": "Named tracer result",
+              "description": "any JSON value"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "debug_traceBlockByNumber",
+      "params": [],
+      "result": {
+        "name": "Block trace",
+        "schema": {
+          "title": "Array of per-transaction traces",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "Opcode tracer entry",
+                "type": "object",
+                "required": ["txHash", "result"]
+              },
+              {
+                "title": "Call tracer entry",
+                "type": "object",
+                "required": ["txHash"],
+                "anyOf": [{"required": ["result"]}, {"required": ["error"]}]
+              },
+              {
+                "title": "Named tracer entry",
+                "type": "object",
+                "required": ["txHash"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "eth_call",
+      "params": [],
+      "result": {
+        "name": "Return data",
+        "schema": {"type": "string"}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
speconly tests validate the client's response against the method's OpenRPC result schema. For the `debug_trace*` methods that schema is an `anyOf` whose named-tracer escape-hatch branch is deliberately unconstrained — so whole-schema validation accepts any value and speconly enforcement is vacuous for tracing methods.

This selects the `anyOf` branch matching the tracer the test requested (mirroring execution-apis' speccheck): no tracer → the opcode branch, `callTracer` → the Call tracer branch, anything else → the whole schema as before. A known tracer with no matching branch is an error rather than a fallback, so a spec title reword cannot silently disable validation. Branches are extracted from the raw document because the generated OpenRPC union types do not survive a second marshal round-trip.

Backward-compatible: against a spec without callTracer branches, opcode speconly fixtures still validate (the "Opcode tracer" branches have existed since the opcode-tracer standardization), and no fixture in that era requests callTracer. Pairs with the callTracer spec PR (execution-apis, to follow).
