### PR TITLE
simulators/lean: fix gossip mock duplicate-publish and gossip snappy framing

### DIFF
--- a/simulators/lean/src/scenarios/gossip.rs
+++ b/simulators/lean/src/scenarios/gossip.rs
@@ -328,7 +328,9 @@ dyn_async! {
         mock.publish(block_topic.clone(), block_bytes.clone())
             .expect("should publish first copy of invalid block");
         sleep(Duration::from_secs(1)).await;
-        mock.publish(block_topic, block_bytes)
+        // Re-send the exact same bytes, so the client sees a real duplicate.
+        // The mock has to bypass its own publisher-side duplicate cache to do it.
+        mock.publish_duplicate(block_topic, block_bytes)
             .expect("should publish second copy of invalid block");
 
         mock.process_events_for(Duration::from_secs(5)).await;

--- a/simulators/lean/src/utils/libp2p_mock.rs
+++ b/simulators/lean/src/utils/libp2p_mock.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Cursor, Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::B256;
@@ -9,7 +11,8 @@ use futures::prelude::*;
 use libp2p::{
     gossipsub::{
         Behaviour as GossipsubBehaviour, ConfigBuilder as GossipsubConfigBuilder,
-        Event as GossipsubEvent, IdentTopic, MessageAuthenticity, TopicHash, ValidationMode,
+        Event as GossipsubEvent, IdentTopic, Message as GossipsubMessage, MessageAuthenticity,
+        MessageId, TopicHash, ValidationMode,
     },
     request_response::{
         self, Behaviour as RequestResponseBehaviour, Codec, Event as ReqRespEvent,
@@ -42,6 +45,44 @@ pub const LEAN_BLOCKS_BY_RANGE_PROTOCOL: &str = "/leanconsensus/req/blocks_by_ra
 // Keep the mock's gossipsub limit above that client-side limit so a valid
 // client-produced signed block reaches the validation test.
 const LEAN_GOSSIP_MAX_TRANSMIT_SIZE: usize = 16 * 1024 * 1024;
+
+/// Domain prefix used when the gossip payload failed snappy decompression.
+const MESSAGE_DOMAIN_INVALID_SNAPPY: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
+/// Domain prefix used when the gossip payload decompressed successfully.
+const MESSAGE_DOMAIN_VALID_SNAPPY: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
+/// Lean gossip message ids are the first 20 bytes of the SHA256 digest.
+const MESSAGE_ID_LENGTH: usize = 20;
+
+/// Compute a gossip message id the way lean clients do.
+///
+/// libp2p's default id function is `source || sequence_number`, which is a
+/// constant under [`MessageAuthenticity::Anonymous`]: an anonymous message
+/// carries neither field, so every message the mock publishes hashes to the
+/// same id and gossipsub rejects the second one with `PublishError::Duplicate`.
+/// Deriving the id from the payload instead keeps distinct messages distinct,
+/// and matches the lean networking spec so the mock agrees with the client on
+/// what counts as a duplicate.
+///
+/// `salt` is mock-local and never travels on the wire. [`MockNode::publish_duplicate`]
+/// bumps it so a test can re-send byte-identical data that the client under
+/// test still sees as a genuine duplicate.
+fn lean_gossip_message_id(message: &GossipsubMessage, salt: u64) -> MessageId {
+    // Gossip payloads use raw snappy; framing is only used by req/resp.
+    let decompressed = snap::raw::Decoder::new().decompress_vec(&message.data).ok();
+    let (domain, data) = match decompressed.as_deref() {
+        Some(data) => (MESSAGE_DOMAIN_VALID_SNAPPY, data),
+        None => (MESSAGE_DOMAIN_INVALID_SNAPPY, message.data.as_slice()),
+    };
+
+    let topic = message.topic.as_str().as_bytes();
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update((topic.len() as u64).to_le_bytes());
+    hasher.update(topic);
+    hasher.update(data);
+    hasher.update(salt.to_le_bytes());
+    MessageId::from(hasher.finalize()[..MESSAGE_ID_LENGTH].to_vec())
+}
 
 // Gossip topic helpers
 pub fn lean_block_topic(fork_digest: &str) -> IdentTopic {
@@ -619,6 +660,9 @@ pub struct MockNode {
     /// subscription check this set first so they don't miss events that
     /// arrived before the test loop started.
     pub seen_subscriptions: HashMap<TopicHash, HashSet<PeerId>>,
+    /// Mock-local salt mixed into [`lean_gossip_message_id`], bumped by
+    /// [`MockNode::publish_duplicate`] to re-send byte-identical payloads.
+    publish_salt: Arc<AtomicU64>,
 }
 
 impl MockNode {
@@ -633,6 +677,9 @@ impl MockNode {
         let secp_keypair = libp2p_identity::secp256k1::Keypair::from(secret_key);
         let keypair = libp2p_identity::Keypair::from(secp_keypair);
 
+        let publish_salt = Arc::new(AtomicU64::new(0));
+        let message_id_salt = publish_salt.clone();
+
         let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair.clone())
             .with_tokio()
             .with_quic()
@@ -641,6 +688,14 @@ impl MockNode {
                 let gossipsub_config = GossipsubConfigBuilder::default()
                     .validation_mode(ValidationMode::Anonymous)
                     .max_transmit_size(LEAN_GOSSIP_MAX_TRANSMIT_SIZE)
+                    // Required by the anonymous config above: an anonymous
+                    // message carries no source and no sequence number, which
+                    // is all libp2p's default id function hashes, so every
+                    // message would get the same id and the second publish
+                    // would be rejected as a duplicate.
+                    .message_id_fn(move |message| {
+                        lean_gossip_message_id(message, message_id_salt.load(Ordering::Relaxed))
+                    })
                     .build()
                     .expect("Failed to create anonymous gossipsub config");
                 // Lean clients use anonymous gossipsub validation. Publishing signed
@@ -678,6 +733,7 @@ impl MockNode {
             gossip_messages: Vec::new(),
             secret_key_bytes: Some(secret_key_bytes),
             seen_subscriptions: HashMap::new(),
+            publish_salt,
         })
     }
 
@@ -883,6 +939,19 @@ impl MockNode {
             .publish(topic, data)
             .map_err(|e| format!("Failed to publish message: {e:?}"))
             .map(|_| ())
+    }
+
+    /// Re-publish a payload this mock has already sent on the same topic.
+    ///
+    /// gossipsub refuses to publish a message whose id is already in its
+    /// publisher-side duplicate cache, so a plain [`MockNode::publish`] of
+    /// identical bytes fails with `PublishError::Duplicate` before anything
+    /// reaches the wire. Bumping the mock-local id salt sidesteps that cache
+    /// without touching the bytes sent, so the client under test receives a
+    /// genuine duplicate and exercises its own deduplication.
+    pub fn publish_duplicate(&mut self, topic: IdentTopic, data: Vec<u8>) -> Result<(), String> {
+        self.publish_salt.fetch_add(1, Ordering::Relaxed);
+        self.publish(topic, data)
     }
 
     /// Drain gossip messages observed since the previous call.

--- a/simulators/lean/src/utils/libp2p_mock.rs
+++ b/simulators/lean/src/utils/libp2p_mock.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::io::{self, Cursor, Read, Write};
+use std::io::{self, Cursor, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -335,46 +335,44 @@ impl LeanBlock {
 }
 
 /// Encode a block as an unsigned gossip block message using the selected
-/// devnet's wire shape: snappy-compressed SSZ bytes (no varint prefix).
+/// devnet's wire shape: raw-snappy-compressed SSZ bytes (no varint prefix).
+///
+/// Gossip payloads carry raw snappy. Snappy *framing* belongs to req/resp, and
+/// a framed payload published on a gossip topic is undecodable to a conformant
+/// client, which silently reduces every gossip test that publishes a block to
+/// asserting that the client discarded garbage.
 pub fn encode_gossip_block(block: &LeanBlock) -> Vec<u8> {
     let ssz_bytes = block.to_signed_wire_ssz_bytes();
-    let mut encoder = FrameEncoder::new(Vec::new());
-    encoder
-        .write_all(&ssz_bytes)
-        .expect("failed to snappy-compress gossip bytes");
-    encoder
-        .flush()
-        .expect("failed to flush gossip snappy encoder");
-    encoder
-        .into_inner()
-        .expect("failed to finish gossip snappy encoder")
+    snap::raw::Encoder::new()
+        .compress_vec(&ssz_bytes)
+        .expect("failed to snappy-compress gossip bytes")
 }
 
-/// Decode a framed-snappy, raw-snappy, or raw-SSZ signed-block payload and retain its block.
+/// Decode a signed-block payload captured from the block gossip topic.
 ///
-/// This accepts the exact bytes carried on the gossipsub topic. It is useful
-/// for tests that capture a client-produced, cryptographically valid envelope
-/// and need to identify the corresponding block in the client's fork-choice
-/// store without synthesizing a proof in Hive.
+/// This takes the exact bytes carried on the gossipsub topic. It is useful for
+/// tests that capture a client-produced, cryptographically valid envelope and
+/// need to identify the corresponding block in the client's fork-choice store
+/// without synthesizing a proof in Hive.
+///
+/// Gossip payloads are raw snappy, so that is the only encoding accepted here.
+/// A client that publishes snappy framing or bare SSZ on a gossip topic is not
+/// conformant, and absorbing that would hide the defect and let the client pass
+/// the tests built on top of this.
 pub fn decode_gossip_block(data: &[u8]) -> io::Result<LeanBlock> {
-    let mut decoder = FrameDecoder::new(Cursor::new(data));
-    let mut decompressed = Vec::new();
-    if decoder.read_to_end(&mut decompressed).is_ok() {
-        if let Ok(block) = LeanBlock::from_signed_wire_ssz_bytes(&decompressed) {
-            return Ok(block);
-        }
-    }
+    let decompressed = snap::raw::Decoder::new()
+        .decompress_vec(data)
+        .map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("gossip payload is not raw snappy: {err}"),
+            )
+        })?;
 
-    if let Ok(decompressed) = snap::raw::Decoder::new().decompress_vec(data) {
-        if let Ok(block) = LeanBlock::from_signed_wire_ssz_bytes(&decompressed) {
-            return Ok(block);
-        }
-    }
-
-    LeanBlock::from_signed_wire_ssz_bytes(data).map_err(|err| {
+    LeanBlock::from_signed_wire_ssz_bytes(&decompressed).map_err(|err| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("neither framed-snappy, raw-snappy, nor raw signed-block SSZ: {err:?}"),
+            format!("gossip payload is not a signed block: {err:?}"),
         )
     })
 }


### PR DESCRIPTION
Two gossip tests currently fail on **every** lean client on [hive.leanroadmap.org](https://hive.leanroadmap.org/):

```
gossip: caches orphan block              0/6
gossip: deduplicates duplicate messages  0/6
(the other three gossip tests)           6/6
```

Both fail on the same line, before anything reaches the client under test:

```
should publish parent block: "Failed to publish message: Duplicate"
should publish second copy of invalid block: "Failed to publish message: Duplicate"
```

This is a mock bug, not a client bug. The regression starts at d764a937 (#1590), which is also where the run went from 5 failures to 12.

## 1. Message ids collide for anonymous publishers

#1590 switched the mock to `MessageAuthenticity::Anonymous`. That part is right: lean clients use anonymous gossipsub validation, so a signed envelope gets rejected before block validation. But the default `message_id_fn` was left in place, and it is:

```rust
// libp2p-gossipsub 0.49.4, src/config.rs:518
let mut source_string = if let Some(peer_id) = message.source.as_ref() {
    peer_id.to_base58()
} else {
    PeerId::from_bytes(&[0, 1, 0]).expect("Valid peer id").to_base58()
};
source_string.push_str(&message.sequence_number.unwrap_or_default().to_string());
```

An anonymous message carries neither a source nor a sequence number, so **every message the mock publishes hashes to the same id**. `Behaviour::publish` checks `duplicate_cache.contains(&msg_id)` and returns `PublishError::Duplicate` for the second publish regardless of payload. The three tests that publish once are unaffected; the two that publish twice cannot pass.

`duplicate_cache_time` is not a workaround here: `DuplicateCache::contains` does not sweep expired entries (only `insert` does, via `TimeCache::entry`), and the sweep happens after the check.

The same collision has a quieter effect on the receive path — `handle_received_message` drops everything after the first message for the same reason, which silently caps `take_gossip_messages()` that #1590's own new validation tests rely on.

**Fix:** derive the id from the payload using the lean networking spec's scheme (`sha256(domain ‖ topic_len ‖ topic ‖ data)[..20]`), so the mock agrees with clients on what counts as a duplicate.

Re-sending byte-identical bytes still has to get past the publisher-side cache, so `MockNode::publish_duplicate` bumps a mock-local salt mixed into the id. The salt never travels on the wire, so the client still receives a genuine duplicate and its own deduplication is what the test exercises.

## 2. Gossip blocks were framed snappy

While verifying the above: `encode_gossip_block` compressed with `FrameEncoder`, but gossip payloads carry **raw** snappy — leanSpec decompresses gossip with the raw decoder only (`node/networking/gossipsub/behavior.py`), and framing belongs to req/resp.

Nothing failed as a result, which is the problem. Both of these tests only assert that the client did not import the block and stayed responsive, and both hold trivially when the client cannot decompress the payload. A local run against ethlambda logged, for every block the mock published:

```
ERROR Failed to decompress gossipped block err=snappy: corrupt input
```

So fixing only the first issue would turn the tests green without them testing anything.

`decode_gossip_block` had the mirror image of this: it took whichever of raw snappy, framed snappy or bare SSZ happened to parse. Its input is bytes a client published on a gossip topic, so raw snappy is the only conformant encoding, and accepting the other two would hide a client's framing defect and let it pass the validation tests built on that decode. It is now strict, and reports which of the two steps failed.

## Verification

Local hive run against `ethlambda_devnet5`:

| suite | before | after |
|---|---|---|
| gossip | 4/6 | **6/6** |
| validation (exercises `decode_gossip_block`) | 7/7 | **7/7** |

The client logs show the gossip tests became meaningful rather than merely green. Before, every published block was a decompress error. After:

```
test 5  Received block from gossip slot=2 proposer=0 parent_root=cacacaca   <- orphan child
        Received block from gossip slot=1 proposer=0 parent_root=00000000   <- parent
test 6  Received block from gossip slot=1 proposer=9999                     <- once; client dropped the duplicate
test 4  Failed to decompress ... (invalid header)                           <- the deliberate garbage, still correct
```

Test 5 receiving two payloads where it previously received one is the direct evidence that the second publish now reaches the wire. Test 6 receiving exactly one is the direct evidence that the duplicate went out and the client deduplicated it. The validation suite staying at 7/7 shows a real client envelope decodes under the strict decoder.

Two things worth flagging for review:

- The strict decoder can newly fail a client that publishes framed snappy on a gossip topic. That is the intent, but it is a behaviour change beyond the reported failure.
- On a framing deviation, `wait_for_client_generated_valid_block` still panics with "client did not gossip and import a valid block within N seconds"; the framing error is appended as `last_decoding_error` rather than leading. That message predates this PR, so I left it alone, but it is worth sharpening.
