### PR TITLE
clients: wire HIVE_TARGET_GAS_LIMIT for besu, erigon, reth, ethrex

### DIFF
--- a/clients/besu/besu.sh
+++ b/clients/besu/besu.sh
@@ -122,6 +122,9 @@ fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then
     FLAGS="$FLAGS --miner-extra-data=$HIVE_MINER_EXTRA"
 fi
+if [ "$HIVE_TARGET_GAS_LIMIT" != "" ]; then
+    FLAGS="$FLAGS --target-gas-limit=$HIVE_TARGET_GAS_LIMIT"
+fi
 FLAGS="$FLAGS --min-gas-price=1 --tx-pool-price-bump=0 --rpc-gas-cap=50000000"
 
 # Configure peer-to-peer networking.

--- a/clients/erigon/erigon.sh
+++ b/clients/erigon/erigon.sh
@@ -114,6 +114,9 @@ fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then
     FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"
 fi
+if [ "$HIVE_TARGET_GAS_LIMIT" != "" ]; then
+    FLAGS="$FLAGS --miner.gaslimit $HIVE_TARGET_GAS_LIMIT"
+fi
 
 # Import clique signing key.
 if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then

--- a/clients/ethrex/ethrex.sh
+++ b/clients/ethrex/ethrex.sh
@@ -95,6 +95,9 @@ if [ "$HIVE_MINER_EXTRA" != "" ]; then
     echo "Warning: miner extra data not supported."
     exit 1
 fi
+if [ "$HIVE_TARGET_GAS_LIMIT" != "" ]; then
+    FLAGS="$FLAGS --builder.gas-limit $HIVE_TARGET_GAS_LIMIT"
+fi
 
 # Import clique signing key.
 if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then

--- a/clients/nimbus-el/nimbus.sh
+++ b/clients/nimbus-el/nimbus.sh
@@ -69,6 +69,10 @@ if [ "$HIVE_NETWORK_ID" != "" ]; then
   FLAGS="$FLAGS --network:$HIVE_NETWORK_ID"
 fi
 
+if [ "$HIVE_TARGET_GAS_LIMIT" != "" ]; then
+  FLAGS="$FLAGS --gas-limit:$HIVE_TARGET_GAS_LIMIT"
+fi
+
 # Configure the chain.
 jq -f /mapper.jq /genesis.json > /genesis-start.json
 FLAGS="$FLAGS --network:/genesis-start.json"

--- a/clients/nimbus-el/nimbus.sh
+++ b/clients/nimbus-el/nimbus.sh
@@ -69,10 +69,6 @@ if [ "$HIVE_NETWORK_ID" != "" ]; then
   FLAGS="$FLAGS --network:$HIVE_NETWORK_ID"
 fi
 
-if [ "$HIVE_TARGET_GAS_LIMIT" != "" ]; then
-  FLAGS="$FLAGS --gas-limit:$HIVE_TARGET_GAS_LIMIT"
-fi
-
 # Configure the chain.
 jq -f /mapper.jq /genesis.json > /genesis-start.json
 FLAGS="$FLAGS --network:/genesis-start.json"

--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -128,6 +128,9 @@ fi
 #if [ "$HIVE_MINER_EXTRA" != "" ]; then
 #    FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"
 #fi
+if [ "$HIVE_TARGET_GAS_LIMIT" != "" ]; then
+    FLAGS="$FLAGS --builder.gaslimit $HIVE_TARGET_GAS_LIMIT"
+fi
 
 # Import clique signing key.
 # TODO


### PR DESCRIPTION
## Summary

Pass `HIVE_TARGET_GAS_LIMIT` to the client's target gas limit flag in the besu, erigon, reth, and ethrex wrappers. Only go-ethereum and nethermind consumed it before.

| client | flag |
|---|---|
| besu | `--target-gas-limit` |
| erigon | `--miner.gaslimit` |
| reth | `--builder.gaslimit` |
| ethrex | `--builder.gas-limit` |

## Why

#1585 defaults `HIVE_TARGET_GAS_LIMIT` to 60,000,000 in rpc-compat so that `testing_buildBlockV1` builds deterministic blocks across clients. A client that does not consume the variable keeps its own default and builds a different gas limit, which changes the block hash. Besu fails 2 of 4 buildBlockV1 tests on current execution-apis fixtures for this reason.

## Verification

Ran `rpc-compat/testing_buildBlockV1` with besu (main), erigon and reth (glamsterdam-devnet-8 images) before and after, on both the current fixtures and the ethereum/execution-apis#867 Amsterdam fixtures:

- besu: 2 failed → 0 failed on both fixture sets.
- erigon, reth: unchanged, no regression. Erigon's remaining Amsterdam failures are unrelated to this variable: it requires `targetGasLimit` in the payload attributes for Glamsterdam+ (ethereum/execution-apis#862), which node configuration cannot supply.
- ethrex: flag verified against the image's `--help`; not exercised at runtime because ethrex cannot import the rpc-compat chain (lambdaclass/ethrex#5504).

An alternative is to emit the value from hivechain's forkenv output. The sim-side default from #1585 already covers where the value comes from, so this PR only adds the client-side consumption.