### PR TITLE
internal/libhive,simulators/ethereum/eels: support optional authenticated GitHub clones, redact token from recorded commands

### DIFF
--- a/internal/libhive/redact.go
+++ b/internal/libhive/redact.go
@@ -1,0 +1,54 @@
+package libhive
+
+import "strings"
+
+// redactedValue replaces the value of a sensitive build argument wherever hive
+// records or serves its own invocation: the run metadata in the results JSON
+// and the /hive endpoint of the simulation API.
+const redactedValue = "<redacted>"
+
+// isSensitiveBuildArg reports whether the value of a build argument must not be
+// recorded. The comparison is case-insensitive because client files and
+// --sim.buildarg conventionally use lowercase keys (github_token) while
+// excludedBuildArgs lists them in uppercase.
+func isSensitiveBuildArg(key string) bool {
+	return excludedBuildArgs[strings.ToUpper(key)]
+}
+
+// redactCommandArgs returns a copy of a hive command line in which the values of
+// sensitive build arguments are replaced by redactedValue. It recognises both the
+// "--flag KEY=VALUE" and the "--flag=KEY=VALUE" spelling of any flag whose name
+// ends in ".buildarg" (currently --sim.buildarg). All other arguments are copied
+// unchanged, and the input slice is not modified.
+func redactCommandArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := 0; i < len(out); i++ {
+		flag := strings.TrimLeft(out[i], "-")
+		if flag == out[i] {
+			continue // not a flag
+		}
+		name, inline, hasInline := strings.Cut(flag, "=")
+		if !strings.HasSuffix(name, ".buildarg") {
+			continue
+		}
+		if hasInline {
+			// inline is a suffix of out[i]: keep the "--name=" prefix as written.
+			out[i] = out[i][:len(out[i])-len(inline)] + redactBuildArg(inline)
+		} else if i+1 < len(out) {
+			i++
+			out[i] = redactBuildArg(out[i])
+		}
+	}
+	return out
+}
+
+// redactBuildArg redacts the value of a KEY=VALUE build argument when KEY is
+// sensitive. Anything else is returned as is.
+func redactBuildArg(kv string) string {
+	key, _, ok := strings.Cut(kv, "=")
+	if !ok || !isSensitiveBuildArg(key) {
+		return kv
+	}
+	return key + "=" + redactedValue
+}

--- a/internal/libhive/redact_test.go
+++ b/internal/libhive/redact_test.go
@@ -1,0 +1,90 @@
+package libhive
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestRedactCommandArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "separate value argument",
+			in:   []string{"hive", "--sim", "ethereum/eels/consume-engine", "--sim.buildarg", "github_token=ghs_abc123"},
+			want: []string{"hive", "--sim", "ethereum/eels/consume-engine", "--sim.buildarg", "github_token=<redacted>"},
+		},
+		{
+			name: "inline value argument",
+			in:   []string{"hive", "--sim.buildarg=github_token=ghs_abc123"},
+			want: []string{"hive", "--sim.buildarg=github_token=<redacted>"},
+		},
+		{
+			name: "single dash and uppercase key",
+			in:   []string{"hive", "-sim.buildarg", "GITHUB_TOKEN=ghs_abc123"},
+			want: []string{"hive", "-sim.buildarg", "GITHUB_TOKEN=<redacted>"},
+		},
+		{
+			name: "non-sensitive build args are kept, including values containing '='",
+			in:   []string{"hive", "--sim.buildarg", "fixtures=https://example.org/f.tar.gz?a=b", "--sim.buildarg", "branch=forks/amsterdam"},
+			want: []string{"hive", "--sim.buildarg", "fixtures=https://example.org/f.tar.gz?a=b", "--sim.buildarg", "branch=forks/amsterdam"},
+		},
+		{
+			name: "mixed sensitive and non-sensitive",
+			in:   []string{"hive", "--sim.buildarg", "branch=main", "--sim.buildarg", "github_token=x", "--client", "go-ethereum"},
+			want: []string{"hive", "--sim.buildarg", "branch=main", "--sim.buildarg", "github_token=<redacted>", "--client", "go-ethereum"},
+		},
+		{
+			name: "other flags whose values look like KEY=VALUE are untouched",
+			in:   []string{"hive", "--sim.limit", "github_token=1", "--client", "go-ethereum"},
+			want: []string{"hive", "--sim.limit", "github_token=1", "--client", "go-ethereum"},
+		},
+		{
+			name: "trailing buildarg flag without a value",
+			in:   []string{"hive", "--sim.buildarg"},
+			want: []string{"hive", "--sim.buildarg"},
+		},
+		{
+			name: "empty",
+			in:   []string{},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := slices.Clone(tt.in)
+			got := redactCommandArgs(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("redactCommandArgs(%q)\n got %q\nwant %q", tt.in, got, tt.want)
+			}
+			if !slices.Equal(tt.in, orig) {
+				t.Errorf("input slice was modified: %q", tt.in)
+			}
+		})
+	}
+}
+
+func TestFilterClientDesignatorsIsCaseInsensitive(t *testing.T) {
+	in := []ClientDesignator{{
+		Client:        "go-ethereum",
+		Nametag:       "default",
+		DockerfileExt: "git",
+		BuildArgs: map[string]string{
+			"github":       "ethereum/go-ethereum",
+			"tag":          "master",
+			"github_token": "ghs_abc123",
+			"GOPROXY":      "https://proxy.example.org",
+		},
+	}}
+	got := filterClientDesignators(in)
+	want := map[string]string{"github": "ethereum/go-ethereum", "tag": "master"}
+	if len(got) != 1 || !reflect.DeepEqual(got[0].BuildArgs, want) {
+		t.Errorf("filtered build args = %v, want %v", got[0].BuildArgs, want)
+	}
+	if in[0].BuildArgs["github_token"] != "ghs_abc123" {
+		t.Errorf("input designator was modified")
+	}
+}

--- a/internal/libhive/testmanager.go
+++ b/internal/libhive/testmanager.go
@@ -108,7 +108,7 @@ func filterClientDesignators(clients []ClientDesignator) []ClientDesignator {
 
 		// Filter build args
 		for key, value := range client.BuildArgs {
-			if !excludedBuildArgs[key] {
+			if !isSensitiveBuildArg(key) {
 				filteredClient.BuildArgs[key] = value
 			}
 		}
@@ -123,8 +123,11 @@ func NewTestManager(config SimEnv, b ContainerBackend, clients []*ClientDefiniti
 		hiveInfo.Commit, hiveInfo.Date = hiveVersion()
 	}
 
-	// Filter sensitive build args from HiveInfo.ClientFile
+	// Filter sensitive build args from HiveInfo.ClientFile and from the
+	// recorded command line: both end up in the results JSON and are served
+	// to simulators by the /hive endpoint.
 	hiveInfo.ClientFile = filterClientDesignators(hiveInfo.ClientFile)
+	hiveInfo.Command = redactCommandArgs(hiveInfo.Command)
 
 	return &TestManager{
 		clientDefs:        clients,

--- a/simulators/ethereum/eels/consume-engine/Dockerfile
+++ b/simulators/ethereum/eels/consume-engine/Dockerfile
@@ -5,12 +5,22 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 ARG fixtures=stable@latest
 ENV FIXTURES=${fixtures}
 ARG branch=""
+# Optional token for authenticated GitHub clones; anonymous clones are
+# rate-limited per IP and fail intermittently on shared CI runners. Pass only
+# short-lived tokens (e.g. the Actions job token): the classic builder records
+# build-arg values in the image history.
+ARG github_token=""
 
 ## Clone and install EELS
 RUN apt-get update && apt-get install -y git isal
 
 # Clone repo and use the default branch if none specified
-RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
+RUN if [ -n "$github_token" ]; then \
+        export GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$github_token" | base64 -w0)"; \
+    fi && \
+    git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     cd execution-specs && \
     if [ -n "$branch" ]; then \
         git fetch --depth 1 origin "$branch" && \

--- a/simulators/ethereum/eels/consume-enginex/Dockerfile
+++ b/simulators/ethereum/eels/consume-enginex/Dockerfile
@@ -5,12 +5,22 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 ARG fixtures=stable@latest
 ENV FIXTURES=${fixtures}
 ARG branch=""
+# Optional token for authenticated GitHub clones; anonymous clones are
+# rate-limited per IP and fail intermittently on shared CI runners. Pass only
+# short-lived tokens (e.g. the Actions job token): the classic builder records
+# build-arg values in the image history.
+ARG github_token=""
 
 ## Clone and install EELS
 RUN apt-get update && apt-get install -y git isal
 
 # Clone repo and use the default branch if none specified
-RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
+RUN if [ -n "$github_token" ]; then \
+        export GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$github_token" | base64 -w0)"; \
+    fi && \
+    git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     cd execution-specs && \
     if [ -n "$branch" ]; then \
     git fetch --depth 1 origin "$branch" && \

--- a/simulators/ethereum/eels/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eels/consume-rlp/Dockerfile
@@ -5,12 +5,22 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 ARG fixtures=stable@latest
 ENV FIXTURES=${fixtures}
 ARG branch=""
+# Optional token for authenticated GitHub clones; anonymous clones are
+# rate-limited per IP and fail intermittently on shared CI runners. Pass only
+# short-lived tokens (e.g. the Actions job token): the classic builder records
+# build-arg values in the image history.
+ARG github_token=""
 
 ## Clone and install EELS
 RUN apt-get update && apt-get install -y git isal
 
 # Clone repo and use the default branch if none specified
-RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
+RUN if [ -n "$github_token" ]; then \
+        export GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$github_token" | base64 -w0)"; \
+    fi && \
+    git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     cd execution-specs && \
     if [ -n "$branch" ]; then \
         git fetch --depth 1 origin "$branch" && \

--- a/simulators/ethereum/eels/consume-sync/Dockerfile
+++ b/simulators/ethereum/eels/consume-sync/Dockerfile
@@ -5,12 +5,22 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 ARG fixtures=stable@latest
 ENV FIXTURES=${fixtures}
 ARG branch=""
+# Optional token for authenticated GitHub clones; anonymous clones are
+# rate-limited per IP and fail intermittently on shared CI runners. Pass only
+# short-lived tokens (e.g. the Actions job token): the classic builder records
+# build-arg values in the image history.
+ARG github_token=""
 
 ## Clone and install EELS
 RUN apt-get update && apt-get install -y git
 
 # Clone repo and use the default branch if none specified
-RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
+RUN if [ -n "$github_token" ]; then \
+        export GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$github_token" | base64 -w0)"; \
+    fi && \
+    git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     cd execution-specs && \
     if [ -n "$branch" ]; then \
         git fetch --depth 1 origin "$branch" && \

--- a/simulators/ethereum/eels/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eels/execute-blobs/Dockerfile
@@ -3,6 +3,11 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default git-ref/fork
 ARG branch=""
+# Optional token for authenticated GitHub clones; anonymous clones are
+# rate-limited per IP and fail intermittently on shared CI runners. Pass only
+# short-lived tokens (e.g. the Actions job token): the classic builder records
+# build-arg values in the image history.
+ARG github_token=""
 ARG fork=Osaka
 ENV FORK=${fork}
 
@@ -10,7 +15,12 @@ ENV FORK=${fork}
 RUN apt-get update && apt-get install -y git
 
 # Clone repo and use the default branch if none specified
-RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
+RUN if [ -n "$github_token" ]; then \
+        export GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$github_token" | base64 -w0)"; \
+    fi && \
+    git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     cd execution-specs && \
     if [ -n "$branch" ]; then \
         git fetch --depth 1 origin "$branch" && \


### PR DESCRIPTION
Adds an optional `github_token` build-arg to the five eels simulator Dockerfiles (`consume-engine`, `consume-enginex`, `consume-rlp`, `consume-sync`, `execute-blobs`). When set, the `git clone` of execution-specs and the subsequent branch fetch authenticate against GitHub; when unset (the default), the build behaves exactly as today. hive also redacts the token from the command line it records in the results and serves to simulators.

## Motivation

The simulator image builds clone execution-specs anonymously, and GitHub rate-limits anonymous git-over-HTTPS per source IP. On shared CI runners this intermittently kills the build before any test runs:

```
Step 6/13 : RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && ...
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

GitHub answers the anonymous `info/refs` request with an HTTP 401 auth challenge when the IP has exceeded its unauthenticated quota. Git then tries to prompt for credentials, and there is no terminal inside a Docker build, so the clone dies and hive reports `image build failed`. Git's only code path to a username prompt is a 401 response (`http.c` handles 429 separately and never prompts), so the failure mode identifies the cause even though the HTTP exchange is not visible in build logs.

We have observed this on ethpandaops runners across ethpandaops/hive-tests dashboard runs (e.g. [consume-engine, nethermind](https://github.com/ethpandaops/hive-tests/actions/runs/33615372383/job/100199901867) and [consume-engine, reth](https://github.com/ethpandaops/hive-tests/actions/runs/33615372383/job/100199901866)), ethereum/execution-specs CI (e.g. [this Engine job](https://github.com/ethereum/execution-specs/actions/runs/33661674686/job/100355625044)), and other EF repo infra. GitHub [tightened unauthenticated rate limits in May 2025](https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/), explicitly covering HTTPS clones, and recommends authenticated requests; authenticating the clone is the fix GitHub documents rather than a workaround.

## Mechanism

When `github_token` is non-empty, the RUN step exports `GIT_CONFIG_*` environment variables that add an `http.https://github.com/.extraheader` authorization header, the same mechanism `actions/checkout` uses. The header applies to both the clone and the optional branch fetch, and the token is never written to the image filesystem or to git config on disk.

One caveat is documented in the Dockerfile comment: hive uses the classic Docker builder, which records build-arg values in the image history, so callers should pass short-lived tokens only. The natural choice on CI is the Actions job token (`github.token`), which is repo-scoped, works for cloning public repos, and expires when the job ends.

Hive records its command line in every results JSON and serves it via the `/hive` endpoint, so the token passed through `--sim.buildarg` would otherwise be published with the results. `NewTestManager` now redacts the values of sensitive build arguments from the recorded command, and the build-arg key match is case-insensitive.

## Usage

```
./hive --sim ethereum/eels/consume-engine --client reth \
    --sim.buildarg github_token=$GITHUB_TOKEN ...
```

A companion PR wires this up for the ethpandaops/hive-tests dashboard workflows.

## Validation

The RUN shell logic was tested standalone under dash (the `/bin/sh` of the bookworm-slim base images): with an empty token the request is anonymous and succeeds as before; with an invalid token GitHub rejects the operation (`remote: Invalid username or token`), confirming the header is actually sent; with a valid token the authenticated clone succeeds. Unit tests in `internal/libhive/redact_test.go` cover the command-line redaction for both `--sim.buildarg KEY=VALUE` and `--sim.buildarg=KEY=VALUE`, and the case-insensitive client-file filter.

