### PR TITLE
clients/nethermind: only mark post-merge genesis when TTD is set

### DIFF
--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -28,18 +28,6 @@ def to_bool:
   end
 ;
 
-# Only mark the chain as post-merge when Hive supplied a terminal total difficulty.
-def merge_config:
-  if env.HIVE_TERMINAL_TOTAL_DIFFICULTY == null then
-    {}
-  else
-    {
-      "terminalTotalDifficulty": (env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int),
-      "terminalTotalDifficultyPassed": true
-    }
-  end
-;
-
 # Replace config in input and keep it first for Nethermind's format detection.
 # Nethermind also requires alloc address keys to carry a 0x prefix.
 {
@@ -66,6 +54,8 @@ def merge_config:
     "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
+    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY == null then null else true end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
@@ -124,7 +114,7 @@ def merge_config:
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
     "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x00000000219ab540356cBB839Cbe05303d7705Fa")
-  } + merge_config | remove_empty
+  } | remove_empty
 } + (
   del(.config) |
   if .alloc then

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -55,7 +55,6 @@ def to_bool:
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
-    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY == null then null else true end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,

--- a/clients/nethermind/mapper.jq
+++ b/clients/nethermind/mapper.jq
@@ -28,6 +28,18 @@ def to_bool:
   end
 ;
 
+# Only mark the chain as post-merge when Hive supplied a terminal total difficulty.
+def merge_config:
+  if env.HIVE_TERMINAL_TOTAL_DIFFICULTY == null then
+    {}
+  else
+    {
+      "terminalTotalDifficulty": (env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int),
+      "terminalTotalDifficultyPassed": true
+    }
+  end
+;
+
 # Replace config in input and keep it first for Nethermind's format detection.
 # Nethermind also requires alloc address keys to carry a 0x prefix.
 {
@@ -54,13 +66,11 @@ def to_bool:
     "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
     "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
-    "terminalTotalDifficulty": (env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int // 9223372036854775807),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
     "osakaTime": env.HIVE_OSAKA_TIMESTAMP|to_int,
     "amsterdamTime": env.HIVE_AMSTERDAM_TIMESTAMP|to_int,
-    "terminalTotalDifficultyPassed": true,
     "blobSchedule": {
       "cancun": {
         "target": (if env.HIVE_CANCUN_BLOB_TARGET then env.HIVE_CANCUN_BLOB_TARGET|to_int else 3 end),
@@ -114,7 +124,7 @@ def to_bool:
     "bpo4Time": env.HIVE_BPO4_TIMESTAMP|to_int,
     "bpo5Time": env.HIVE_BPO5_TIMESTAMP|to_int,
     "depositContractAddress": (env.HIVE_DEPOSIT_CONTRACT_ADDRESS // "0x00000000219ab540356cBB839Cbe05303d7705Fa")
-  }|remove_empty
+  } + merge_config | remove_empty
 } + (
   del(.config) |
   if .alloc then


### PR DESCRIPTION
## Summary

- Emit `terminalTotalDifficulty` only when `HIVE_TERMINAL_TOTAL_DIFFICULTY` is configured.
- Do not emit Geth-specific `terminalTotalDifficultyPassed` from Nethermind's mapper.
- Preserve the existing Engine API configuration for explicit-TTD runs.

## Root cause

The Geth-style Nethermind mapper defaulted TTD to the maximum value when the Hive environment did not provide a terminal difficulty. The matching RPC configuration did not expose an Engine API URL in that case. Nethermind consequently exited during merge initialization with `Engine module wasn't configured on any port`, before the devp2p discovery tests ran.

## Validation

- JQ matrix passed for unset, zero, and explicit TTD configurations before the final unused-field removal.
- Focused Hive `discv4` run passed 16/16 tests with the patched client image.
- Focused Hive Go packages passed.
- `git diff --check` passed after the final removal.
- Full `go test ./...` remains limited by the unrelated Windows `cmd/hiveview/TestBuildAllBundles` esbuild error: `The working directory "/" is not an absolute path`.