### PR TITLE
simulators/ethereum/engine: wait for sent tx to reach the pending pool before payload building

### DIFF
--- a/simulators/ethereum/engine/client/node/node.go
+++ b/simulators/ethereum/engine/client/node/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth"
@@ -708,7 +709,11 @@ func (n *GethNode) NonceAt(ctx context.Context, account common.Address, blockNum
 }
 
 func (n *GethNode) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
-	panic("NOT IMPLEMENTED")
+	pool := n.eth.TxPool()
+	if tx = pool.Get(hash); tx != nil {
+		return tx, pool.Status(hash) == txpool.TxStatusPending, nil
+	}
+	return nil, false, nil
 }
 
 func (n *GethNode) PendingTransactionCount(ctx context.Context) (uint, error) {

--- a/simulators/ethereum/engine/helper/tx.go
+++ b/simulators/ethereum/engine/helper/tx.go
@@ -559,7 +559,38 @@ func (txSender *TransactionSender) SendTransaction(testCtx context.Context, acco
 			return nil, errors.Wrapf(testCtx.Err(), "timeout retrying SendTransaction, last error: %v", err)
 		}
 	}
+	// SendTransaction returns as soon as the tx is admitted to the pool, but its
+	// promotion into the pending view that payload builders read is asynchronous.
+	// Wait for it so a payload built right afterwards is guaranteed to include it
+	// (ethereum/hive#1351).
+	_ = waitForTransactionPending(testCtx, node, tx.Hash())
 	return tx, nil
+}
+
+// txPendingPollInterval is how often the sender polls the recipient's pool while
+// waiting for a sent transaction to become pending.
+const txPendingPollInterval = 50 * time.Millisecond
+
+// txPendingTimeout bounds the best-effort wait for a sent transaction to become
+// pending; on expiry the send still succeeds and the previous timing-dependent
+// payload-building behavior applies.
+const txPendingTimeout = 10 * time.Second
+
+// waitForTransactionPending blocks until node reports txHash as pending in its
+// transaction pool, or txPendingTimeout elapses.
+func waitForTransactionPending(testCtx context.Context, node client.EngineClient, txHash common.Hash) error {
+	ctx, cancel := context.WithTimeout(testCtx, txPendingTimeout)
+	defer cancel()
+	for {
+		if _, isPending, err := node.TransactionByHash(ctx, txHash); err == nil && isPending {
+			return nil
+		}
+		select {
+		case <-time.After(txPendingPollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
 func (txSender *TransactionSender) SendNextTransaction(testCtx context.Context, node client.EngineClient, txCreator TransactionCreator) (typ.Transaction, error) {

--- a/simulators/ethereum/engine/helper/tx_test.go
+++ b/simulators/ethereum/engine/helper/tx_test.go
@@ -1,0 +1,72 @@
+package helper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/hive/simulators/ethereum/engine/client"
+)
+
+// stubEngineClient satisfies client.EngineClient with only TransactionByHash
+// implemented; the remaining methods are never exercised by the tests below.
+type stubEngineClient struct {
+	client.EngineClient
+	txByHash func(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error)
+}
+
+func (s *stubEngineClient) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
+	return s.txByHash(ctx, hash)
+}
+
+func TestWaitForTransactionPending(t *testing.T) {
+	txHash := common.HexToHash("0x1234")
+
+	t.Run("immediate", func(t *testing.T) {
+		calls := 0
+		node := &stubEngineClient{txByHash: func(_ context.Context, hash common.Hash) (*types.Transaction, bool, error) {
+			calls++
+			if hash != txHash {
+				t.Fatalf("queried wrong hash: %v", hash)
+			}
+			return nil, true, nil
+		}}
+		if err := waitForTransactionPending(context.Background(), node, txHash); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected one poll, got %d", calls)
+		}
+	})
+
+	t.Run("eventual", func(t *testing.T) {
+		calls := 0
+		node := &stubEngineClient{txByHash: func(_ context.Context, _ common.Hash) (*types.Transaction, bool, error) {
+			calls++
+			return nil, calls > 2, nil
+		}}
+		if err := waitForTransactionPending(context.Background(), node, txHash); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected three polls, got %d", calls)
+		}
+	})
+
+	t.Run("context", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		node := &stubEngineClient{txByHash: func(_ context.Context, _ common.Hash) (*types.Transaction, bool, error) {
+			return nil, false, nil
+		}}
+		start := time.Now()
+		if err := waitForTransactionPending(ctx, node, txHash); err == nil {
+			t.Fatal("expected an error on expired context")
+		}
+		if time.Since(start) > txPendingTimeout {
+			t.Fatal("wait exceeded the bounded timeout")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #1351.

The "Invalid Missing Ancestor Syncing ReOrg, Transaction*" engine tests intermittently fail during setup with "Unable to customize payload: no transactions available for modification", before the client under test is exercised. The flake has been observed against several clients (geth, erigon, reth, nethermind), confirming it is harness-side.

## Root cause

In `ProduceSingleBlock` the harness sends a transaction from the `OnPayloadProducerSelected` hook, then produces the payload after a fixed `PayloadProductionClientDelay` (1s). `eth_sendRawTransaction` returns once the tx is *admitted* to the recipient's pool, but its promotion into the *pending* view that payload builders snapshot is asynchronous. The builder can therefore produce a payload with zero transactions, which makes `GenerateInvalidPayload` fail in `helper/customizer.go`.

## Fix

`helper.SendTransaction` now waits, after a successful send, until the recipient reports the tx as pending (`TransactionByHash` returning `isPending`). The wait is best-effort and bounded to 10s: on expiry the send still succeeds and restores the previous timing-dependent behavior. This covers every `SendNextTransaction` caller (including the affected reorg tests) with no per-test changes and no extra latency in the common case.

The in-process `GethNode` producer gets a real `TransactionByHash` implementation backed by its txpool (`Get` plus `Status == TxStatusPending`); unknown hashes return `(nil, false, nil)`, matching `ethclient` semantics used on the HTTP client path.

Relation to #1462 (wider fixed delay, adds latency to every produced block) and #1561 (same chokepoint plus `PendingTransactionCount` and a new `go-ethereum` root-package import): happy to defer to either if maintainers prefer.

## Testing

- `go build ./...` and `go vet ./...` in `simulators/ethereum/engine`.
- `go test ./helper/...` in `simulators/ethereum/engine`: existing tests pass; added `TestWaitForTransactionPending` covering the immediate-pending, eventual-pending (polling) and context-expiry paths.
