### PR TITLE
internal/libhive: release the test-case mutex before removing containers

### DIFF
--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -541,22 +541,29 @@ func logFileSize(path string) int64 {
 	return info.Size()
 }
 
+type clientStop struct {
+	id   string
+	wait func()
+}
+
 // EndTest finishes the test case
 func (manager *TestManager) EndTest(suiteID TestSuiteID, testID TestID, result *TestResult) error {
 	manager.testCaseMutex.Lock()
-	defer manager.testCaseMutex.Unlock()
 
 	// Check if the test case is running
 	testSuite, ok := manager.runningTestSuites[suiteID]
 	if !ok {
+		manager.testCaseMutex.Unlock()
 		return ErrNoSuchTestCase
 	}
 	testCase, ok := manager.runningTestCases[testID]
 	if !ok {
+		manager.testCaseMutex.Unlock()
 		return ErrNoSuchTestCase
 	}
 	// Make sure there is at least a result summary
 	if result == nil {
+		manager.testCaseMutex.Unlock()
 		return ErrNoSummaryResult
 	}
 
@@ -578,17 +585,26 @@ func (manager *TestManager) EndTest(suiteID TestSuiteID, testID TestID, result *
 		}
 	}
 
-	// Stop running clients.
+	// Claim still-running clients for stopping while holding the lock; the
+	// actual container removal happens after the lock is released, so
+	// concurrently running test cases are not blocked on the manager.
+	var stops []clientStop
 	for _, v := range testCase.ClientInfo {
 		if v.wait != nil {
-			manager.backend.DeleteContainer(v.ID)
-			v.wait()
+			stops = append(stops, clientStop{id: v.ID, wait: v.wait})
 			v.wait = nil
 		}
 	}
 
 	// Delete from running, if it's still there.
 	delete(manager.runningTestCases, testID)
+	manager.testCaseMutex.Unlock()
+
+	// Stop the claimed clients.
+	for _, stop := range stops {
+		manager.backend.DeleteContainer(stop.id)
+		stop.wait()
+	}
 	return nil
 }
 
@@ -636,23 +652,36 @@ func (manager *TestManager) RegisterNode(testID TestID, nodeID string, nodeInfo 
 // StopNode stops a client container.
 func (manager *TestManager) StopNode(testID TestID, nodeID string) error {
 	manager.testCaseMutex.Lock()
-	defer manager.testCaseMutex.Unlock()
-
 	testCase, ok := manager.runningTestCases[testID]
 	if !ok {
+		manager.testCaseMutex.Unlock()
 		return ErrNoSuchNode
 	}
 	nodeInfo, ok := testCase.ClientInfo[nodeID]
 	if !ok {
+		manager.testCaseMutex.Unlock()
 		return ErrNoSuchNode
 	}
+	// Claim the node for stopping while holding the lock, then release it:
+	// container removal can take a while and must not block API calls of
+	// concurrently running test cases.
+	stop := clientStop{id: nodeInfo.ID, wait: nodeInfo.wait}
+	nodeInfo.wait = nil
+	manager.testCaseMutex.Unlock()
+
 	// Stop the container.
-	if nodeInfo.wait != nil {
-		if err := manager.backend.DeleteContainer(nodeInfo.ID); err != nil {
+	if stop.wait != nil {
+		if err := manager.backend.DeleteContainer(stop.id); err != nil {
+			// Keep the node stoppable when removal fails. This also preserves
+			// EndTest's ability to clean it up on a later attempt.
+			manager.testCaseMutex.Lock()
+			if nodeInfo.wait == nil {
+				nodeInfo.wait = stop.wait
+			}
+			manager.testCaseMutex.Unlock()
 			return fmt.Errorf("unable to stop client: %v", err)
 		}
-		nodeInfo.wait()
-		nodeInfo.wait = nil
+		stop.wait()
 	}
 	return nil
 }

--- a/internal/libhive/testmanager_test.go
+++ b/internal/libhive/testmanager_test.go
@@ -3,6 +3,7 @@ package libhive_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"mime/multipart"
 	"net/http"
@@ -10,11 +11,124 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ethereum/hive/internal/fakes"
 	"github.com/ethereum/hive/internal/libhive"
 	"github.com/ethereum/hive/internal/simapi"
 )
+
+const testOperationTimeout = 5 * time.Second
+
+func TestClientTeardownDoesNotBlockOtherTests(t *testing.T) {
+	for _, method := range []string{"EndTest", "StopNode"} {
+		t.Run(method, func(t *testing.T) {
+			deleteStarted := make(chan struct{})
+			continueDelete := make(chan struct{})
+			backend := fakes.NewContainerBackend(&fakes.BackendHooks{
+				DeleteContainer: func(string) error {
+					close(deleteStarted)
+					<-continueDelete
+					return nil
+				},
+			})
+
+			clients := []*libhive.ClientDefinition{{Name: "test-client", Image: "test-client-image"}}
+			tm := libhive.NewTestManager(libhive.SimEnv{}, backend, clients, libhive.HiveInfo{})
+			srv := httptest.NewServer(tm.API())
+			defer srv.Close()
+
+			suiteID, err := tm.StartTestSuite("test-suite", "test suite description")
+			if err != nil {
+				t.Fatal("StartTestSuite:", err)
+			}
+			testID, err := tm.StartTest(suiteID, "test", "test description")
+			if err != nil {
+				t.Fatal("StartTest:", err)
+			}
+			nodeID := startClientHTTP(t, srv.URL, suiteID, testID)
+
+			teardownDone := make(chan error, 1)
+			go func() {
+				if method == "EndTest" {
+					teardownDone <- tm.EndTest(suiteID, testID, &libhive.TestResult{Pass: true})
+				} else {
+					teardownDone <- tm.StopNode(testID, nodeID)
+				}
+			}()
+
+			select {
+			case <-deleteStarted:
+			case <-time.After(testOperationTimeout):
+				t.Fatal("container deletion did not start")
+			}
+
+			startDone := make(chan error, 1)
+			go func() {
+				_, err := tm.StartTest(suiteID, "concurrent-test", "concurrent test description")
+				startDone <- err
+			}()
+
+			select {
+			case err := <-startDone:
+				if err != nil {
+					t.Fatal("concurrent StartTest:", err)
+				}
+			case <-time.After(testOperationTimeout):
+				close(continueDelete)
+				t.Fatal("StartTest blocked on an unrelated container deletion")
+			}
+
+			close(continueDelete)
+			select {
+			case err := <-teardownDone:
+				if err != nil {
+					t.Fatalf("%s: %v", method, err)
+				}
+			case <-time.After(testOperationTimeout):
+				t.Fatalf("%s did not complete", method)
+			}
+		})
+	}
+}
+
+func TestStopNodeRetriesContainerDeletion(t *testing.T) {
+	deleteCalls := 0
+	backend := fakes.NewContainerBackend(&fakes.BackendHooks{
+		DeleteContainer: func(string) error {
+			deleteCalls++
+			if deleteCalls == 1 {
+				return errors.New("test deletion failure")
+			}
+			return nil
+		},
+	})
+
+	clients := []*libhive.ClientDefinition{{Name: "test-client", Image: "test-client-image"}}
+	tm := libhive.NewTestManager(libhive.SimEnv{}, backend, clients, libhive.HiveInfo{})
+	srv := httptest.NewServer(tm.API())
+	defer srv.Close()
+
+	suiteID, err := tm.StartTestSuite("test-suite", "test suite description")
+	if err != nil {
+		t.Fatal("StartTestSuite:", err)
+	}
+	testID, err := tm.StartTest(suiteID, "test", "test description")
+	if err != nil {
+		t.Fatal("StartTest:", err)
+	}
+	nodeID := startClientHTTP(t, srv.URL, suiteID, testID)
+
+	if err := tm.StopNode(testID, nodeID); err == nil {
+		t.Fatal("first StopNode succeeded, want deletion error")
+	}
+	if err := tm.StopNode(testID, nodeID); err != nil {
+		t.Fatal("second StopNode:", err)
+	}
+	if deleteCalls != 2 {
+		t.Fatalf("DeleteContainer called %d times, want 2", deleteCalls)
+	}
+}
 
 func TestRegisterMultiTestNode(t *testing.T) {
 	// Track container deletions to verify lifecycle behavior.


### PR DESCRIPTION

## Summary

`TestManager` uses one mutex to protect its shared registry of tests and clients. Before this change, `EndTest` and `StopNode` kept that mutex locked while Docker removed a client container and Hive waited for it to exit. Removal routinely takes hundreds of milliseconds and can take seconds. During that time, unrelated tests could not start or finish, and their clients could not be registered or stopped, because all of those operations need the same
mutex.

This change keeps the mutex only long enough to update the registry and claim ownership of the client teardown. The slow `DeleteContainer` + `wait()` work then runs after the mutex is released, allowing other tests to continue.

~~~text
Before

teardown worker:  [ lock -------- DeleteContainer + wait -------- unlock ]
other workers:                 [ blocked manager API calls ]

After

teardown worker:  [ lock + claim ][ DeleteContainer + wait ]
other workers:                     [ manager API calls continue ]
~~~

## How teardown remains single-owner

The lock was serving an important purpose. [PR #439](https://github.com/ethereum/hive/pull/439) moved teardown under it in 2021 to ensure that two callers could not delete the same client container. This change preserves that single-owner rule while narrowing the locked section:

1. Under `testCaseMutex`, copy the container ID and exit callback into a local claim, then clear the stored callback. Other callers now see that teardown as already claimed.
2. Release the mutex, then remove the container and wait for its exit.
3. If `StopNode` cannot remove the container, restore the callback under the mutex so a later call can retry.

`EndTest` applies the same claim to every client still owned by the test before removing the test from the registry. The API surface, stored results, and normal sequenced lifecycle behavior are unchanged.

## Performance evidence

The direct A/B benchmark changed only this lock-boundary fix: same host, Geth image, fixtures, execution-specs revision, workload, and commands. The full benchmark comprised 144 runs over `-n 0` through `-n 16`.

For `consume engine` on a 368-test Cancun slice, median wall time was:

| workers (`-n`) | hive master | with fix | change |
|---:|---:|---:|---:|
| 1 | 328.4 s | 328.1 s | -0.1% |
| 4 | 134.4 s | 128.4 s | -4.5% |
| 8 | 143.2 s | 114.7 s | **-19.9%** |
| 16 | 174.9 s | 117.4 s | **-32.9%** |

The shape matches lock contention: no measurable effect at one worker, increasing benefit with concurrency, and removal of the regression above four workers. The practical knee moved from `-n 4` to `-n 8`; peak speedup improved from 2.44x to 2.86x.

At the deliberately high-contention `-n 16` setting, workloads with more container teardown benefited more: improvements ranged from 19.1% to 39.4%. This supports the lock-contention explanation; `-n 16` is a stress point, not the recommended worker count.

## Reliability evidence

| validation | coverage | result |
|---|---|---|
| Controlled A/B | 144 runs over `-n 0` through `-n 16` | No unexpected failures, errors, verdict changes, non-zero exits, or leaked containers |
| Full-release soak | 24 runs at `-n 1`, `4`, `8`, `16`, and `24`; 54,438 tests and 2,352-2,659 client starts per run | No stalls; every run produced the same 54,374-pass / 64-fail verdict set, with the 64 stable client-under-test failures |
| Teardown tracing | Three full-release runs at `-n 8` | Same verdict set; unrelated-worker dispatch idle was 0.3 ms median (0.1% of the inter-group gap) |

The tracing also showed a 453.9 ms median stop call for the worker doing the stop. `StopNode` therefore remains synchronous for its caller; this PR removes the wait imposed on unrelated workers.

These are bounded results: all load validation used the pytest/xdist-based EngineX simulator with Geth on one 12-core / 16-thread host. It covered full-release runs up to 24 workers, but not every client, host, multi-client workload, or simulator lifecycle model.

## Automated validation

The final reviewed worktree passes `go test ./...`, `go test -race ./internal/libhive`, `go vet ./...`, and `go build ./...`, plus 100 consecutive runs of the focused regression tests. Those tests block `DeleteContainer` and verify that an unrelated `StartTest` can continue during both `EndTest` and `StopNode`; another test verifies that a failed
`StopNode` deletion remains retryable.

## Risk and compatibility

The behavioral change is that removals from different test cases may now overlap. Their maximum concurrency is bounded by simulator parallelism, which the caller already controls. The full-release soak exercised this through `-n 24` without stalls or verdict drift.

Container ownership remains serialized under `testCaseMutex`, so the fix does not reintroduce the double-delete bug that motivated the old locking.

The trade-off is that concurrent lifecycle calls for the same test do not join each other's teardown. `EndTest` can return while an in-flight `StopNode` still owns a removal; a concurrent duplicate `StopNode` returns success immediately; and if that removal fails as `EndTest` finishes, the manager does not retry the container. These cases require a simulator to overlap lifecycle calls for the same test, such as ending a test while a stop is in flight or stopping the same client twice concurrently. The pytest-based load validation sequences those calls and therefore does not directly exercise these overlap cases. A follow-up can add teardown joining if a simulator needs that concurrency.
