### PR TITLE
simulators/ethereum/engine: apply withdrawals CL mock config

### DIFF
--- a/simulators/ethereum/engine/suites/withdrawals/spec_unit_test.go
+++ b/simulators/ethereum/engine/suites/withdrawals/spec_unit_test.go
@@ -1,9 +1,12 @@
 package suite_withdrawals
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/hive/simulators/ethereum/engine/clmock"
 	"github.com/ethereum/hive/simulators/ethereum/engine/globals"
+	enginetest "github.com/ethereum/hive/simulators/ethereum/engine/test"
 )
 
 type BaseSpecExpected struct {
@@ -48,6 +51,30 @@ func TestBaseSpecFunctions(t *testing.T) {
 		if spec.GetTotalPayloadCount() != tc.ExpectedTotalPayloadCount {
 			t.Fatalf("tc %d: unexpected total payload count, expected=%d, got=%d", i, tc.ExpectedTotalPayloadCount, spec.GetTotalPayloadCount())
 		}
+	}
+}
+
+func TestConfigureCLMock(t *testing.T) {
+	spec := WithdrawalsBaseSpec{
+		BaseSpec: enginetest.BaseSpec{
+			SlotsToSafe:      big.NewInt(32),
+			SlotsToFinalized: big.NewInt(64),
+		},
+		TimeIncrements: 12,
+	}
+	cl := new(clmock.CLMocker)
+
+	spec.ConfigureCLMock(cl)
+
+	if cl.SlotsToSafe == nil || cl.SlotsToSafe.Cmp(spec.SlotsToSafe) != 0 {
+		t.Fatalf("unexpected slots to safe: want %v, got %v", spec.SlotsToSafe, cl.SlotsToSafe)
+	}
+	if cl.SlotsToFinalized == nil || cl.SlotsToFinalized.Cmp(spec.SlotsToFinalized) != 0 {
+		t.Fatalf("unexpected slots to finalized: want %v, got %v", spec.SlotsToFinalized, cl.SlotsToFinalized)
+	}
+	wantTimeIncrement := big.NewInt(int64(spec.GetBlockTimeIncrements()))
+	if cl.BlockTimestampIncrement == nil || cl.BlockTimestampIncrement.Cmp(wantTimeIncrement) != 0 {
+		t.Fatalf("unexpected block timestamp increment: want %v, got %v", wantTimeIncrement, cl.BlockTimestampIncrement)
 	}
 }
 

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -1052,6 +1052,7 @@ func (ws *WithdrawalsBaseSpec) VerifyContractsStorage(t *test.Env) {
 // Changes the CL Mocker default time increments of 1 to the value specified
 // in the test spec.
 func (ws *WithdrawalsBaseSpec) ConfigureCLMock(cl *clmock.CLMocker) {
+	ws.BaseSpec.ConfigureCLMock(cl)
 	cl.BlockTimestampIncrement = big.NewInt(int64(ws.GetBlockTimeIncrements()))
 }
 


### PR DESCRIPTION
The `WithdrawalsBaseSpec` wasn't setting `SlotsToSafe` and `SlotsToFinalized` to 32 and 64 respectively as in the `BaseSpec`. This caused some tests in the `withdrawals` suite to change the `FinalisedHash` backwards or on a different fork. This should not be allowed as the `FinalisedHash` is final and is only allowed to move forward on the same chain. This issue got surfaced in Erigon while adding some new logic for support for longer reorgs during non-finality and adding validation for this as part of it. With `SlotsToFinalized` being set to 64 the tests pass because the `FinalisedHash` correctly sits further behind than the re-org point the tests are exercising.