### PR TITLE
Use Geth-style genesis for Nethermind

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -16,313 +16,108 @@ def remove_empty:
   )
 ;
 
-# Converts number to hex, from https://rosettacode.org/wiki/Non-decimal_radices/Convert#jq
-def int_to_hex:
-  def stream:
-    recurse(if . > 0 then ./16|floor else empty end) | . % 16 ;
-  if . == 0 then "0x0"
-  else "0x" + ([stream] | reverse | .[1:] | map(if .<10 then 48+. else 87+. end) | implode)
+# Converts decimal string to number.
+def to_int:
+  if . == null then . else .|tonumber end
+;
+
+# Converts "1" / "0" to boolean.
+def to_bool:
+  if . == null then . else
+    if . == "1" then true else false end
   end
 ;
 
-# Converts decimal number in string to hex.
-def to_hex:
-  if . != null and startswith("0x") then . else
-    if (. != null and . != "") then .|tonumber|int_to_hex else . end
-  end
-;
-
-# Zero-pads hex string.
-def infix_zeros_to_length(s;l):
-  if . != null then
-    (.[0:s])+("0"*(l-(.|length)))+(.[s:l])
-  else .
-  end
-;
-
-# This gives the consensus engine definition for the ethash engine.
-def ethash_engine:
-  {
-    "Ethash": {
-      "params": {
-        "minimumDifficulty": "0x20000",
-        "difficultyBoundDivisor": "0x800",
-        "durationLimit": "0x0d",
-        "homesteadTransition": env.HIVE_FORK_HOMESTEAD|to_hex,
-        "eip100bTransition": env.HIVE_FORK_BYZANTIUM|to_hex,
-        "daoHardforkTransition": env.HIVE_FORK_DAO_BLOCK|to_hex,
-        "daoHardforkBeneficiary": "0xbf4ed7b27f1d666546e30d74d50d173d20bca754",
-        "blockReward": {
-          "0x0": "0x4563918244F40000",
-          (env.HIVE_FORK_BYZANTIUM|to_hex//""): "0x29A2241AF62C0000",
-          (env.HIVE_FORK_CONSTANTINOPLE|to_hex//""): "0x1BC16D674EC80000",
-        },
-        "difficultyBombDelays": {
-          (env.HIVE_FORK_BYZANTIUM|to_hex//""): 3000000,
-          (env.HIVE_FORK_CONSTANTINOPLE|to_hex//""): 2000000,
-          (env.HIVE_FORK_MUIR_GLACIER|to_hex//""): 4000000,
-          (env.HIVE_FORK_LONDON|to_hex//""): 700000,
-          (env.HIVE_FORK_ARROW_GLACIER|to_hex//""): 1000000,
-          (env.HIVE_FORK_GRAY_GLACIER|to_hex//""): 700000,
-        }
-      }
-    }
-  }
-;
-
-# This gives the consensus engine definition for the clique PoA engine.
-def clique_engine:
-  {
-    "clique": {
-       "params": {
-         "period": env.HIVE_CLIQUE_PERIOD|tonumber,
-         "epoch": 30000,
-         "blockReward": "0x0"
-       }
-    }
-  }
-;
-
+# Replace config in input and keep it first for Nethermind's format detection.
+# Nethermind also requires alloc address keys to carry a 0x prefix.
 {
-  "version": "1",
-  "engine": (if env.HIVE_CLIQUE_PERIOD then clique_engine else ethash_engine end),
-  "params": {
-    # Tangerine Whistle
-    "eip150Transition": env.HIVE_FORK_TANGERINE|to_hex,
-
-    # Spurious Dragon
-    "eip160Transition": env.HIVE_FORK_SPURIOUS|to_hex,
-    "eip161abcTransition": env.HIVE_FORK_SPURIOUS|to_hex,
-    "eip161dTransition": env.HIVE_FORK_SPURIOUS|to_hex,
-    "eip155Transition": env.HIVE_FORK_SPURIOUS|to_hex,
-    "maxCodeSizeTransition": env.HIVE_FORK_SPURIOUS|to_hex,
-    "maxCodeSize": 24576,
-    "maximumExtraDataSize": "0x400",
-
-    # Byzantium
-    "eip140Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
-    "eip211Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
-    "eip214Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
-    "eip658Transition": env.HIVE_FORK_BYZANTIUM|to_hex,
-
-    # Constantinople
-    "eip145Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
-    "eip1014Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
-    "eip1052Transition": env.HIVE_FORK_CONSTANTINOPLE|to_hex,
-
-    # Petersburg
-    "eip1283Transition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_CONSTANTINOPLE|to_hex end),
-    "eip1283DisableTransition": (if env.HIVE_FORK_ISTANBUL|to_hex == "0x0" then "0x0" else env.HIVE_FORK_PETERSBURG|to_hex end),
-
-    # Istanbul
-    "eip152Transition": env.HIVE_FORK_ISTANBUL|to_hex,
-    "eip1108Transition": env.HIVE_FORK_ISTANBUL|to_hex,
-    "eip1344Transition": env.HIVE_FORK_ISTANBUL|to_hex,
-    "eip1884Transition": env.HIVE_FORK_ISTANBUL|to_hex,
-    "eip2028Transition": env.HIVE_FORK_ISTANBUL|to_hex,
-    "eip2200Transition": env.HIVE_FORK_ISTANBUL|to_hex,
-
-    # Berlin
-    "eip2565Transition": env.HIVE_FORK_BERLIN|to_hex,
-    "eip2718Transition": env.HIVE_FORK_BERLIN|to_hex,
-    "eip2929Transition": env.HIVE_FORK_BERLIN|to_hex,
-    "eip2930Transition": env.HIVE_FORK_BERLIN|to_hex,
-
-    # London
-    "eip1559Transition": env.HIVE_FORK_LONDON|to_hex,
-    "eip3238Transition": env.HIVE_FORK_LONDON|to_hex,
-    "eip3529Transition": env.HIVE_FORK_LONDON|to_hex,
-    "eip3541Transition": env.HIVE_FORK_LONDON|to_hex,
-    "eip3198Transition": env.HIVE_FORK_LONDON|to_hex,
-
-    # Merge
-    "MergeForkIdTransition": env.HIVE_MERGE_BLOCK_ID|to_hex,
-
-    # Shanghai
-    "eip3651TransitionTimestamp": env.HIVE_SHANGHAI_TIMESTAMP|to_hex,
-    "eip3855TransitionTimestamp": env.HIVE_SHANGHAI_TIMESTAMP|to_hex,
-    "eip3860TransitionTimestamp": env.HIVE_SHANGHAI_TIMESTAMP|to_hex,
-    "eip4895TransitionTimestamp": env.HIVE_SHANGHAI_TIMESTAMP|to_hex,
-
-    # Cancun
-    "eip4844TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
-    "eip4788TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
-    "eip1153TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
-    "eip5656TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
-    "eip6780TransitionTimestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
-
-    # Prague
-    "eip2537TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-    "eip2935TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-    "eip6110TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-    "eip7002TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-    "eip7251TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-    "eip7685TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-    "eip7702TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-    "eip7623TransitionTimestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-
-    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x00000000219ab540356cBB839Cbe05303d7705Fa"),
-
-    # Osaka
-    "eip7594TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7823TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7825TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7883TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7918TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7951TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7939TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7934TransitionTimestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-    "eip7934MaxRlpBlockSize": "0x800000",
-
-    # Amsterdam
-    "eip2780TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7708TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7778TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7843TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7928TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7954TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7976TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7981TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip7997TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip8024TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip8037TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip8038TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip8246TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-    "eip8282TransitionTimestamp": env.HIVE_AMSTERDAM_TIMESTAMP|to_hex,
-
-    # Other chain parameters
-    "networkID": env.HIVE_NETWORK_ID|to_hex,
-    "chainID": env.HIVE_CHAIN_ID|to_hex,
-
-    "blobSchedule": [
-      if env.HIVE_CANCUN_TIMESTAMP then {
-          "timestamp": env.HIVE_CANCUN_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_CANCUN_BLOB_TARGET then env.HIVE_CANCUN_BLOB_TARGET|to_hex else "0x3" end),
-          "max": (if env.HIVE_CANCUN_BLOB_MAX then env.HIVE_CANCUN_BLOB_MAX|to_hex else "0x6" end),
-          "baseFeeUpdateFraction": (if env.HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x32f0ed" end)
-      } else null end,
-      if env.HIVE_PRAGUE_TIMESTAMP then {
-          "timestamp": env.HIVE_PRAGUE_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_PRAGUE_BLOB_TARGET then env.HIVE_PRAGUE_BLOB_TARGET|to_hex else "0x6" end),
-          "max": (if env.HIVE_PRAGUE_BLOB_MAX then env.HIVE_PRAGUE_BLOB_MAX|to_hex else "0x9" end),
-          "baseFeeUpdateFraction": (if env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x4c6964" end)
-      } else null end,
-      if env.HIVE_OSAKA_TIMESTAMP then {
-          "timestamp": env.HIVE_OSAKA_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_OSAKA_BLOB_TARGET then env.HIVE_OSAKA_BLOB_TARGET|to_hex else "0x6" end),
-          "max": (if env.HIVE_OSAKA_BLOB_MAX then env.HIVE_OSAKA_BLOB_MAX|to_hex else "0x9" end),
-          "baseFeeUpdateFraction": (if env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x4c6964" end)
-      } else null end,
-      if env.HIVE_BPO1_TIMESTAMP then {
-          "timestamp": env.HIVE_BPO1_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_BPO1_BLOB_TARGET then env.HIVE_BPO1_BLOB_TARGET|to_hex else "0xa" end),
-          "max": (if env.HIVE_BPO1_BLOB_MAX then env.HIVE_BPO1_BLOB_MAX|to_hex else "0xf" end),
-          "baseFeeUpdateFraction": (if env.HIVE_BPO1_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO1_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x7f5a51" end)
-      } else null end,
-      if env.HIVE_BPO2_TIMESTAMP then {
-          "timestamp": env.HIVE_BPO2_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_BPO2_BLOB_TARGET then env.HIVE_BPO2_BLOB_TARGET|to_hex else "0xe" end),
-          "max": (if env.HIVE_BPO2_BLOB_MAX then env.HIVE_BPO2_BLOB_MAX|to_hex else "0x15" end),
-          "baseFeeUpdateFraction": (if env.HIVE_BPO2_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO2_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0xb24b3f" end)
-      } else null end,
-      if env.HIVE_BPO3_TIMESTAMP then {
-          "timestamp": env.HIVE_BPO3_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_BPO3_BLOB_TARGET then env.HIVE_BPO3_BLOB_TARGET|to_hex else "0x9" end),
-          "max": (if env.HIVE_BPO3_BLOB_MAX then env.HIVE_BPO3_BLOB_MAX|to_hex else "0xe" end),
-          "baseFeeUpdateFraction": (if env.HIVE_BPO3_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO3_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x86c73b" end)
-      } else null end,
-      if env.HIVE_BPO4_TIMESTAMP then {
-          "timestamp": env.HIVE_BPO4_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_BPO4_BLOB_TARGET then env.HIVE_BPO4_BLOB_TARGET|to_hex else "0x9" end),
-          "max": (if env.HIVE_BPO4_BLOB_MAX then env.HIVE_BPO4_BLOB_MAX|to_hex else "0xe" end),
-          "baseFeeUpdateFraction": (if env.HIVE_BPO4_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO4_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x86c73b" end)
-      } else null end,
-      if env.HIVE_BPO5_TIMESTAMP then {
-          "timestamp": env.HIVE_BPO5_TIMESTAMP|to_hex,
-          "target": (if env.HIVE_BPO5_BLOB_TARGET then env.HIVE_BPO5_BLOB_TARGET|to_hex else "0x9" end),
-          "max": (if env.HIVE_BPO5_BLOB_MAX then env.HIVE_BPO5_BLOB_MAX|to_hex else "0xe" end),
-          "baseFeeUpdateFraction": (if env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION|to_hex else "0x86c73b" end)
-      } else null end
-    ] | map(select(. != null)) | reverse | unique_by(.timestamp),
-  },
-  "genesis": {
-    "seal": {
-      "ethereum":{
-         "nonce": .nonce|infix_zeros_to_length(2;18),
-         "mixHash": .mixHash,
+  "config": {
+    "ethash": (if env.HIVE_CLIQUE_PERIOD then null else {} end),
+    "clique": (if env.HIVE_CLIQUE_PERIOD == null then null else {
+      "period": env.HIVE_CLIQUE_PERIOD|to_int,
+    } end),
+    "chainId": env.HIVE_CHAIN_ID|to_int,
+    "homesteadBlock": env.HIVE_FORK_HOMESTEAD|to_int,
+    "daoForkBlock": env.HIVE_FORK_DAO_BLOCK|to_int,
+    "daoForkSupport": env.HIVE_FORK_DAO_VOTE|to_bool,
+    "eip150Block": env.HIVE_FORK_TANGERINE|to_int,
+    "eip150Hash": env.HIVE_FORK_TANGERINE_HASH,
+    "eip155Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "eip158Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "byzantiumBlock": env.HIVE_FORK_BYZANTIUM|to_int,
+    "constantinopleBlock": env.HIVE_FORK_CONSTANTINOPLE|to_int,
+    "petersburgBlock": env.HIVE_FORK_PETERSBURG|to_int,
+    "istanbulBlock": env.HIVE_FORK_ISTANBUL|to_int,
+    "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
+    "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
+    "londonBlock": env.HIVE_FORK_LONDON|to_int,
+    "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
+    "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "terminalTotalDifficulty": (env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int // 9223372036854775807),
+    "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
+    "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
+    "osakaTime": env.HIVE_OSAKA_TIMESTAMP|to_int,
+    "amsterdamTime": env.HIVE_AMSTERDAM_TIMESTAMP|to_int,
+    "terminalTotalDifficultyPassed": true,
+    "blobSchedule": {
+      "cancun": {
+        "target": (if env.HIVE_CANCUN_BLOB_TARGET then env.HIVE_CANCUN_BLOB_TARGET|to_int else 3 end),
+        "max": (if env.HIVE_CANCUN_BLOB_MAX then env.HIVE_CANCUN_BLOB_MAX|to_int else 6 end),
+        "baseFeeUpdateFraction": (if env.HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 3338477 end)
       },
-    },
-    "difficulty": .difficulty,
-    "author": .coinbase,
-    "timestamp": .timestamp,
-    "parentHash": .parentHash,
-    "extraData": .extraData,
-    "gasLimit": .gasLimit,
-    "baseFeePerGas": .baseFeePerGas,
-    "blobGasUsed": .blobGasUsed,
-    "excessBlobGas": .excessBlobGas,
-    "parentBeaconBlockRoot": .parentBeaconBlockRoot,
-  },
-  "accounts": ((.alloc|with_entries(.key|="0x"+.)) * {
-    "0x0000000000000000000000000000000000000001": {
-      "builtin": {
-        "name": "ecrecover",
-        "pricing": {"linear": {"base": 3000, "word": 0}},
+      "prague": {
+        "target": (if env.HIVE_PRAGUE_BLOB_TARGET then env.HIVE_PRAGUE_BLOB_TARGET|to_int else 6 end),
+        "max": (if env.HIVE_PRAGUE_BLOB_MAX then env.HIVE_PRAGUE_BLOB_MAX|to_int else 9 end),
+        "baseFeeUpdateFraction": (if env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 5007716 end)
+      },
+      "osaka": {
+        "target": (if env.HIVE_OSAKA_BLOB_TARGET then env.HIVE_OSAKA_BLOB_TARGET|to_int else 6 end),
+        "max": (if env.HIVE_OSAKA_BLOB_MAX then env.HIVE_OSAKA_BLOB_MAX|to_int else 9 end),
+        "baseFeeUpdateFraction": (if env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 5007716 end)
+      },
+      "amsterdam": {
+        "target": (if env.HIVE_AMSTERDAM_BLOB_TARGET then env.HIVE_AMSTERDAM_BLOB_TARGET|to_int else 14 end),
+        "max": (if env.HIVE_AMSTERDAM_BLOB_MAX then env.HIVE_AMSTERDAM_BLOB_MAX|to_int else 21 end),
+        "baseFeeUpdateFraction": (if env.HIVE_AMSTERDAM_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_AMSTERDAM_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 11684671 end)
+      },
+      "bpo1": {
+        "target": (if env.HIVE_BPO1_BLOB_TARGET then env.HIVE_BPO1_BLOB_TARGET|to_int else 10 end),
+        "max": (if env.HIVE_BPO1_BLOB_MAX then env.HIVE_BPO1_BLOB_MAX|to_int else 15 end),
+        "baseFeeUpdateFraction": (if env.HIVE_BPO1_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO1_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 8346193 end)
+      },
+      "bpo2": {
+        "target": (if env.HIVE_BPO2_BLOB_TARGET then env.HIVE_BPO2_BLOB_TARGET|to_int else 14 end),
+        "max": (if env.HIVE_BPO2_BLOB_MAX then env.HIVE_BPO2_BLOB_MAX|to_int else 21 end),
+        "baseFeeUpdateFraction": (if env.HIVE_BPO2_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO2_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 11684671 end)
+      },
+      "bpo3": {
+        "target": (if env.HIVE_BPO3_BLOB_TARGET then env.HIVE_BPO3_BLOB_TARGET|to_int else 9 end),
+        "max": (if env.HIVE_BPO3_BLOB_MAX then env.HIVE_BPO3_BLOB_MAX|to_int else 14 end),
+        "baseFeeUpdateFraction": (if env.HIVE_BPO3_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO3_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 8832827 end)
+      },
+      "bpo4": {
+        "target": (if env.HIVE_BPO4_BLOB_TARGET then env.HIVE_BPO4_BLOB_TARGET|to_int else 9 end),
+        "max": (if env.HIVE_BPO4_BLOB_MAX then env.HIVE_BPO4_BLOB_MAX|to_int else 14 end),
+        "baseFeeUpdateFraction": (if env.HIVE_BPO4_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO4_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 8832827 end)
+      },
+      "bpo5": {
+        "target": (if env.HIVE_BPO5_BLOB_TARGET then env.HIVE_BPO5_BLOB_TARGET|to_int else 9 end),
+        "max": (if env.HIVE_BPO5_BLOB_MAX then env.HIVE_BPO5_BLOB_MAX|to_int else 14 end),
+        "baseFeeUpdateFraction": (if env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_BPO5_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 8832827 end)
       }
     },
-    "0x0000000000000000000000000000000000000002": {
-      "builtin": {
-        "name": "sha256",
-        "pricing": {"linear": {"base": 60, "word": 12}}
-      }
-    },
-    "0x0000000000000000000000000000000000000003": {
-      "builtin": {
-        "name": "ripemd160",
-        "pricing": {"linear": {"base": 600, "word": 120}}
-      }
-    },
-    "0x0000000000000000000000000000000000000004": {
-      "builtin": {
-        "name": "identity",
-        "pricing": {"linear": {"base": 15, "word": 3}}
-      }
-    },
-    "0x0000000000000000000000000000000000000005": {
-      "builtin": {
-        "name": "modexp",
-        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
-        "pricing": {"modexp": {"divisor": 20}}
-      }
-    },
-    "0x0000000000000000000000000000000000000006": {
-      "builtin": {
-        "name": "alt_bn128_add",
-        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
-        "pricing": {"linear": {"base": 500, "word": 0}
-        }
-      }
-    },
-    "0x0000000000000000000000000000000000000007": {
-      "builtin": {
-        "name": "alt_bn128_mul",
-        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
-        "pricing": {"linear": {"base": 40000, "word": 0}}
-      }
-    },
-    "0x0000000000000000000000000000000000000008": {
-      "builtin": {
-        "name": "alt_bn128_pairing",
-        "activate_at": env.HIVE_FORK_BYZANTIUM|to_hex,
-        "pricing": {"alt_bn128_pairing": {"base": 100000, "pair": 80000}}
-      }
-    },
-    "0x0000000000000000000000000000000000000009": {
-      "builtin": {
-        "name": "blake2_f",
-        "activate_at": env.HIVE_FORK_ISTANBUL|to_hex,
-        "pricing": {"blake2_f": {"gas_per_round": 1}}
-      }
-    },
-  }),
-}|remove_empty
+    "bpo1Time": env.HIVE_BPO1_TIMESTAMP|to_int,
+    "bpo2Time": env.HIVE_BPO2_TIMESTAMP|to_int,
+    "bpo3Time": env.HIVE_BPO3_TIMESTAMP|to_int,
+    "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
+    "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
+    "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x00000000219ab540356cBB839Cbe05303d7705Fa")
+  }|remove_empty
+} + (
+  del(.config) |
+  if .alloc then
+    .alloc |= with_entries(.key |= if startswith("0x") then . else "0x" + . end)
+  else . end
+)

--- a/clients/nethermind/mkconfig.jq
+++ b/clients/nethermind/mkconfig.jq
@@ -96,7 +96,7 @@ def base_config:
     "Init": {
       "WebSocketsEnabled": true,
       "UseMemDb": true,
-      "ChainSpecPath": "/chainspec/test.json",
+      "ChainSpecPath": "/genesis.json",
       "BaseDbPath": "nethermind_db/hive",
       "LogFileName": "/hive.logs.txt"
     },

--- a/clients/nethermind/nethermind.sh
+++ b/clients/nethermind/nethermind.sh
@@ -53,17 +53,17 @@ if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     echo -n $JWT_SECRET > /jwt.secret
 fi
 
-# Generate the genesis and chainspec file.
-mkdir -p /chainspec
-jq -f /mapper.jq /genesis.json > /chainspec/test.json
+# Generate a Geth-style genesis file.
+mv /genesis.json /genesis-input.json
+jq -f /mapper.jq /genesis-input.json > /genesis.json
 
 # Dump genesis. 
 if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
     echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
-    jq 'del(.accounts[] | select(.balance == "0x123450000000000000000" or has("builtin")))' /chainspec/test.json
+    jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
 else
     echo "Supplied genesis state:"
-    cat /chainspec/test.json
+    cat /genesis.json
 fi
 
 # Check sync mode.


### PR DESCRIPTION
## What

Replace Hive's Nethermind-specific Parity chain-spec conversion with the Geth-style genesis mapper already used by the Geth client, then point Nethermind at the mapped `/genesis.json`.

The mapper keeps `config` first for Nethermind's format detection and adds `0x` prefixes to allocation keys for Nethermind's strict address parser.

## Why

Maintaining a separate Parity-style conversion duplicates the fork schedule and must explicitly copy every genesis header field. It dropped the EIP-7843 `slotNumber` field, causing Nethermind to derive the wrong genesis hash. Nethermind can now load Geth-style genesis files directly, so retaining the input schema avoids this class of field-loss bug.

## Impact

Nethermind receives the same environment-derived fork configuration as Geth while preserving fixture-level genesis fields. The old generated `/chainspec/test.json` is no longer used.

This is an independent broader alternative to the one-field mapper fix in #1592.

## Checks

- The previously failing EIP-7843 SLOTNUM consume-engine case passes.
- The Glamsterdam filtered sweep reached 2,313 passed cases with zero failures or errors before it was intentionally stopped.
- Hive's core Go packages pass; the full suite still has the existing `cmd/hiveview` test whose `/` path assumption is incompatible with Windows.
