### PR TITLE
clients/go-ethereum: update git dockerfile to golang 1.25

### DIFF
--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -1,6 +1,6 @@
 ## Pulls geth from a git repository and builds it from source.
 
-FROM golang:1.24-alpine as builder
+FROM golang:1.25-alpine as builder
 ARG github=ethereum/go-ethereum
 ARG tag=master
 ARG GOPROXY


### PR DESCRIPTION
geth master requires go >= 1.25.0 since ethereum/go-ethereum#35573, so `Dockerfile.git` builds of `ethereum/go-ethereum@master` currently fail with:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

Verified that both geth `master` and older branches still declaring `go 1.24` (e.g. `glamsterdam-devnet-8`) build with `golang:1.25-alpine`.