### PR TITLE
hiveproxy: use GOPROXY "|" separator to fall back to direct on any proxy error

### DIFF
--- a/hiveproxy/Dockerfile
+++ b/hiveproxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1-alpine as builder
-ARG GOPROXY
+ARG GOPROXY="https://proxy.golang.org|direct"
 ENV GOPROXY=${GOPROXY}
-RUN apk add --update gcc musl-dev linux-headers
+RUN apk add --update gcc git musl-dev linux-headers
 
 # Get dependencies first. This improves caching behavior since they only need
 # to be re-downloaded when go.mod changes.


### PR DESCRIPTION
### Description

The hiveproxy image build runs `go mod download` with Go's default `GOPROXY=https://proxy.golang.org,direct`.

The comma form only falls back to `direct` on 404/410, so any other proxy error kills the build and hive dies at startup. We hit this in `execution-specs` CI when proxy.golang.org returned 403 (rate-limited egress IP) for `go-ethereum@v1.14.5`: https://github.com/ethereum/execution-specs/actions/runs/31053968803/job/92467344596
