### PR TITLE
Preserve Nethermind genesis slot number

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -262,6 +262,7 @@ def clique_engine:
     "blobGasUsed": .blobGasUsed,
     "excessBlobGas": .excessBlobGas,
     "parentBeaconBlockRoot": .parentBeaconBlockRoot,
+    "slotNumber": .slotNumber,
   },
   "accounts": ((.alloc|with_entries(.key|="0x"+.)) * {
     "0x0000000000000000000000000000000000000001": {


### PR DESCRIPTION
## What

Pass the `slotNumber` genesis field through Hive's Nethermind mapper.

## Why

The mapper converted Hive's Geth-style genesis into a Nethermind chain spec but dropped `slotNumber`. EIP-7843 fixtures therefore produced a different genesis block hash in Nethermind, and the first forkchoice update remained syncing.

## Impact

Nethermind now receives the fixture's configured genesis slot number. Existing genesis files without this field retain the current behavior because the mapped value is null and Nethermind treats it as unset.

## Checks

- The previously failing EIP-7843 SLOTNUM consume-engine case passes.
- Hive Go packages pass, apart from the existing `cmd/hiveview` test whose `/` path assumption is incompatible with Windows.

Or we can just https://github.com/ethereum/hive/pull/1593
