### PR TITLE
clients/nimbus-el: pass genesis slotNumber through mapper (EIP-7843)

### DIFF
--- a/clients/nimbus-el/mapper.jq
+++ b/clients/nimbus-el/mapper.jq
@@ -51,7 +51,8 @@ def to_bool:
     "alloc"        : .alloc,
     "baseFeePerGas": .baseFeePerGas,
     "excessBlobGas": .excessBlobGas,
-    "blobGasUsed"  : .blobGasUsed
+    "blobGasUsed"  : .blobGasUsed,
+    "slotNumber"   : .slotNumber
   }|remove_empty,
   "config": {
     "clique": (if env.HIVE_CLIQUE_PERIOD == null then null else {


### PR DESCRIPTION
The nimbus-el mapper rebuilds the genesis object from a key whitelist, which drops the EIP-7843 `slotNumber` field. nimbus then builds genesis with slot 0 and mismatches any fixture whose genesis carries a nonzero slot number: `tests/amsterdam/eip7843_slotnum/test_slotnum.py::test_slotnum_genesis` (fixtures `tests-glamsterdam-devnet@v8.1.0`) fails on consume-rlp with `slot_number: expected 0x03e7, got 0x00` and on consume-engine with the genesis forkchoice update stuck `SYNCING`.

Example run: https://hive.ethpandaops.io/#/test/glamsterdam-quick/1786549384-264b0fb999b2d081299a3f589120dd18

nimbus-eth1 already has the client-side plumbing on its devnet branch (`Genesis.slotNumber` in `chain_config.nim`, copied in `toGenesisHeader`), and its genesis uint64 reader accepts both JSON numbers and hex strings, so passing the field through is the only change needed.
